### PR TITLE
Fixed a memory leak in an assignment operator.

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -59,7 +59,9 @@ Molecule& Molecule::operator=(const Molecule& other)
   if (this != &other) {
     m_graphDirty = true;
     m_customElementMap = other.m_customElementMap;
+    delete m_basisSet;
     m_basisSet = NULL;
+    delete m_unitCell;
     m_unitCell = other.m_unitCell ? new UnitCell(*other.m_unitCell) : NULL;
     m_data = other.m_data;
     m_atomicNumbers = other.m_atomicNumbers;


### PR DESCRIPTION
No need to check if the pointers are NULL since delete may be safely called on NULL pointers.