### PR TITLE
fix Gaussian FCHK parsing of unrestricted calculations

### DIFF
--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -165,10 +165,20 @@ void GaussianFchk::processLine(std::istream &in)
       m_alphaOrbitalEnergy = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
       cout << "Alpha MO energies, n = " << m_alphaOrbitalEnergy.size() << endl;
     }
-    else if (key == "Beta Orbital Energies") {
-      m_betaOrbitalEnergy = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
-      cout << "Beta MO energies, n = " << m_betaOrbitalEnergy.size() << endl;
+  }
+  else if (key == "Beta Orbital Energies") {
+    if (m_scftype != Uhf) {
+      cout << "UHF detected. Reassigning Alpha properties." << endl;
+      m_scftype = Uhf;
+      m_alphaOrbitalEnergy = m_orbitalEnergy;
+      m_orbitalEnergy = vector<double>();
+
+      m_alphaMOcoeffs = m_MOcoeffs;
+      m_MOcoeffs = vector<double>();
     }
+
+    m_betaOrbitalEnergy = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
+    cout << "Beta MO energies, n = " << m_betaOrbitalEnergy.size() << endl;
   }
   else if (key == "Alpha MO coefficients" && list.size() > 2) {
     if (m_scftype == Rhf) {


### PR DESCRIPTION
Gaussian FCHK files have a propensity to not emit a `UHF` or `RHF` tag which is the only way the parser would check for the proper calculation type. This PR fixes this by double checking the calculation type if it finds a "Beta Orbital Energies" entry in the FCHK file and fixing the entries appropriately.