### PR TITLE
WIP/openshell

### DIFF
--- a/avogadro/command/qube.cpp
+++ b/avogadro/command/qube.cpp
@@ -30,6 +30,9 @@
 
 using Avogadro::Io::FileFormatManager;
 using Avogadro::Core::Cube;
+using Avogadro::Core::ElectronType;
+using Avogadro::Core::Alpha;
+using Avogadro::Core::Beta;
 using Avogadro::Core::Molecule;
 using Avogadro::Core::GaussianSetTools;
 using std::cin;
@@ -58,6 +61,7 @@ int main(int argc, char *argv[])
   // Process the command line arguments, see what has been requested.
   string inFormat;
   int orbitalNumber=0;
+  ElectronType spin(Alpha);
   string inFile;
   bool density = false;
   for (int i = 1; i < argc; ++i) {
@@ -77,6 +81,9 @@ int main(int argc, char *argv[])
     else if (current == "-orb" && i + 1 < argc) {
       orbitalNumber = atoi(argv[++i]);
       //cout << "plot orbital " << orbitalNumber << endl;
+    }
+    else if (current == "-beta" && i < argc) {
+      spin = Beta;
     }
     else if (current == "-dens" && i < argc) {
       density=true;
@@ -164,7 +171,7 @@ int main(int argc, char *argv[])
       printf("\n");
     }
     double value = m_tools->calculateMolecularOrbital(
-        m_qube->position(i),orbitalNumber);
+        m_qube->position(i),orbitalNumber,spin);
     printf("%13.5E",value);
     //line wrapping
     linecount++;
@@ -182,6 +189,6 @@ int main(int argc, char *argv[])
 
 void printHelp()
 {
-  cout << "Usage: qube [-i <input-type>] <infilename> [-dens] [-orb <orbital number>] [-v / --version] \n"
+  cout << "Usage: qube [-i <input-type>] <infilename> [-dens] [-orb <orbital number>] [-beta] [-v / --version] \n"
        << endl;
 }

--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -207,7 +207,7 @@ protected:
 
   /**
    * Energies of the beta molecular orbitals. If the system is restricted the
-   * the beta energies will not be defined.
+   * the beta energies will be the exact same as the alpha energies.
    */
   std::vector<double> m_betaMOEnergies;
 

--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -207,7 +207,7 @@ protected:
 
   /**
    * Energies of the beta molecular orbitals. If the system is restricted the
-   * the beta energies will be the exact same as the alpha energies.
+   * the beta energies will be unset.
    */
   std::vector<double> m_betaMOEnergies;
 

--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -19,7 +19,6 @@
 #define AVOGADRO_CORE_BASISSET_H
 
 #include <vector>
-#include <iostream>
 
 #include "avogadrocore.h"
 
@@ -128,7 +127,7 @@ public:
       case Beta:
         return m_electrons[1];
       default:
-        std::cout << "Invalid electron type." << std::endl;
+        // shouldn't get here
         return 0;
     }
   }

--- a/avogadro/core/gaussianset.cpp
+++ b/avogadro/core/gaussianset.cpp
@@ -33,7 +33,6 @@ namespace Core {
 
 GaussianSet::GaussianSet() : m_numMOs(0), m_init(false)
 {
-  m_scfType = Rhf;
 }
 
 GaussianSet::~GaussianSet()
@@ -154,7 +153,7 @@ void GaussianSet::outputAll(ElectronType type)
   // Can be called to print out a summary of the basis set as read in
   unsigned int numAtoms = static_cast<unsigned int>(m_molecule->atomCount());
   cout << "\nGaussian Basis Set\nNumber of atoms:" << numAtoms << endl;
-  switch (m_scfType) {
+  switch (scfType()) {
   case Rhf:
     cout << "RHF orbitals" << endl;
     break;
@@ -434,14 +433,14 @@ void GaussianSet::initCalculation()
 
 bool GaussianSet::generateDensity()
 {
-  if (m_scfType == Unknown)
+  if (scfType() == Unknown)
     return false;
 
   m_density.resize(m_numMOs, m_numMOs);
   m_density = MatrixX::Zero(m_numMOs, m_numMOs);
   for (unsigned int iBasis=0; iBasis < m_numMOs; ++iBasis) {
     for (unsigned int jBasis=0;jBasis<=iBasis; ++jBasis) {
-      switch (m_scfType) {
+      switch (scfType()) {
       case Rhf:
         for (unsigned int iMO = 0; iMO < m_electrons[0] / 2; ++iMO) {
           double icoeff = m_moMatrix[0](iBasis, iMO);
@@ -469,7 +468,7 @@ bool GaussianSet::generateDensity()
              << endl;
         break;
       default:
-        cout << "Unhandled scf type:" << m_scfType << endl;
+        cout << "Unhandled scf type:" << scfType() << endl;
       }
     }
   }
@@ -478,7 +477,7 @@ bool GaussianSet::generateDensity()
 
 bool GaussianSet::generateSpinDensity()
 {
-  if (m_scfType != Uhf)
+  if (scfType() != Uhf)
     return false;
 
   m_spinDensity.resize(m_numMOs, m_numMOs);

--- a/avogadro/core/gaussianset.h
+++ b/avogadro/core/gaussianset.h
@@ -30,11 +30,6 @@ namespace Avogadro {
 namespace Core {
 
 /**
- * Enumeration of the SCF type.
- */
-enum ScfType { Rhf, Uhf, Rohf, Unknown };
-
-/**
  * @class GaussianSet gaussianset.h <avogadro/core/gaussianset.h>
  * @brief A container for Gaussian type outputs from QM codes.
  * @author Marcus D. Hanwell
@@ -90,10 +85,10 @@ public:
   /**
    * Set the molecular orbital (MO) coefficients to the GaussianSet.
    * @param MOs Vector containing the MO coefficients for the GaussianSet.
-   * @param type The type of the MOs (Paired, Alpha, Beta).
+   * @param type The type of the MOs (Alpha or Beta).
    */
   void setMolecularOrbitals(const std::vector<double>& MOs,
-                            ElectronType type = Paired);
+                            ElectronType type);
 
   /**
    * Set the SCF density matrix for the GaussianSet.
@@ -114,29 +109,19 @@ public:
   /**
    * @return The number of molecular orbitals in the GaussianSet.
    */
-  unsigned int molecularOrbitalCount(ElectronType type = Paired) AVO_OVERRIDE;
+  unsigned int molecularOrbitalCount(ElectronType type) AVO_OVERRIDE;
 
   /**
    * Debug routine, outputs all of the data in the GaussianSet.
    * @param The electrons to output the information for.
    */
-  void outputAll(ElectronType type = Paired);
+  void outputAll(ElectronType type);
 
   /**
    * @return True of the basis set is valid, false otherwise.
    * Default is true, if false then the basis set is likely unusable.
    */
   bool isValid() AVO_OVERRIDE;
-
-  /**
-   * Set the SCF type for the object.
-   */
-  void setScfType(ScfType type) { m_scfType = type; }
-
-  /**
-   * Get the SCF type for the object.
-   */
-  ScfType scfType() const { return m_scfType; }
 
   /**
    * Initialize the calculation, this must normally be done before anything.
@@ -180,8 +165,6 @@ private:
 
   unsigned int m_numMOs;            //! The number of GTOs (not always!)
   bool m_init;                      //! Has the calculation been initialised?
-
-  ScfType m_scfType;
 
   /**
    * @brief Generate the density matrix if we have the required information.

--- a/avogadro/core/gaussiansettools.cpp
+++ b/avogadro/core/gaussiansettools.cpp
@@ -42,9 +42,10 @@ GaussianSetTools::~GaussianSetTools()
 }
 
 double GaussianSetTools::calculateMolecularOrbital(const Vector3 &position,
-                                                   int mo) const
+                                                   int mo,
+                                                   ElectronType type) const
 {
-  if (mo > static_cast<int>(m_basis->molecularOrbitalCount()))
+  if (mo > static_cast<int>(m_basis->molecularOrbitalCount(type)))
     return 0.0;
 
   vector<double> values(calculateValues(position));

--- a/avogadro/core/gaussiansettools.h
+++ b/avogadro/core/gaussiansettools.h
@@ -20,6 +20,7 @@
 #define AVOGADRO_CORE_GAUSSIANSETTOOLS_H
 
 #include "avogadrocore.h"
+#include "basisset.h"
 
 #include "vector.h"
 
@@ -52,7 +53,8 @@ public:
    * @return The value of the molecular orbital at the position specified.
    */
   double calculateMolecularOrbital(const Vector3 &position,
-                                   int molecularOrbitalNumber) const;
+                                   int molecularOrbitalNumber,
+                                   ElectronType type) const;
 
   /**
    * @brief Calculate the value of the electron density at the position

--- a/avogadro/core/slaterset.h
+++ b/avogadro/core/slaterset.h
@@ -112,7 +112,7 @@ public:
   /**
    * @return The number of molecular orbitals in the BasisSet.
    */
-  unsigned int molecularOrbitalCount(ElectronType type = Paired) AVO_OVERRIDE;
+  unsigned int molecularOrbitalCount(ElectronType type) AVO_OVERRIDE;
 
   /**
    * @return True of the basis set is valid, false otherwise.

--- a/avogadro/core/slatersettools.cpp
+++ b/avogadro/core/slatersettools.cpp
@@ -42,9 +42,10 @@ SlaterSetTools::~SlaterSetTools()
 }
 
 double SlaterSetTools::calculateMolecularOrbital(const Vector3 &position,
-                                                 int mo) const
+                                                 int mo,
+                                                 ElectronType type) const
 {
-  if (mo > static_cast<int>(m_basis->molecularOrbitalCount()))
+  if (mo > static_cast<int>(m_basis->molecularOrbitalCount(type)))
     return 0.0;
 
   vector<double> values(calculateValues(position));

--- a/avogadro/core/slatersettools.h
+++ b/avogadro/core/slatersettools.h
@@ -20,6 +20,7 @@
 #define AVOGADRO_CORE_SLATERSETTOOLS_H
 
 #include "avogadrocore.h"
+#include "basisset.h"
 
 #include "vector.h"
 
@@ -52,7 +53,8 @@ public:
    * @return The value of the molecular orbital at the position specified.
    */
   double calculateMolecularOrbital(const Vector3 &position,
-                                   int molecularOrbitalNumber) const;
+                                   int molecularOrbitalNumber,
+                                   ElectronType type) const;
 
   /**
    * @brief Calculate the value of the electron density at the position

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -37,4 +37,4 @@ set(SOURCES
 avogadro_add_library(AvogadroIO ${HEADERS} ${SOURCES})
 
 # HDF5 library paths provided by find module
-target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE hdf5)
+target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE ${HDF5_LIBRARIES})

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -37,4 +37,4 @@ set(SOURCES
 avogadro_add_library(AvogadroIO ${HEADERS} ${SOURCES})
 
 # HDF5 library paths provided by find module
-target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE ${HDF5_LIBRARIES})
+target_link_libraries(AvogadroIO LINK_PUBLIC AvogadroCore LINK_PRIVATE hdf5)

--- a/avogadro/qtplugins/quantumoutput/gaussiansetconcurrent.cpp
+++ b/avogadro/qtplugins/quantumoutput/gaussiansetconcurrent.cpp
@@ -33,6 +33,9 @@ using Core::GaussianSet;
 using Core::GaussianSetTools;
 using Core::Cube;
 
+using Core::Alpha;
+
+
 template<typename Derived>
 class BasisSetConcurrent
 {
@@ -134,7 +137,8 @@ void GaussianSetConcurrent::processOrbital(GaussianShell &shell)
   Vector3 pos = shell.tCube->position(shell.pos);
   shell.tCube->setValue(shell.pos,
                         shell.tools->calculateMolecularOrbital(pos,
-                                                               shell.state));
+                                                               shell.state,
+                        Alpha)); // TODO: don't hard code Alpha orbitals.
 }
 
 void GaussianSetConcurrent::processDensity(GaussianShell &shell)

--- a/avogadro/qtplugins/quantumoutput/quantumoutput.cpp
+++ b/avogadro/qtplugins/quantumoutput/quantumoutput.cpp
@@ -48,6 +48,8 @@ namespace QtPlugins {
 using Core::GaussianSet;
 using Core::Cube;
 
+using Core::Alpha;
+
 QuantumOutput::QuantumOutput(QObject *p) :
   ExtensionPlugin(p),
   m_progressDialog(NULL),
@@ -119,13 +121,13 @@ void QuantumOutput::setMolecule(QtGui::Molecule *mol)
 void QuantumOutput::homoActivated()
 {
   if (m_basis)
-    calculateMolecularOrbital(m_basis->electronCount() / 2, 0.02f, 0.2f);
+    calculateMolecularOrbital(m_basis->totalElectronCount() / 2, 0.02f, 0.2f);
 }
 
 void QuantumOutput::lumoActivated()
 {
   if (m_basis)
-    calculateMolecularOrbital(m_basis->electronCount() / 2 + 1, 0.02f, 0.2f);
+    calculateMolecularOrbital(m_basis->totalElectronCount() / 2 + 1, 0.02f, 0.2f);
 }
 
 void QuantumOutput::surfacesActivated()
@@ -141,8 +143,8 @@ void QuantumOutput::surfacesActivated()
             SLOT(calculateElectronDensity(float,float)));
   }
 
-  m_dialog->setNumberOfElectrons(m_basis->electronCount(),
-                                 m_basis->molecularOrbitalCount());
+  m_dialog->setNumberOfElectrons(m_basis->totalElectronCount(),
+                                 m_basis->molecularOrbitalCount(Alpha)); // TODO: don't hard code Alpha
   m_dialog->show();
 }
 

--- a/avogadro/qtplugins/quantumoutput/slatersetconcurrent.cpp
+++ b/avogadro/qtplugins/quantumoutput/slatersetconcurrent.cpp
@@ -32,6 +32,8 @@ using Core::SlaterSet;
 using Core::SlaterSetTools;
 using Core::Cube;
 
+using Core::Alpha;
+
 struct SlaterShell
 {
   SlaterSetTools *tools; // A pointer to the tools, cannot write to member vars
@@ -123,7 +125,8 @@ void SlaterSetConcurrent::processOrbital(SlaterShell &shell)
   Vector3 pos = shell.tCube->position(shell.pos);
   shell.tCube->setValue(shell.pos,
                         shell.tools->calculateMolecularOrbital(pos,
-                                                               shell.state));
+                                                               shell.state,
+                        Alpha));  // TODO: Don't hard code Alpha orbitals
 }
 
 void SlaterSetConcurrent::processDensity(SlaterShell &shell)

--- a/avogadro/quantumio/gamessus.cpp
+++ b/avogadro/quantumio/gamessus.cpp
@@ -348,6 +348,11 @@ void GAMESSUSOutput::load(GaussianSet* basis)
     basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
   */
 
+  if (m_orbitalEnergy.size() > 0) {
+    basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
+    basis->setOrbitalEnergies(m_orbitalEnergy, Beta);
+  }
+
   //generateDensity();
   //if (m_density.rows())
     //basis->setDensityMatrix(m_density);

--- a/avogadro/quantumio/gamessus.cpp
+++ b/avogadro/quantumio/gamessus.cpp
@@ -32,14 +32,18 @@ namespace QuantumIO {
 using Core::Atom;
 using Core::BasisSet;
 using Core::GaussianSet;
+
 using Core::Rhf;
 using Core::Uhf;
 using Core::Rohf;
 using Core::Unknown;
 
+using Core::Alpha;
+using Core::Beta;
+
 GAMESSUSOutput::GAMESSUSOutput() :
   m_coordFactor(1.0),
-  m_scftype(Rhf)
+  m_scftype(Unknown)
 {
 }
 
@@ -86,20 +90,33 @@ bool GAMESSUSOutput::read(std::istream &in, Core::Molecule &molecule)
     }
     else if (Core::contains(buffer, "NUMBER OF ELECTRONS")) {
       vector<string> parts = Core::split(buffer, '=');
-      if (parts.size() == 2)
-        m_electrons = Core::lexicalCast<int>(parts[1]);
+      if (parts.size() == 2) {
+        unsigned int electrons = Core::lexicalCast<int>(parts[1]);
+        cout << "Total electrons: " << electrons << endl;
+      }
       else
         cout << "error" << buffer << endl;
     }
-    /*else if (Core::contains(buffer, "NUMBER OF OCCUPIED ORBITALS (ALPHA)")) {
+    else if (Core::contains(buffer, "NUMBER OF OCCUPIED ORBITALS (ALPHA)")) {
       cout << "Found alpha orbitals\n";
+      vector<string> parts = Core::split(buffer, '=');
+      if (parts.size() == 2)
+        m_electronsB = Core::lexicalCast<int>(parts[1]);
+      else
+        cout << "error" << buffer << endl;
+
     }
     else if (Core::contains(buffer, "NUMBER OF OCCUPIED ORBITALS (BETA )")) {
       cout << "Found alpha orbitals\n";
+      vector<string> parts = Core::split(buffer, '=');
+      if (parts.size() == 2)
+        m_electronsB = Core::lexicalCast<int>(parts[1]);
+      else
+        cout << "error" << buffer << endl;
     }
     else if (Core::contains(buffer, "SCFTYP=")) {
       cout << "Found SCF type\n";
-    }*/
+    }
     else if (Core::contains(buffer, "EIGENVECTORS")) {
       readEigenvectors(in);
     }
@@ -284,7 +301,9 @@ void GAMESSUSOutput::readEigenvectors(std::istream &in)
 void GAMESSUSOutput::load(GaussianSet* basis)
 {
   // Now load up our basis set
-  basis->setElectronCount(m_electrons);
+  basis->setScfType(m_scftype);
+  basis->setElectronCount(m_electronsA, Alpha);
+  basis->setElectronCount(m_electronsA, Beta);
 
   // Set up the GTO primitive counter, go through the shells and add them
   int nGTO = 0;
@@ -317,18 +336,21 @@ void GAMESSUSOutput::load(GaussianSet* basis)
   //    qDebug() << " loading MOs " << m_MOcoeffs.size();
 
   // Now to load in the MO coefficients
-  if (m_MOcoeffs.size())
-    basis->setMolecularOrbitals(m_MOcoeffs);
+  if (m_MOcoeffs.size() && m_scftype == Rhf) {
+    basis->setMolecularOrbitals(m_MOcoeffs, Alpha);
+    basis->setMolecularOrbitals(m_MOcoeffs, Beta);
+  }
+  /*
+  // TODO: we will never get here because we never attempt to set the m_alphaMOcoeffs or m_betaMOcoeffs
   if (m_alphaMOcoeffs.size())
-    basis->setMolecularOrbitals(m_alphaMOcoeffs, BasisSet::Alpha);
+    basis->setMolecularOrbitals(m_alphaMOcoeffs, Alpha);
   if (m_betaMOcoeffs.size())
-    basis->setMolecularOrbitals(m_betaMOcoeffs, BasisSet::Beta);
+    basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
+  */
 
   //generateDensity();
   //if (m_density.rows())
     //basis->setDensityMatrix(m_density);
-
-  basis->setScfType(m_scftype);
 }
 
 void GAMESSUSOutput::reorderMOs()
@@ -437,11 +459,6 @@ void GAMESSUSOutput::outputAll()
       cout << m_MOcoeffs.at(i) << "\t";
     cout << "\n";
   }
-
-
-
-
-
 
   if (m_alphaMOcoeffs.size())
     cout << "Alpha MO coefficients.\n";

--- a/avogadro/quantumio/gamessus.cpp
+++ b/avogadro/quantumio/gamessus.cpp
@@ -340,13 +340,13 @@ void GAMESSUSOutput::load(GaussianSet* basis)
     basis->setMolecularOrbitals(m_MOcoeffs, Alpha);
     basis->setMolecularOrbitals(m_MOcoeffs, Beta);
   }
-  /*
-  // TODO: we will never get here because we never attempt to set the m_alphaMOcoeffs or m_betaMOcoeffs
+
+  // TODO: we will never get here because we never attempt to read the m_alphaMOcoeffs or m_betaMOcoeffs
   if (m_alphaMOcoeffs.size())
     basis->setMolecularOrbitals(m_alphaMOcoeffs, Alpha);
   if (m_betaMOcoeffs.size())
     basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
-  */
+
 
   if (m_orbitalEnergy.size() > 0) {
     basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);

--- a/avogadro/quantumio/gamessus.h
+++ b/avogadro/quantumio/gamessus.h
@@ -96,7 +96,6 @@ private:
   void load(Core::GaussianSet *basis);
 
   double m_coordFactor;
-  int m_electrons;
   int m_electronsA;
   int m_electronsB;
   int m_nMOs;

--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -116,9 +116,6 @@ void GaussianFchk::processLine(std::istream &in)
   else if (key == "Number of atoms" && list.size() > 1) {
     cout << "Number of atoms = " << Core::lexicalCast<int>(list[1]) << endl;
   }
-  //else if (key == "Number of electrons" && list.size() > 1) {
-    //m_electrons = Core::lexicalCast<int>(list[1]);
-  //}
   else if (key == "Number of alpha electrons" && list.size() > 1) {
     m_electronsAlpha = Core::lexicalCast<int>(list[1]);
   }
@@ -291,9 +288,7 @@ void GaussianFchk::load(GaussianSet* basis)
 
     if (m_betaMOcoeffs.size() > 0)
       basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
-    else if (m_scftype == Rhf)
-      basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
-    else
+    else if (m_scftype != Rhf)
       cout << "WARNING: Beta orbital coeficients undefined" << endl;
 
     // Set the MO Energies
@@ -302,9 +297,7 @@ void GaussianFchk::load(GaussianSet* basis)
 
     if (m_betaOrbitalEnergy.size() > 0)
       basis->setOrbitalEnergies(m_betaOrbitalEnergy, Beta);
-    else if (m_scftype == Rhf)
-      basis->setOrbitalEnergies(m_alphaOrbitalEnergy, Beta);
-    else
+    else if (m_scftype != Rhf)
       cout << "WARNING: Beta orbital energies undefined" << endl;
 
     if (m_density.rows() > 0)

--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -283,20 +283,32 @@ void GaussianFchk::load(GaussianSet* basis)
   }
   // Now to load in the MO coefficients
   if (basis->isValid()) {
-    if (m_alphaMOcoeffs.size())
+    // Set the MO Coefficients
+    if (m_alphaMOcoeffs.size() > 0)
       basis->setMolecularOrbitals(m_alphaMOcoeffs, Alpha);
 
-    if (m_betaMOcoeffs.size())
+    if (m_betaMOcoeffs.size() > 0)
       basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
     else if (m_scftype == Rhf)
       basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
     else
       cout << "WARNING: Beta orbital coeficients undefined" << endl;
 
-    if (m_density.rows())
+    // Set the MO Energies
+    if (m_alphaOrbitalEnergy.size() > 0)
+      basis->setOrbitalEnergies(m_alphaOrbitalEnergy, Alpha);
+
+    if (m_betaOrbitalEnergy.size() > 0)
+      basis->setOrbitalEnergies(m_betaOrbitalEnergy, Beta);
+    else if (m_scftype == Rhf)
+      basis->setOrbitalEnergies(m_alphaOrbitalEnergy, Beta);
+    else
+      cout << "WARNING: Beta orbital energies undefined" << endl;
+
+    if (m_density.rows() > 0)
       basis->setDensityMatrix(m_density);
 
-    if (m_spinDensity.rows())
+    if (m_spinDensity.rows() > 0)
       basis->setSpinDensityMatrix(m_spinDensity);
   }
   else {

--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -207,6 +207,8 @@ void GaussianFchk::processLine(std::istream &in)
 
 void GaussianFchk::load(GaussianSet* basis)
 {
+  basis->setScfType(m_scftype);
+
   basis->setElectronCount(m_electronsAlpha, Alpha);
   basis->setElectronCount(m_electronsBeta, Beta);
 

--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -34,10 +34,14 @@ namespace QuantumIO {
 using Core::Atom;
 using Core::BasisSet;
 using Core::GaussianSet;
+
 using Core::Rhf;
 using Core::Uhf;
 using Core::Rohf;
 using Core::Unknown;
+
+using Core::Alpha;
+using Core::Beta;
 
 GaussianFchk::GaussianFchk() : m_scftype(Rhf)
 {
@@ -112,9 +116,9 @@ void GaussianFchk::processLine(std::istream &in)
   else if (key == "Number of atoms" && list.size() > 1) {
     cout << "Number of atoms = " << Core::lexicalCast<int>(list[1]) << endl;
   }
-  else if (key == "Number of electrons" && list.size() > 1) {
-    m_electrons = Core::lexicalCast<int>(list[1]);
-  }
+  //else if (key == "Number of electrons" && list.size() > 1) {
+    //m_electrons = Core::lexicalCast<int>(list[1]);
+  //}
   else if (key == "Number of alpha electrons" && list.size() > 1) {
     m_electronsAlpha = Core::lexicalCast<int>(list[1]);
   }
@@ -172,28 +176,15 @@ void GaussianFchk::processLine(std::istream &in)
       m_scftype = Uhf;
       m_alphaOrbitalEnergy = m_orbitalEnergy;
       m_orbitalEnergy = vector<double>();
-
-      m_alphaMOcoeffs = m_MOcoeffs;
-      m_MOcoeffs = vector<double>();
     }
 
     m_betaOrbitalEnergy = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
     cout << "Beta MO energies, n = " << m_betaOrbitalEnergy.size() << endl;
   }
   else if (key == "Alpha MO coefficients" && list.size() > 2) {
-    if (m_scftype == Rhf) {
-      m_MOcoeffs = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
-      if (static_cast<int>(m_MOcoeffs.size()) == Core::lexicalCast<int>(list[2]))
-        cout << "MO coefficients, n = " << m_MOcoeffs.size() << endl;
-    }
-    else if (m_scftype == Uhf) {
-      m_alphaMOcoeffs = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
-      if (static_cast<int>(m_alphaMOcoeffs.size()) == Core::lexicalCast<int>(list[2]))
-        cout << "Alpha MO coefficients, n = " << m_alphaMOcoeffs.size() << endl;
-    }
-    else {
-      cout << "Error, alpha MO coefficients, n = " << m_MOcoeffs.size() << endl;
-    }
+    m_alphaMOcoeffs = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
+    if (static_cast<int>(m_alphaMOcoeffs.size()) == Core::lexicalCast<int>(list[2]))
+      cout << "Alpha MO coefficients, n = " << m_alphaMOcoeffs.size() << endl;
   }
   else if (key == "Beta MO coefficients" && list.size() > 2) {
       m_betaMOcoeffs = readArrayD(in, Core::lexicalCast<int>(list[2]), 16);
@@ -216,10 +207,8 @@ void GaussianFchk::processLine(std::istream &in)
 
 void GaussianFchk::load(GaussianSet* basis)
 {
-  // Now load up our basis set
-  basis->setElectronCount(m_electrons);
-  //basis->setElectronCount(m_electronsAlpha, Core::GaussianSet::alpha);
-  //basis->setElectronCount(m_electronsBeta, Core::GaussianSet::beta);
+  basis->setElectronCount(m_electronsAlpha, Alpha);
+  basis->setElectronCount(m_electronsBeta, Beta);
 
   // Set up the GTO primitive counter, go through the shells and add them
   int nGTO = 0;
@@ -294,16 +283,19 @@ void GaussianFchk::load(GaussianSet* basis)
   }
   // Now to load in the MO coefficients
   if (basis->isValid()) {
-    if (m_MOcoeffs.size())
-      basis->setMolecularOrbitals(m_MOcoeffs);
-    else
-      cout << "Error no MO coefficients...\n";
     if (m_alphaMOcoeffs.size())
-      basis->setMolecularOrbitals(m_alphaMOcoeffs, BasisSet::Alpha);
+      basis->setMolecularOrbitals(m_alphaMOcoeffs, Alpha);
+
     if (m_betaMOcoeffs.size())
-      basis->setMolecularOrbitals(m_betaMOcoeffs, BasisSet::Beta);
+      basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
+    else if (m_scftype == Rhf)
+      basis->setMolecularOrbitals(m_betaMOcoeffs, Beta);
+    else
+      cout << "WARNING: Beta orbital coeficients undefined" << endl;
+
     if (m_density.rows())
       basis->setDensityMatrix(m_density);
+
     if (m_spinDensity.rows())
       basis->setSpinDensityMatrix(m_spinDensity);
   }
@@ -577,12 +569,12 @@ void GaussianFchk::outputAll()
     cout << i << " : type = " << m_shellTypes.at(i)
          << ", number = " << m_shellNums.at(i)
          << ", atom = " << m_shelltoAtom.at(i) << endl;
-  if (m_MOcoeffs.size()) {
-    cout << "MO coefficients:\n";
-    for (unsigned int i = 0; i < m_MOcoeffs.size(); ++i)
-      cout << m_MOcoeffs.at(i) << "\t";
-    cout << endl << endl;
-  }
+//  if (m_MOcoeffs.size()) {
+//    cout << "MO coefficients:\n";
+//    for (unsigned int i = 0; i < m_MOcoeffs.size(); ++i)
+//      cout << m_MOcoeffs.at(i) << "\t";
+//    cout << endl << endl;
+//  }
   if (m_alphaMOcoeffs.size()) {
     cout << "Alpha MO coefficients:\n";
     for (unsigned int i = 0; i < m_alphaMOcoeffs.size(); ++i)

--- a/avogadro/quantumio/gaussianfchk.cpp
+++ b/avogadro/quantumio/gaussianfchk.cpp
@@ -581,12 +581,7 @@ void GaussianFchk::outputAll()
     cout << i << " : type = " << m_shellTypes.at(i)
          << ", number = " << m_shellNums.at(i)
          << ", atom = " << m_shelltoAtom.at(i) << endl;
-//  if (m_MOcoeffs.size()) {
-//    cout << "MO coefficients:\n";
-//    for (unsigned int i = 0; i < m_MOcoeffs.size(); ++i)
-//      cout << m_MOcoeffs.at(i) << "\t";
-//    cout << endl << endl;
-//  }
+
   if (m_alphaMOcoeffs.size()) {
     cout << "Alpha MO coefficients:\n";
     for (unsigned int i = 0; i < m_alphaMOcoeffs.size(); ++i)

--- a/avogadro/quantumio/gaussianfchk.h
+++ b/avogadro/quantumio/gaussianfchk.h
@@ -91,7 +91,7 @@ private:
   std::vector<double> m_orbitalEnergy;
   std::vector<double> m_alphaOrbitalEnergy;
   std::vector<double> m_betaOrbitalEnergy;
-  std::vector<double> m_MOcoeffs;
+//  std::vector<double> m_MOcoeffs;
   std::vector<double> m_alphaMOcoeffs;
   std::vector<double> m_betaMOcoeffs;
   MatrixX m_density;     /// Total density matrix

--- a/avogadro/quantumio/gaussianfchk.h
+++ b/avogadro/quantumio/gaussianfchk.h
@@ -91,7 +91,6 @@ private:
   std::vector<double> m_orbitalEnergy;
   std::vector<double> m_alphaOrbitalEnergy;
   std::vector<double> m_betaOrbitalEnergy;
-//  std::vector<double> m_MOcoeffs;
   std::vector<double> m_alphaMOcoeffs;
   std::vector<double> m_betaMOcoeffs;
   MatrixX m_density;     /// Total density matrix

--- a/avogadro/quantumio/molden.cpp
+++ b/avogadro/quantumio/molden.cpp
@@ -260,14 +260,12 @@ void MoldenFile::load(GaussianSet* basis) {
   // Now to load in the MO coefficients
   if (m_MOcoeffs.size() > 0) {
     basis->setMolecularOrbitals(m_MOcoeffs, Alpha);
-    basis->setMolecularOrbitals(m_MOcoeffs, Beta);
   }
 
   // TODO: Currently these arn't read from the file and if they were, open shell isn't supported.
   // Now load the MO energies
   if (m_orbitalEnergy.size() > 0) {
     basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
-    basis->setOrbitalEnergies(m_orbitalEnergy, Beta);
   }
 }
 

--- a/avogadro/quantumio/molden.cpp
+++ b/avogadro/quantumio/molden.cpp
@@ -228,6 +228,8 @@ void MoldenFile::load(GaussianSet* basis) {
     cout << "Warning: Open shell Molden files not implemented." << endl;
     return;
   }
+  basis->setScfType(Rhf); // TODO: implement open shell systems?
+
   basis->setElectronCount(m_electrons/2, Alpha);
   basis->setElectronCount(m_electrons/2, Beta);
 

--- a/avogadro/quantumio/molden.cpp
+++ b/avogadro/quantumio/molden.cpp
@@ -256,9 +256,16 @@ void MoldenFile::load(GaussianSet* basis) {
     }
   }
   // Now to load in the MO coefficients
-  if (m_MOcoeffs.size()) {
+  if (m_MOcoeffs.size() > 0) {
     basis->setMolecularOrbitals(m_MOcoeffs, Alpha);
     basis->setMolecularOrbitals(m_MOcoeffs, Beta);
+  }
+
+  // TODO: Currently these arn't read from the file and if they were, open shell isn't supported.
+  // Now load the MO energies
+  if (m_orbitalEnergy.size() > 0) {
+    basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
+    basis->setOrbitalEnergies(m_orbitalEnergy, Beta);
   }
 }
 

--- a/avogadro/quantumio/molden.cpp
+++ b/avogadro/quantumio/molden.cpp
@@ -34,10 +34,14 @@ namespace QuantumIO {
 using Core::Atom;
 using Core::BasisSet;
 using Core::GaussianSet;
+
 using Core::Rhf;
 using Core::Uhf;
 using Core::Rohf;
 using Core::Unknown;
+
+using Core::Alpha;
+using Core::Beta;
 
 MoldenFile::MoldenFile():
   m_coordFactor(1.0),
@@ -218,10 +222,14 @@ void MoldenFile::readAtom(const vector<string> &list)
   m_aPos.push_back(Core::lexicalCast<double>(list[5]) * m_coordFactor);
 }
 
-void MoldenFile::load(GaussianSet* basis)
-{
+void MoldenFile::load(GaussianSet* basis) {
   // Now load up our basis set
-  basis->setElectronCount(m_electrons);
+  if (m_electrons % 2 != 0) {
+    cout << "Warning: Open shell Molden files not implemented." << endl;
+    return;
+  }
+  basis->setElectronCount(m_electrons/2, Alpha);
+  basis->setElectronCount(m_electrons/2, Beta);
 
   // Set up the GTO primitive counter, go through the shells and add them
   int nGTO = 0;
@@ -248,8 +256,10 @@ void MoldenFile::load(GaussianSet* basis)
     }
   }
   // Now to load in the MO coefficients
-  if (m_MOcoeffs.size())
-    basis->setMolecularOrbitals(m_MOcoeffs);
+  if (m_MOcoeffs.size()) {
+    basis->setMolecularOrbitals(m_MOcoeffs, Alpha);
+    basis->setMolecularOrbitals(m_MOcoeffs, Beta);
+  }
 }
 
 void MoldenFile::outputAll()

--- a/avogadro/quantumio/molden.h
+++ b/avogadro/quantumio/molden.h
@@ -79,7 +79,7 @@ private:
   std::vector<double> m_a;
   std::vector<double> m_c;
   std::vector<double> m_csp;
-  std::vector<double> m_orbitalEnergy;
+  std::vector<double> m_orbitalEnergy;  // TODO: support open shell
   std::vector<double> m_MOcoeffs;
 
   enum Mode { Atoms, GTO, MO, Unrecognized };

--- a/avogadro/quantumio/mopacaux.cpp
+++ b/avogadro/quantumio/mopacaux.cpp
@@ -35,6 +35,9 @@ using Core::Atom;
 using Core::BasisSet;
 using Core::SlaterSet;
 
+using Core::Alpha;
+using Core::Beta;
+
 MopacAux::MopacAux()
 {
 }
@@ -153,12 +156,19 @@ void MopacAux::load(SlaterSet* basis)
     //basis->setIsValid(false);
     return;
   }
+
+  if (m_electrons % 2 != 0) {
+    cout << "Open shell input not implemented for mopac" << endl;
+    return;
+  }
+
   // Now load up our basis set
   basis->addSlaterIndices(m_atomIndex);
   basis->addSlaterTypes(m_atomSym);
   basis->addZetas(m_zeta);
   basis->addPQNs(m_pqn);
-  basis->setElectronCount(m_electrons);
+  basis->setElectronCount(m_electrons/2, Alpha);
+  basis->setElectronCount(m_electrons/2, Beta);
   basis->addOverlapMatrix(m_overlap);
   basis->addEigenVectors(m_eigenVectors);
   basis->addDensityMatrix(m_density);

--- a/avogadro/quantumio/mopacaux.cpp
+++ b/avogadro/quantumio/mopacaux.cpp
@@ -160,7 +160,7 @@ void MopacAux::load(SlaterSet* basis)
   }
 
   if (m_electrons % 2 != 0) {
-    cout << "Open shell input not implemented for mopac" << endl;
+    cout << "Open shell input not implemented for MOPAC. Bailing out." << endl;
     return;
   }
 
@@ -178,11 +178,8 @@ void MopacAux::load(SlaterSet* basis)
   basis->addDensityMatrix(m_density);
 
   // TODO: these currently aren't read and if they where, open shell systems would be wrong.
-  if (m_orbitalEnergy.size() > 0) {
+  if (m_orbitalEnergy.size() > 0)
     basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
-    basis->setOrbitalEnergies(m_orbitalEnergy, Beta);
-  }
-
 }
 
 vector<int> MopacAux::readArrayElements(std::istream &in, unsigned int n)

--- a/avogadro/quantumio/mopacaux.cpp
+++ b/avogadro/quantumio/mopacaux.cpp
@@ -35,6 +35,8 @@ using Core::Atom;
 using Core::BasisSet;
 using Core::SlaterSet;
 
+using Core::Rhf;
+
 using Core::Alpha;
 using Core::Beta;
 
@@ -161,6 +163,8 @@ void MopacAux::load(SlaterSet* basis)
     cout << "Open shell input not implemented for mopac" << endl;
     return;
   }
+
+  basis->setScfType(Rhf); // TODO: support open shell
 
   // Now load up our basis set
   basis->addSlaterIndices(m_atomIndex);

--- a/avogadro/quantumio/mopacaux.cpp
+++ b/avogadro/quantumio/mopacaux.cpp
@@ -172,6 +172,13 @@ void MopacAux::load(SlaterSet* basis)
   basis->addOverlapMatrix(m_overlap);
   basis->addEigenVectors(m_eigenVectors);
   basis->addDensityMatrix(m_density);
+
+  // TODO: these currently arn't read and if they where, open shell systems would fail.
+  if (m_orbitalEnergy.size() > 0) {
+    basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
+    basis->setOrbitalEnergies(m_orbitalEnergy, Beta);
+  }
+
 }
 
 vector<int> MopacAux::readArrayElements(std::istream &in, unsigned int n)

--- a/avogadro/quantumio/mopacaux.cpp
+++ b/avogadro/quantumio/mopacaux.cpp
@@ -173,7 +173,7 @@ void MopacAux::load(SlaterSet* basis)
   basis->addEigenVectors(m_eigenVectors);
   basis->addDensityMatrix(m_density);
 
-  // TODO: these currently arn't read and if they where, open shell systems would fail.
+  // TODO: these currently aren't read and if they where, open shell systems would be wrong.
   if (m_orbitalEnergy.size() > 0) {
     basis->setOrbitalEnergies(m_orbitalEnergy, Alpha);
     basis->setOrbitalEnergies(m_orbitalEnergy, Beta);

--- a/avogadro/quantumio/mopacaux.h
+++ b/avogadro/quantumio/mopacaux.h
@@ -80,7 +80,7 @@ private:
   std::vector<int> m_shelltoAtom;
   std::vector<double> m_c;
   std::vector<double> m_csp;
-  std::vector<double> m_orbitalEnergy;
+  std::vector<double> m_orbitalEnergy;  // TODO: support open shell
   std::vector<double> m_MOcoeffs;
 
   std::vector<int> m_atomIndex;

--- a/tests/core/basissettest.cpp
+++ b/tests/core/basissettest.cpp
@@ -22,11 +22,30 @@
 using namespace Avogadro::Core;
 using Avogadro::Core::SlaterSet;
 
-TEST(BasisSetTest, homo)
+TEST(BasisSetTest, electronCount)
+{
+  SlaterSet basis;
+
+  basis.setElectronCount(1, Alpha);
+  EXPECT_EQ(basis.electronCount(Alpha), 1);
+  EXPECT_EQ(basis.electronCount(Beta), 0);
+}
+
+TEST(BasisSetTest, totalElectronCount)
 {
   SlaterSet basis;
 
   basis.setElectronCount(2, Alpha);
+  basis.setElectronCount(1, Beta);
+
+  EXPECT_EQ(basis.totalElectronCount(), 3);
+}
+
+TEST(BasisSetTest, homo)
+{
+  SlaterSet basis;
+
+  basis.setElectronCount(1, Alpha);
   EXPECT_EQ(basis.homo(Alpha), 1);
   EXPECT_TRUE(basis.homo(basis.homo(Alpha), Alpha));
 
@@ -46,4 +65,3 @@ TEST(BasisSetTest, homo)
 
   EXPECT_TRUE(!basis.homo(basis.homo(Alpha), Beta));
 }
-

--- a/tests/core/basissettest.cpp
+++ b/tests/core/basissettest.cpp
@@ -19,33 +19,31 @@
 #include <avogadro/core/basisset.h>
 #include <avogadro/core/slaterset.h>
 
-using Avogadro::Core::BasisSet;
+using namespace Avogadro::Core;
 using Avogadro::Core::SlaterSet;
 
 TEST(BasisSetTest, homo)
 {
   SlaterSet basis;
 
-  basis.setElectronCount(2, BasisSet::Paired);
-  EXPECT_EQ(basis.homo(), 1);
-  EXPECT_TRUE(basis.homo(basis.homo()));
+  basis.setElectronCount(2, Alpha);
+  EXPECT_EQ(basis.homo(Alpha), 1);
+  EXPECT_TRUE(basis.homo(basis.homo(Alpha), Alpha));
 
-  EXPECT_EQ(basis.lumo(), 2);
-  EXPECT_TRUE(basis.lumo(basis.lumo()));
+  EXPECT_EQ(basis.lumo(Alpha), 2);
+  EXPECT_TRUE(basis.lumo(basis.lumo(Alpha), Alpha));
 
 
   basis = SlaterSet();
-  basis.setElectronCount(2, BasisSet::Alpha);
-  basis.setElectronCount(1, BasisSet::Beta);
+  basis.setElectronCount(2, Alpha);
+  basis.setElectronCount(1, Beta);
 
-  EXPECT_EQ(basis.homo(), 1);
-  EXPECT_TRUE(basis.homo(basis.homo()));
+  EXPECT_EQ(basis.homo(Alpha), 2);
+  EXPECT_EQ(basis.homo(Beta), 1);
 
-  // This is broken: the lumo could be either the 
-  // next alpha or the next beta depending on the 
-  // energetics of the system
+  EXPECT_TRUE(basis.homo(basis.homo(Alpha), Alpha));
+  EXPECT_TRUE(basis.homo(basis.homo(Beta), Beta));
 
-  // EXPECT_EQ(basis.lumo(), 2);
-  // EXPECT_TRUE(basis.lumo(basis.lumo()));
+  EXPECT_TRUE(!basis.homo(basis.homo(Alpha), Beta));
 }
 


### PR DESCRIPTION
This is a work in progress. Input appreciated. Once this is ready for merging, I'll do a re-base/squash against master and open a new pull request.

This PR improves support for open shell electronic configurations. A number of changes are made to the internal representation of `BasisSet` and its sub-types.
The summary is that alpha and beta electrons are given equal status in both UHF and RHF configurations.