### PR TITLE
Don't reset the camera on scene initialization

### DIFF
--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -62,8 +62,6 @@ void GLRenderer::initialize()
     m_valid = false;
     return;
   }
-
-  resetCamera();
 }
 
 void GLRenderer::resize(int width, int height)


### PR DESCRIPTION
This causes subtle bugs, and is done elsewhere. This fixes the export
bitmap which causes initializeGL in the widget, and hence initialize in
the renderer to be called.

Change-Id: I7d10fce26ae4852fd2bff558fc063f3701d6ae85