### PR TITLE
Workaround for systems with both python2 and 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ endif()
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR})
+
+if(USE_BOOST_PYTHON)
+  add_subdirectory(boostpython)
+endif()
+
 add_subdirectory(utilities)
 add_subdirectory(thirdparty)
 add_subdirectory(avogadro)
@@ -54,10 +59,6 @@ option(BUILD_DOCUMENTATION "Build project documentation" OFF)
 
 if(BUILD_DOCUMENTATION)
   add_subdirectory(docs)
-endif()
-
-if(USE_BOOST_PYTHON)
-  add_subdirectory(boostpython)
 endif()
 
 install(


### PR DESCRIPTION
Hi. 

Currently, ```cmake -DUSE_BOOST_PYTHON -DUSE_QT``` fails on systems with both python 2 and 3 due to discrepancy between minimum python versions for boostpython module and for qtgui module.

This patch at least workaround this issue, by finding later version of python first.