### PR TITLE
Add gaussiancube to quantumio

### DIFF
--- a/avogadro/quantumio/CMakeLists.txt
+++ b/avogadro/quantumio/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(HEADERS
   gamessus.h
   gaussianfchk.h
+  gaussiancube.h
   molden.h
   mopacaux.h
 )
@@ -18,6 +19,7 @@ set(SOURCES
   #gamessukout.cpp
   gamessus.cpp
   gaussianfchk.cpp
+  gaussiancube.cpp
   molden.cpp
   mopacaux.cpp
 )

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -1,0 +1,104 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2010 Geoffrey R. Hutchison
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "gaussiancube.h"
+
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/utilities.h>
+#include <avogadro/core/cube.h>
+
+#include <iostream>
+
+namespace Avogadro {
+namespace QuantumIO {
+
+GaussianCube::GaussianCube()
+{
+}
+
+GaussianCube::~GaussianCube()
+{
+}
+
+std::vector<std::string> GaussianCube::fileExtensions() const
+{
+  std::vector<std::string> extensions;
+  extensions.push_back("cube");
+  return extensions;
+}
+
+std::vector<std::string> GaussianCube::mimeTypes() const
+{
+  return std::vector<std::string>();
+}
+
+bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
+{
+  // Using the existing cube class
+  Core::Cube cube;
+
+  // Variables we will need
+  std::string line;
+  std::vector<std::string> list;
+
+  int nAtoms;
+  Avogadro::Vector3 min, spacing;
+  Avogadro::Vector3i dim;
+
+  // Gaussian Cube format is very specific
+
+  // Read and set name
+  getline(in, line);
+  cube.setName(line);
+
+  // Read and skip field title (we may be able to use this to setCubeType in the future)
+  getline(in, line);   
+
+  // Next line contains nAtoms and m_min
+  in >> nAtoms;
+  for (auto i = 0; i < 3; ++i) in >> min(i);
+
+  // Next 3 lines contains spacing and dim
+  for (auto i = 0; i < 3; ++i) {
+    getline(in, line);
+    list = Core::split(Core::trimmed(line), ' ');
+    dim(i) = Core::lexicalCast<int>(list[i]);  
+    spacing(i) = Core::lexicalCast<int>(list[i + 1]);  
+  }
+
+  // Geometry block
+  Avogadro::Vector3 pos;
+  for (auto i = 0; i < 3; ++i) {
+    list = Core::split(Core::trimmed(line), ' ');
+    Core::Atom a = molecule.addAtom(Core::lexicalCast<unsigned char>(list[0]));
+    for (auto j = 2; j < 5; ++j) pos(i) = Core::lexicalCast<double>(list[i]);
+    a.setPosition3d(pos);
+  }
+
+  // Render molecule  
+  molecule.perceiveBondsSimple();
+  return true;
+}
+
+bool GaussianCube::write(std::ostream &out, const Core::Molecule &molecule)
+{
+    // Not implemented yet
+    return false;
+}
+
+} // End QuantumIO namespace
+} // End Avogadro namespace

--- a/avogadro/quantumio/gaussiancube.h
+++ b/avogadro/quantumio/gaussiancube.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2008-2009 Marcus D. Hanwell
+  Copyright 2010-2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QUANTUMIO_GAUSSIANCUBE_H
+#define AVOGADRO_QUANTUMIO_GAUSSIANCUBE_H
+
+#include "avogadroquantumioexport.h"
+#include <avogadro/io/fileformat.h>
+
+#include <vector>
+
+namespace Avogadro {
+namespace QuantumIO {
+
+class AVOGADROQUANTUMIO_EXPORT GaussianCube : public Io::FileFormat
+{
+public:
+  GaussianCube();
+  ~GaussianCube() AVO_OVERRIDE;
+
+  Operations supportedOperations() const AVO_OVERRIDE
+  {
+    return Read | File | Stream | String;
+  }
+
+  FileFormat * newInstance() const AVO_OVERRIDE { return new GaussianCube; }
+  std::string identifier() const AVO_OVERRIDE { return "Avogadro: GaussianCube"; }
+  std::string name() const AVO_OVERRIDE { return "Gaussian"; }
+  std::string description() const AVO_OVERRIDE
+  {
+    return "Gaussian cube file format.";
+  }
+
+  std::string specificationUrl() const AVO_OVERRIDE
+  {
+    return "http://www.gaussian.com/g_tech/g_ur/u_cubegen.htm";
+  }
+
+  std::vector<std::string> fileExtensions() const AVO_OVERRIDE;
+  std::vector<std::string> mimeTypes() const AVO_OVERRIDE;
+
+  bool read(std::istream &in, Core::Molecule &molecule) AVO_OVERRIDE;
+  bool write(std::ostream &out, const Core::Molecule &molecule) AVO_OVERRIDE;
+
+private:
+  void outputAll();
+}; // End GaussianCube
+
+} // End QuantumIO namespace
+} // End Avogadro namespace
+
+#endif


### PR DESCRIPTION
@cryos I finally had some time to start working on this. I created the gaussiancube class in quantumio of avogadrolibs. I followed the molden example, however the OpenBabel cube file reader is called automatically (molden allows me to select the Avogadro: Molden reader, for example). I assume I need to add something somewhere else?

Additionally, It would be fantastic if you could comment on my code quality/github usage. I am very excited to get started with this project! Thanks!