### PR TITLE
Fix linking to HDF5 libraries.

### DIFF
--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -36,5 +36,5 @@ set(SOURCES
 
 avogadro_add_library(AvogadroIO ${HEADERS} ${SOURCES})
 
-# hdf5 is the HDF5 imported target
-target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE hdf5)
+# HDF5 library paths provided by find module
+target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE ${HDF5_LIBRARIES})


### PR DESCRIPTION
Use library paths as provided by CMake's find module to correctly find
shared library in subdirectories, e.g.:
/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so