### PR TITLE
Fix the BasisSet.homo(..) functions

### DIFF
--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -95,10 +95,7 @@ public:
    */
   bool homo(unsigned int n)
   {
-    if (n + 1 == static_cast<unsigned int>(m_electrons[0] / 2))
-      return true;
-    else
-      return false;
+    return n == homo();
   }
 
   /**
@@ -117,10 +114,7 @@ public:
    */
   bool lumo(unsigned int n)
   {
-    if (n == static_cast<unsigned int>(m_electrons[0] / 2))
-      return true;
-    else
-      return false;
+    return n == lumo();
   }
   /**
    * @return The molecular orbital number corresponding to the LUMO orbital.

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -3,6 +3,7 @@ set(tests
   Array
   Atom
   AtomTyper
+  BasisSet
   Bond
   CoordinateBlockGenerator
   CoordinateSet

--- a/tests/core/basissettest.cpp
+++ b/tests/core/basissettest.cpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2011-2012 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/basisset.h>
+#include <avogadro/core/slaterset.h>
+
+using Avogadro::Core::BasisSet;
+using Avogadro::Core::SlaterSet;
+
+TEST(BasisSetTest, homo)
+{
+  SlaterSet basis;
+
+  basis.setElectronCount(2, BasisSet::Paired);
+  EXPECT_EQ(basis.homo(), 1);
+  EXPECT_TRUE(basis.homo(basis.homo()));
+
+  EXPECT_EQ(basis.lumo(), 2);
+  EXPECT_TRUE(basis.lumo(basis.lumo()));
+
+
+  basis = SlaterSet();
+  basis.setElectronCount(2, BasisSet::Alpha);
+  basis.setElectronCount(1, BasisSet::Beta);
+
+  EXPECT_EQ(basis.homo(), 1);
+  EXPECT_TRUE(basis.homo(basis.homo()));
+
+  // This is broken: the lumo could be either the 
+  // next alpha or the next beta depending on the 
+  // energetics of the system
+
+  // EXPECT_EQ(basis.lumo(), 2);
+  // EXPECT_TRUE(basis.lumo(basis.lumo()));
+}
+


### PR DESCRIPTION
Before this patch, basis.homo(basis.homo()) == false.

Added a unit test.