### PR TITLE
Add gaussiancube reader to quantumio, initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-CMakeLists.txt.user*
-*.pro
-*.pro.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 CMakeLists.txt.user*
+*.pro
+*.pro.user

--- a/avogadro/qtplugins/quantumoutput/quantumoutput.cpp
+++ b/avogadro/qtplugins/quantumoutput/quantumoutput.cpp
@@ -33,6 +33,7 @@
 #include <avogadro/io/fileformatmanager.h>
 #include <avogadro/quantumio/gamessus.h>
 #include <avogadro/quantumio/gaussianfchk.h>
+#include <avogadro/quantumio/gaussiancube.h>
 #include <avogadro/quantumio/molden.h>
 #include <avogadro/quantumio/mopacaux.h>
 
@@ -80,6 +81,7 @@ QuantumOutput::QuantumOutput(QObject *p) :
   // Register our quantum file format.
   Io::FileFormatManager::registerFormat(new QuantumIO::GAMESSUSOutput);
   Io::FileFormatManager::registerFormat(new QuantumIO::GaussianFchk);
+  Io::FileFormatManager::registerFormat(new QuantumIO::GaussianCube);
   Io::FileFormatManager::registerFormat(new QuantumIO::MoldenFile);
   Io::FileFormatManager::registerFormat(new QuantumIO::MopacAux);
 }

--- a/avogadro/quantumio/CMakeLists.txt
+++ b/avogadro/quantumio/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(HEADERS
   gamessus.h
   gaussianfchk.h
+  gaussiancube.h
   molden.h
   mopacaux.h
 )
@@ -18,6 +19,7 @@ set(SOURCES
   #gamessukout.cpp
   gamessus.cpp
   gaussianfchk.cpp
+  gaussiancube.cpp
   molden.cpp
   mopacaux.cpp
 )

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -64,21 +64,21 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
   std::string cubeName = line;
 
   // Read and skip field title (we may be able to use this to setCubeType in the future)
-  getline(in, line);   
+  getline(in, line);
 
   // Next line contains nAtoms and m_min
   in >> nAtoms;
   for (auto i = 0; i < 3; ++i)
     in >> min(i);
-  getline(in, line); //capture newline before continuing 
+  getline(in, line); //capture newline before continuing
 
   // Next 3 lines contains spacing and dim
   for (auto i = 0; i < 3; ++i) {
     getline(in, line);
     line = Core::trimmed(line);
     list = Core::split(line, ' ');
-    dim(i) = Core::lexicalCast<int>(list[0]);  
-    spacing(i) = Core::lexicalCast<double>(list[i + 1]);  
+    dim(i) = Core::lexicalCast<int>(list[0]);
+    spacing(i) = Core::lexicalCast<double>(list[i + 1]);
   }
 
   // Geometry block
@@ -95,9 +95,9 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
     a.setPosition3d(pos);
   }
 
-  // Render molecule  
+  // Render molecule
   molecule.perceiveBondsSimple();
-  
+
   // Get a cube object from molecule
   Core::Cube *cube = molecule.addCube();
 

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2010 Geoffrey R. Hutchison
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "gaussiancube.h"
+
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/utilities.h>
+#include <avogadro/core/cube.h>
+
+#include <iostream>
+
+namespace Avogadro {
+namespace QuantumIO {
+
+GaussianCube::GaussianCube()
+{
+}
+
+GaussianCube::~GaussianCube()
+{
+}
+
+std::vector<std::string> GaussianCube::fileExtensions() const
+{
+  std::vector<std::string> extensions;
+  extensions.push_back("cube");
+  return extensions;
+}
+
+std::vector<std::string> GaussianCube::mimeTypes() const
+{
+  return std::vector<std::string>();
+}
+
+bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
+{
+  // Using the existing cube class
+  Core::Cube cube;
+
+  // Variables we will need
+  std::string line;
+  std::vector<std::string> list;
+
+  int nAtoms;
+  Avogadro::Vector3 min, spacing;
+  Avogadro::Vector3i dim;
+
+  // Gaussian Cube format is very specific
+
+  // Read and set name
+  getline(in, line);
+  cube.setName(line);
+
+  // Read and skip field title (we may be able to use this to setCubeType in the future)
+  getline(in, line);   
+
+  // Next line contains nAtoms and m_min
+  in >> nAtoms;
+  for (auto i = 0; i < 3; ++i) in >> min(i);
+  getline(in, line);
+
+  // Next 3 lines contains spacing and dim
+  for (auto i = 0; i < 3; ++i) {
+    getline(in, line);
+    line = Core::trimmed(line);
+    list = Core::split(line, ' ');
+    dim(i) = Core::lexicalCast<int>(list[0]);  
+    spacing(i) = Core::lexicalCast<double>(list[i + 1]);  
+  }
+
+  // Geometry block
+  Avogadro::Vector3 pos;
+  for (auto i = 0; i < nAtoms; ++i) {
+    getline(in, line);
+    line = Core::trimmed(line);
+    list = Core::split(line, ' ');
+    short int atomNum = Core::lexicalCast<short int>(list[0]);
+    Core::Atom a = molecule.addAtom(static_cast<unsigned char>(atomNum));
+    for (auto j = 2; j < 5; ++j) pos(j - 2) = Core::lexicalCast<double>(list[j]);
+    pos = pos * Avogadro::BOHR_TO_ANGSTROM;
+    a.setPosition3d(pos);
+  }
+
+  // Render molecule  
+  molecule.perceiveBondsSimple();
+
+  // Cube block, set limits and populate data
+  cube.setLimits(min, dim, spacing);
+  std::vector<double> values;
+  // push_back is slow for this, resize vector first
+  values.resize(dim(0) * dim(1) * dim(2));
+  for (auto i = 0; i < values.size(); ++i) in >> values[i];
+  cube.setData(values);
+
+  return true;
+}
+
+bool GaussianCube::write(std::ostream &out, const Core::Molecule &molecule)
+{
+    // Not implemented yet
+    return false;
+}
+
+} // End QuantumIO namespace
+} // End Avogadro namespace

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -2,7 +2,7 @@
 
   This source file is part of the Avogadro project.
 
-  Copyright 2010 Geoffrey R. Hutchison
+  Copyright 2015 Barry E. Moore II
   Copyright 2013 Kitware, Inc.
 
   This source code is released under the New BSD License, (the "License").
@@ -53,9 +53,9 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
   std::vector<std::string> list;
 
   int nAtoms;
-  Avogadro::Vector3 min;
-  Avogadro::Vector3 spacing;
-  Avogadro::Vector3i dim;
+  Vector3 min;
+  Vector3 spacing;
+  Vector3i dim;
 
   // Gaussian Cube format is very specific
 
@@ -68,12 +68,12 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
 
   // Next line contains nAtoms and m_min
   in >> nAtoms;
-  for (auto i = 0; i < 3; ++i)
+  for (unsigned int i = 0; i < 3; ++i)
     in >> min(i);
   getline(in, line); //capture newline before continuing
 
   // Next 3 lines contains spacing and dim
-  for (auto i = 0; i < 3; ++i) {
+  for (unsigned int i = 0; i < 3; ++i) {
     getline(in, line);
     line = Core::trimmed(line);
     list = Core::split(line, ' ');
@@ -82,16 +82,16 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
   }
 
   // Geometry block
-  Avogadro::Vector3 pos;
-  for (auto i = 0; i < nAtoms; ++i) {
+  Vector3 pos;
+  for (unsigned int i = 0; i < nAtoms; ++i) {
     getline(in, line);
     line = Core::trimmed(line);
     list = Core::split(line, ' ');
     short int atomNum = Core::lexicalCast<short int>(list[0]);
     Core::Atom a = molecule.addAtom(static_cast<unsigned char>(atomNum));
-    for (auto j = 2; j < 5; ++j)
+    for (unsigned int j = 2; j < 5; ++j)
       pos(j - 2) = Core::lexicalCast<double>(list[j]);
-    pos = pos * Avogadro::BOHR_TO_ANGSTROM;
+    pos = pos * BOHR_TO_ANGSTROM;
     a.setPosition3d(pos);
   }
 
@@ -106,7 +106,7 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
   std::vector<double> values;
   // push_back is slow for this, resize vector first
   values.resize(dim(0) * dim(1) * dim(2));
-  for (auto i = 0; i < values.size(); ++i)
+  for (unsigned int i = 0; i < values.size(); ++i)
     in >> values[i];
   cube->setData(values);
 

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -3,7 +3,6 @@
   This source file is part of the Avogadro project.
 
   Copyright 2015 Barry E. Moore II
-  Copyright 2013 Kitware, Inc.
 
   This source code is released under the New BSD License, (the "License").
 
@@ -52,7 +51,7 @@ bool GaussianCube::read(std::istream &in, Core::Molecule &molecule)
   std::string line;
   std::vector<std::string> list;
 
-  int nAtoms;
+  unsigned int nAtoms;
   Vector3 min;
   Vector3 spacing;
   Vector3i dim;

--- a/avogadro/quantumio/gaussiancube.h
+++ b/avogadro/quantumio/gaussiancube.h
@@ -3,7 +3,6 @@
   This source file is part of the Avogadro project.
 
   Copyright 2015 Barry E. Moore II
-  Copyright 2013 Kitware, Inc.
 
   This source code is released under the New BSD License, (the "License").
 

--- a/avogadro/quantumio/gaussiancube.h
+++ b/avogadro/quantumio/gaussiancube.h
@@ -2,8 +2,8 @@
 
   This source file is part of the Avogadro project.
 
-  Copyright 2008-2009 Marcus D. Hanwell
-  Copyright 2010-2013 Kitware, Inc.
+  Copyright 2015 Barry E. Moore II
+  Copyright 2013 Kitware, Inc.
 
   This source code is released under the New BSD License, (the "License").
 

--- a/avogadro/quantumio/gaussiancube.h
+++ b/avogadro/quantumio/gaussiancube.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2008-2009 Marcus D. Hanwell
+  Copyright 2010-2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QUANTUMIO_GAUSSIANCUBE_H
+#define AVOGADRO_QUANTUMIO_GAUSSIANCUBE_H
+
+#include "avogadroquantumioexport.h"
+#include <avogadro/io/fileformat.h>
+
+#include <vector>
+
+namespace Avogadro {
+namespace QuantumIO {
+
+class AVOGADROQUANTUMIO_EXPORT GaussianCube : public Io::FileFormat
+{
+public:
+  GaussianCube();
+  ~GaussianCube() AVO_OVERRIDE;
+
+  Operations supportedOperations() const AVO_OVERRIDE
+  {
+    return Read | File | Stream | String;
+  }
+
+  FileFormat * newInstance() const AVO_OVERRIDE { return new GaussianCube; }
+  std::string identifier() const AVO_OVERRIDE { return "Avogadro: GaussianCube"; }
+  std::string name() const AVO_OVERRIDE { return "Gaussian"; }
+  std::string description() const AVO_OVERRIDE
+  {
+    return "Gaussian cube file format.";
+  }
+
+  std::string specificationUrl() const AVO_OVERRIDE
+  {
+    return "http://www.gaussian.com/g_tech/g_ur/u_cubegen.htm";
+  }
+
+  std::vector<std::string> fileExtensions() const AVO_OVERRIDE;
+  std::vector<std::string> mimeTypes() const AVO_OVERRIDE;
+
+  bool read(std::istream &in, Core::Molecule &molecule) AVO_OVERRIDE;
+  bool write(std::ostream &out, const Core::Molecule &molecule) AVO_OVERRIDE;
+
+private:
+  void outputAll();
+}; // End GaussianCube
+
+} // End QuantumIO namespace
+} // End Avogadro namespace
+
+#endif


### PR DESCRIPTION
Added gaussiancube reader to quantumio. I couldn't find an example where you take a <code>Core::Cube</code> and render the isosurface. It looks like this is done through <code>Molecule::addCube()</code>, but it isn't obvious to me how this works. Do I use <code>addCube</code> to generate the Cube and then populate the object?

Additionally, it would be great to get some feedback on my code style and pull request. I am excited to work on this project! @cryos @ghutchis 