### PR TITLE
Fix mouse interaction using a high-resolution screen.

### DIFF
--- a/avogadro/qtopengl/editglwidget.cpp
+++ b/avogadro/qtopengl/editglwidget.cpp
@@ -29,6 +29,7 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
+#include <QtWidgets/QApplication>
 
 namespace Avogadro {
 namespace QtOpenGL {
@@ -43,6 +44,8 @@ EditGLWidget::EditGLWidget(QWidget *parent_)
           SIGNAL(pluginStateChanged(Avogadro::QtGui::ScenePlugin*)),
           SLOT(updateScene()));
   m_renderer.setTextRenderStrategy(new QtTextRenderStrategy);
+  // set the resolution of the screen for the camera
+  m_renderer.camera().setDevicePixelRatio(qApp->devicePixelRatio());
 }
 
 EditGLWidget::~EditGLWidget()

--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -30,6 +30,7 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
+#include <QtWidgets/QApplication>
 
 namespace Avogadro {
 namespace QtOpenGL {
@@ -46,6 +47,8 @@ GLWidget::GLWidget(QWidget *parent_)
           SLOT(updateScene()));
   connect(&m_scenePlugins, SIGNAL(pluginConfigChanged()), SLOT(updateScene()));
   m_renderer.setTextRenderStrategy(new QtTextRenderStrategy);
+  // set the resolution of the screen for the camera
+  m_renderer.camera().setDevicePixelRatio(qApp->devicePixelRatio());
 }
 
 GLWidget::~GLWidget()

--- a/avogadro/rendering/camera.cpp
+++ b/avogadro/rendering/camera.cpp
@@ -23,7 +23,7 @@
 namespace Avogadro {
 namespace Rendering {
 
-Camera::Camera() : m_width(0), m_height(0),
+  Camera::Camera() : m_width(0), m_height(0), m_pixelScale(1.0),
   m_projectionType(Perspective), m_orthographicScale(1.0)
 {
   m_projection.setIdentity();
@@ -106,8 +106,8 @@ Vector3f Camera::project(const Vector3f &point) const
 Vector3f Camera::unProject(const Vector3f &point) const
 {
   Eigen::Matrix4f mvp = m_projection.matrix() * m_modelView.matrix();
-  Vector4f result(2.0f * point.x() / static_cast<float>(m_width) - 1.0f,
-                  2.0f * (static_cast<float>(m_height) - point.y()) /
+  Vector4f result(2.0f * m_pixelScale * point.x() / static_cast<float>(m_width) - 1.0f,
+                  2.0f * (static_cast<float>(m_height) - m_pixelScale * point.y()) /
                   static_cast<float>(m_height) - 1.0f,
                   2.0f * point.z() - 1.0f,
                   1.0f);
@@ -164,6 +164,12 @@ void Camera::setViewport(int w, int h)
   m_width = w;
   m_height = h;
 }
+
+void Camera::setDevicePixelRatio(float scale)
+{
+  m_pixelScale = scale;
+}
+
 
 void Camera::setProjection(const Eigen::Affine3f &transform)
 {

--- a/avogadro/rendering/camera.h
+++ b/avogadro/rendering/camera.h
@@ -149,6 +149,16 @@ public:
   int height() const { return m_height; }
 
   /**
+   * Set the resolution of the viewport (i.e., from physical to logical pixels)
+   */
+  void setDevicePixelRatio(float scale);
+
+  /**
+   * Get the scale of the viewport pixels. (Better to use native qApp()->devicePixelRatio() instead)
+   */
+  float devicePixelRatio() const { return m_pixelScale; }
+
+  /**
    * Set the model view matrix to the identity. This resets the model view
    * matrix.
    */
@@ -202,6 +212,7 @@ private:
   Eigen::Affine3f m_modelView;
   int m_width;
   int m_height;
+  float m_pixelScale;
   Projection m_projectionType;
   float m_orthographicScale;
 };


### PR DESCRIPTION
Checks the application's devicePixelRatio() and scales the camera. 
Otherwise on a Mac "retina" display (and probably others) clicks
are not properly unprojected into GL space.

Change-Id: Icac9406094bf203757d0502a9749f2d8413c5a60
