### PR TITLE
Added POSCAR format and clipboard import crystal.

### DIFF
--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADERS
   fileformatmanager.h
   gromacsformat.h
   mdlformat.h
+  poscarformat.h
   xyzformat.h
 )
 
@@ -39,6 +40,7 @@ set(SOURCES
   fileformatmanager.cpp
   gromacsformat.cpp
   mdlformat.cpp
+  poscarformat.cpp
   xyzformat.cpp
 )
 

--- a/avogadro/io/fileformatmanager.cpp
+++ b/avogadro/io/fileformatmanager.cpp
@@ -22,6 +22,7 @@
 #include "cjsonformat.h"
 #include "gromacsformat.h"
 #include "mdlformat.h"
+#include "poscarformat.h"
 #include "xyzformat.h"
 
 #include <avogadro/stl/memory_p.h>
@@ -296,6 +297,7 @@ FileFormatManager::FileFormatManager()
   addFormat(new CjsonFormat);
   addFormat(new GromacsFormat);
   addFormat(new MdlFormat);
+  addFormat(new PoscarFormat);
   addFormat(new XyzFormat);
 }
 

--- a/avogadro/io/poscarformat.cpp
+++ b/avogadro/io/poscarformat.cpp
@@ -1,0 +1,342 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "poscarformat.h"
+
+#include <avogadro/core/elements.h> // for atomicNumberFromSymbol()
+#include <avogadro/core/matrix.h> // for matrix3
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/vector.h> // for Vector3
+#include <avogadro/core/unitcell.h>
+#include <avogadro/core/utilities.h> // for split(), trimmed(), lexicalCast()
+
+#include <algorithm> // for std::count()
+#include <iomanip>
+#include <iostream>
+
+namespace Avogadro {
+namespace Io {
+
+using std::getline;
+using std::string;
+using std::vector;
+
+using Core::Array;
+using Core::Atom;
+using Core::Elements;
+using Core::Molecule;
+using Core::UnitCell;
+using Core::lexicalCast;
+using Core::split;
+using Core::trimmed;
+
+PoscarFormat::PoscarFormat()
+{
+}
+
+PoscarFormat::~PoscarFormat()
+{
+}
+
+bool PoscarFormat::read(std::istream &inStream, Core::Molecule &mol)
+{
+  size_t numLines = std::count(std::istreambuf_iterator<char>(inStream),
+                               std::istreambuf_iterator<char>(), '\n');
+
+  // There must be at least 7 "\n"'s to have a minimum crystal (including 1 atom)
+  if (numLines < 7) {
+    appendError("Error: POSCAR file is 7 or fewer lines long");
+    return false;
+  }
+
+  // We have to go back to the beginning if we are going to read again
+  inStream.clear();
+  inStream.seekg(0, std::ios::beg);
+
+  // We'll use these throughout
+  bool ok;
+  string line;
+  vector<string> stringSplit;
+
+  // First line is comment line
+  getline(inStream, line);
+  line = trimmed(line);
+  string title = " ";
+  if (!line.empty())
+    title = line;
+
+  // Next line is scaling factor
+  getline(inStream, line);
+  double scalingFactor = lexicalCast<double>(line, ok);
+
+  if (!ok) {
+    appendError("Error: Could not convert scaling factor to double in POSCAR");
+    return false;
+  }
+
+  Matrix3 cellMat;
+
+  // Next comes the matrix
+  for (size_t i = 0; i < 3; ++i) {
+    getline(inStream, line);
+    stringSplit = split(line, ' ');
+    // If this is not three, then there is some kind of error in the line
+    if (stringSplit.size() != 3) {
+      appendError("Error reading lattice vectors in POSCAR");
+      return false;
+    }
+    // UnitCell expects a matrix of this form
+    cellMat(0,i) = lexicalCast<double>(stringSplit.at(0)) * scalingFactor;
+    cellMat(1,i) = lexicalCast<double>(stringSplit.at(1)) * scalingFactor;
+    cellMat(2,i) = lexicalCast<double>(stringSplit.at(2)) * scalingFactor;
+  }
+
+  // Sometimes, atomic symbols go here.
+  getline(inStream, line);
+  stringSplit = split(line, ' ');
+
+  if (stringSplit.empty()) {
+    appendError("Error reading numbers of atom types in POSCAR");
+    return false;
+  }
+
+  // Try a lexical cast here. If it fails, assume we have an atomic symbols list
+  lexicalCast<uint>(trimmed(stringSplit.at(0)), ok);
+  vector<string> symbolsList;
+  vector<unsigned char> atomicNumbers;
+
+  if (!ok) {
+    // Assume atomic symbols are here and store them
+    symbolsList = split(line, ' ');
+    // Store atomic nums
+    for (size_t i = 0; i < symbolsList.size(); ++i)
+      atomicNumbers.push_back(Elements::atomicNumberFromSymbol(symbolsList[i]));
+    // This next one should be atom types
+    getline(inStream, line);
+  }
+  // If the atomic symbols aren't here, try to find them in the title
+  // In Vasp 4.x, symbols are in the title like so: " O4H2 <restOfTitle>"
+  else {
+    stringSplit = split(title, ' ');
+    if (stringSplit.size() != 0) {
+      string trimmedFormula = trimmed(stringSplit.at(0));
+      // Let's replace all numbers with spaces
+      for (size_t i = 0; i < trimmedFormula.size(); ++i) {
+        if (isdigit(trimmedFormula.at(i)))
+          trimmedFormula[i] = ' ';
+      }
+      // Now get the symbols with a simple space split
+      symbolsList = split(trimmedFormula, ' ');
+      for (size_t i = 0; i < symbolsList.size(); ++i)
+        atomicNumbers.push_back(Elements::atomicNumberFromSymbol(symbolsList.at(i)));
+    }
+  }
+
+  stringSplit = split(line, ' ');
+  vector<uint> atomCounts;
+  for (size_t i = 0; i < stringSplit.size(); ++i) {
+    uint atomCount = lexicalCast<uint>(stringSplit.at(i));
+    atomCounts.push_back(atomCount);
+  }
+
+  // If we never filled up the atomic numbers, fill them up
+  // now with "1, 2, 3..."
+  if (atomicNumbers.size() == 0)
+    for (size_t i = 1; i <= atomCounts.size(); ++i) atomicNumbers.push_back(i);
+
+  if (atomicNumbers.size() != atomCounts.size()) {
+    appendError("Error: numSymbols and numTypes are not equal in POSCAR!");
+    return false;
+  }
+
+  // Starts with either [Ss]elective dynamics, [KkCc]artesian, or
+  // other for fractional coords.
+  getline(inStream, line);
+  line = trimmed(line);
+
+  // If selective dynamics, get the next line
+  if (line.empty() || line.at(0) == 'S' || line.at(0) == 's')
+    getline(inStream, line);
+
+  line = trimmed(line);
+  if (line.empty()) {
+    appendError("Error determining Direct or Cartesian in POSCAR");
+    return false;
+  }
+
+  bool cart;
+  // Check if we're using cartesian or fractional coordinates:
+  if (line.at(0) == 'K' || line.at(0) == 'k' ||
+      line.at(0) == 'C' || line.at(0) == 'c' ) {
+    cart = true;
+  }
+  // Assume direct if one of these was not found
+  else {
+    cart = false;
+  }
+
+  vector<Vector3> atoms;
+  for (size_t i = 0; i < atomCounts.size(); ++i) {
+    for (size_t j = 0; j < atomCounts.at(i); ++j) {
+      getline(inStream, line);
+      stringSplit = split(line, ' ');
+      // This may be greater than 3 with selective dynamics
+      if (stringSplit.size() < 3) {
+        appendError("Error reading atomic coordinates in POSCAR");
+        return false;
+      }
+      Vector3 tmpAtom(lexicalCast<double>(stringSplit.at(0)),
+                      lexicalCast<double>(stringSplit.at(1)),
+                      lexicalCast<double>(stringSplit.at(2)));
+      atoms.push_back(tmpAtom);
+    }
+  }
+
+  // Let's make a unit cell
+  UnitCell* cell = new UnitCell(cellMat);
+
+  // If our atomic coordinates are fractional, convert them to Cartesian
+  if (!cart) {
+    for (size_t i = 0; i < atoms.size(); ++i)
+      atoms[i] = cell->toCartesian(atoms.at(i));
+  }
+  // If they're cartesian, we just need to apply the scaling factor
+  else {
+    for (size_t i = 0; i < atoms.size(); ++i)
+      atoms[i] *= scalingFactor;
+  }
+
+  // If we made it this far, the read was a success!
+  // Delete the current molecule. Add the new title and unit cell
+  mol.clearAtoms();
+  mol.setData("name", title);
+  mol.setUnitCell(cell);
+
+  // Now add the atoms
+  size_t k = 0;
+  for (size_t i = 0; i < atomCounts.size(); ++i) {
+    unsigned char atomicNum = atomicNumbers.at(i);
+    for (size_t j = 0; j < atomCounts.at(i); ++j) {
+      Atom newAtom = mol.addAtom(atomicNum);
+      newAtom.setPosition3d(atoms.at(k));
+      ++k;
+    }
+  }
+
+  return true;
+}
+
+bool PoscarFormat::write(std::ostream &outStream, const Core::Molecule &mol)
+{
+  // Title
+  if (mol.data("name").toString().length())
+    outStream << mol.data("name").toString() << std::endl;
+  else
+    outStream << "POSCAR" << std::endl;
+
+  // Scaling factor
+  outStream << " 1.00000000" << std::endl;
+
+  // 3x3 matrix. Transpose is needed to orient the matrix correctly.
+  const Matrix3 &mat = mol.unitCell()->cellMatrix().transpose();
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      outStream << "   " << std::setw(10) << std::right << std::fixed
+                << std::setprecision(8) << mat(i,j);
+    }
+    outStream << std::endl;
+  }
+
+  // Adapted from chemkit:
+  // A map of atomic symbols to their quantity.
+  Array<unsigned char> atomicNumbers = mol.atomicNumbers();
+  std::map<unsigned char, size_t> composition;
+  for (Array<unsigned char>::const_iterator it = atomicNumbers.begin(),
+       itEnd = atomicNumbers.end(); it != itEnd; ++it) {
+    composition[*it]++;
+  }
+
+  // Atom symbols
+  std::map<unsigned char, size_t>::iterator iter = composition.begin();
+  while (iter != composition.end()) {
+    outStream << "   " << Elements::symbol(iter->first);
+    ++iter;
+  }
+  outStream << std::endl;
+
+  // Numbers of each type
+  iter = composition.begin();
+  while (iter != composition.end()) {
+    outStream << "   " << iter->second;
+    ++iter;
+  }
+  outStream << std::endl;
+
+  // Direct or cartesian?
+  outStream << "Direct" << std::endl;
+
+  // Final section is atomic coordinates
+  size_t numAtoms = mol.atomCount();
+  // We need to make sure we that group the atomic numbers together.
+  // The outer loop is for grouping them.
+  iter = composition.begin();
+  while (iter != composition.end()) {
+    unsigned char currentAtomicNum = iter->first;
+    for (size_t i = 0; i < numAtoms; ++i) {
+      // We need to group atomic numbers together. If this one is not
+      // the current atomic number, skip over it.
+      if (atomicNumbers.at(i) != currentAtomicNum)
+        continue;
+
+      Atom atom = mol.atom(i);
+      if (!atom.isValid()) {
+        appendError("Internal error: Atom invalid.");
+        return false;
+      }
+      Vector3 fracCoords = mol.unitCell()->toFractional(atom.position3d());
+      outStream << "  "
+                << std::setw(10) << std::right << std::fixed
+                << std::setprecision(8)
+                << fracCoords.x() << "  "
+                << std::setw(10) << std::right << std::fixed
+                << std::setprecision(8)
+                << fracCoords.y() << "  "
+                << std::setw(10) << std::right << std::fixed
+                << std::setprecision(8)
+                << fracCoords.z() << "\n";
+    }
+    ++iter;
+  }
+
+  return true;
+}
+
+std::vector<std::string> PoscarFormat::fileExtensions() const
+{
+  std::vector<std::string> ext;
+  ext.push_back("POSCAR");
+  return ext;
+}
+
+std::vector<std::string> PoscarFormat::mimeTypes() const
+{
+  std::vector<std::string> mime;
+  mime.push_back("N/A");
+  return mime;
+}
+
+} // end Io namespace
+} // end Avogadro namespace

--- a/avogadro/io/poscarformat.h
+++ b/avogadro/io/poscarformat.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_POSCARFORMAT_H
+#define AVOGADRO_IO_POSCARFORMAT_H
+
+#include "fileformat.h"
+
+namespace Avogadro {
+namespace Io {
+
+/**
+ * @class PoscarFormat poscarformat.h <avogadro/io/poscarformat.h>
+ * @brief Implementation of the generic POSCAR format.
+ * @author Patrick S. Avery
+ */
+
+class AVOGADROIO_EXPORT PoscarFormat : public FileFormat
+{
+public:
+  PoscarFormat();
+  ~PoscarFormat() AVO_OVERRIDE;
+
+  Operations supportedOperations() const AVO_OVERRIDE
+  {
+    return ReadWrite | File | Stream | String;
+  }
+
+  FileFormat * newInstance() const AVO_OVERRIDE { return new PoscarFormat; }
+  std::string identifier() const AVO_OVERRIDE { return "Avogadro: POSCAR"; }
+  std::string name() const AVO_OVERRIDE { return "POSCAR"; }
+  std::string description() const AVO_OVERRIDE
+  {
+    return "Format used by VASP that contains crystal cell and atom info.";
+  }
+
+  std::string specificationUrl() const AVO_OVERRIDE
+  {
+    return "http://cms.mpi.univie.ac.at/vasp/guide/node59.html";
+  }
+
+  std::vector<std::string> fileExtensions() const AVO_OVERRIDE;
+  std::vector<std::string> mimeTypes() const AVO_OVERRIDE;
+
+  bool read(std::istream &inStream, Core::Molecule &mol);
+  bool write(std::ostream &outStream, const Core::Molecule &mol);
+};
+
+} // end Io namespace
+} // end Avogadro namespace
+
+#endif // AVOGADRO_IO_POSCARFORMAT_H
+

--- a/avogadro/qtplugins/crystal/CMakeLists.txt
+++ b/avogadro/qtplugins/crystal/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(crystal_srcs
   crystal.cpp
+  importcrystaldialog.cpp
   unitcelldialog.cpp
   volumescalingdialog.cpp
 )
 
 set(crystal_uis
+  importcrystaldialog.ui
   unitcelldialog.ui
   volumescalingdialog.ui
 )

--- a/avogadro/qtplugins/crystal/crystal.cpp
+++ b/avogadro/qtplugins/crystal/crystal.cpp
@@ -16,6 +16,7 @@
 
 #include "crystal.h"
 
+#include "importcrystaldialog.h"
 #include "unitcelldialog.h"
 #include "volumescalingdialog.h"
 
@@ -40,6 +41,7 @@ Crystal::Crystal(QObject *parent_) :
   Avogadro::QtGui::ExtensionPlugin(parent_),
   m_molecule(NULL),
   m_unitCellDialog(NULL),
+  m_importCrystalClipboardAction(new QAction(this)),
   m_editUnitCellAction(new QAction(this)),
   m_niggliReduceAction(new QAction(this)),
   m_scaleVolumeAction(new QAction(this)),
@@ -47,6 +49,12 @@ Crystal::Crystal(QObject *parent_) :
   m_toggleUnitCellAction(new QAction(this)),
   m_wrapAtomsToCellAction(new QAction(this))
 {
+  m_importCrystalClipboardAction->setText(tr("Import Crystal from Clipboard"));
+  connect(m_importCrystalClipboardAction, SIGNAL(triggered()),
+          SLOT(importCrystalClipboard()));
+  m_actions.push_back(m_importCrystalClipboardAction);
+  m_importCrystalClipboardAction->setProperty("menu priority", 50);
+
   // this will be changed when the molecule is set:
   m_toggleUnitCellAction->setText(tr("Toggle Unit Cell"));
   connect(m_toggleUnitCellAction, SIGNAL(triggered()), SLOT(toggleUnitCell()));
@@ -152,8 +160,21 @@ void Crystal::updateActions()
     foreach (QAction *action, m_actions)
       action->setEnabled(false);
 
+    m_importCrystalClipboardAction->setEnabled(true);
     m_toggleUnitCellAction->setEnabled(true);
     m_toggleUnitCellAction->setText(tr("Add &Unit Cell"));
+  }
+}
+
+void Crystal::importCrystalClipboard()
+{
+  ImportCrystalDialog d;
+  Core::Molecule m;
+  if (d.importCrystalClipboard(m)) {
+    // If we succeeded, update m_molecule
+    *m_molecule = m;
+    m_molecule->emitChanged(Molecule::Added |
+                            Molecule::Atoms | Molecule::UnitCell);
   }
 }
 

--- a/avogadro/qtplugins/crystal/crystal.h
+++ b/avogadro/qtplugins/crystal/crystal.h
@@ -46,6 +46,7 @@ public slots:
 private slots:
   void updateActions();
 
+  void importCrystalClipboard();
   void editUnitCell();
   void niggliReduce();
   void scaleVolume();
@@ -58,6 +59,7 @@ private:
   QtGui::Molecule *m_molecule;
   UnitCellDialog *m_unitCellDialog;
 
+  QAction *m_importCrystalClipboardAction;
   QAction *m_editUnitCellAction;
   QAction *m_niggliReduceAction;
   QAction *m_scaleVolumeAction;

--- a/avogadro/qtplugins/crystal/importcrystaldialog.cpp
+++ b/avogadro/qtplugins/crystal/importcrystaldialog.cpp
@@ -1,0 +1,99 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "importcrystaldialog.h"
+#include "ui_importcrystaldialog.h"
+
+#include <avogadro/core/molecule.h>
+#include <avogadro/io/poscarformat.h>
+#include <avogadro/qtplugins/openbabel/obfileformat.h>
+
+#include <QDebug>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QMessageBox>
+
+#include <QtGui/QClipboard>
+
+using std::vector;
+using std::string;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+ImportCrystalDialog::ImportCrystalDialog(QWidget *p) :
+  QDialog(p),
+  m_ui(new Ui::ImportCrystalDialog)
+{
+  m_ui->setupUi(this);
+}
+
+ImportCrystalDialog::~ImportCrystalDialog()
+{
+  delete m_ui;
+}
+
+bool ImportCrystalDialog::importCrystalClipboard(Avogadro::Core::Molecule &mol)
+{
+  QString text = QApplication::clipboard()->text();
+  m_ui->edit_text->setText(text);
+  // If the user rejected, just return false
+  if (this->exec() == QDialog::Rejected)
+    return false;
+
+  // Use POSCAR format by default. If the extension was set, use that instead
+  std::string ext = m_ui->edit_extension->text().toUpper().toStdString();
+
+  // Update the text
+  text = m_ui->edit_text->toPlainText();
+  std::stringstream s(text.toStdString());
+
+  if (ext.empty() || ext == "POSCAR") {
+   Avogadro::Io::PoscarFormat format;
+   if (format.read(s, mol))
+     return true;
+   // Print out the error messages if we failed
+   else
+     qDebug() << QString::fromStdString(format.error());
+  }
+  // Try using the extension
+  else {
+    // We don't need to set any of the info, so just put in empty strings for
+    // most arguments (except the extension)
+    OBFileFormat ob("", "", "", "", vector<string>{ext}, vector<string>{""});
+    if (ob.read(s, mol))
+      return true;
+    // Print out the error messages from the read if we failed
+    else
+      qDebug() << QString::fromStdString(ob.error());
+  }
+  displayInvalidFormatMessage();
+  return false;
+}
+
+void ImportCrystalDialog::displayInvalidFormatMessage()
+{
+  QMessageBox::critical
+    (this,
+     tr("Cannot Parse Text"),
+     tr("The input is either not formatted using\n"
+        "VASP format or the obabel conversion failed.\n\n"));
+  reject();
+  close();
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/crystal/importcrystaldialog.h
+++ b/avogadro/qtplugins/crystal/importcrystaldialog.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_IMPORTCRYSTALDIALOG_H
+#define AVOGADRO_QTPLUGINS_IMPORTCRYSTALDIALOG_H
+
+#include <avogadro/core/avogadrocore.h>
+
+#include <QtWidgets/QDialog>
+
+namespace Avogadro {
+
+namespace Core {
+class Molecule;
+}
+
+namespace QtPlugins {
+
+namespace Ui {
+class ImportCrystalDialog;
+}
+
+/**
+ * @brief The ImportCrystalDialog class provides a dialog for importing
+ * a crystal from the clipboard.
+ */
+
+class ImportCrystalDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  ImportCrystalDialog(QWidget *p = 0);
+  ~ImportCrystalDialog();
+
+  // Avogadro::Core::Molecule is required for the format function
+  bool importCrystalClipboard(Avogadro::Core::Molecule &mol);
+
+  void displayInvalidFormatMessage();
+
+private:
+  AVO_DISABLE_COPY(ImportCrystalDialog)
+
+  Ui::ImportCrystalDialog *m_ui;
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+#endif // AVOGADRO_QTPLUGINS_IMPORTCRYSTALDIALOG_H

--- a/avogadro/qtplugins/crystal/importcrystaldialog.ui
+++ b/avogadro/qtplugins/crystal/importcrystaldialog.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Avogadro::QtPlugins::ImportCrystalDialog</class>
+ <widget class="QDialog" name="Avogadro::QtPlugins::ImportCrystalDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import Crystal</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>File extension for Open Babel conversion (default - Avogadro::POSCAR):</string>
+     </property>
+     <property name="buddy">
+      <cstring>edit_extension</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="edit_extension"/>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTextEdit" name="edit_text"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Avogadro::QtPlugins::ImportCrystalDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Avogadro::QtPlugins::ImportCrystalDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -4,6 +4,7 @@ set(tests
   Cml
   FileFormatManager
   Mdl
+  Poscar
   Xyz
   )
 

--- a/tests/io/poscartest.cpp
+++ b/tests/io/poscartest.cpp
@@ -1,0 +1,134 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "iotests.h"
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/atom.h>
+#include <avogadro/core/matrix.h>
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/unitcell.h>
+#include <avogadro/core/vector.h>
+
+#include <avogadro/io/poscarformat.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using Avogadro::Core::Atom;
+using Avogadro::Core::Molecule;
+using Avogadro::Core::UnitCell;
+using Avogadro::Io::FileFormat;
+using Avogadro::Io::PoscarFormat;
+using Avogadro::Matrix3;
+using Avogadro::Vector3;
+
+TEST(PoscarTest, read)
+{
+  PoscarFormat poscar;
+  Molecule molecule;
+  EXPECT_TRUE(poscar.readFile(AVOGADRO_DATA "/data/rutile.POSCAR", molecule));
+  ASSERT_EQ(poscar.error(), std::string());
+
+  // First, let's check the unit cell
+  UnitCell *uc = molecule.unitCell();
+
+  EXPECT_EQ(uc->aVector(), Vector3(2.95812000,0.00000000,0.00000000));
+  EXPECT_EQ(uc->bVector(), Vector3(0.00000000,4.59373000,0.00000000));
+  EXPECT_EQ(uc->cVector(), Vector3(0.00000000,0.00000000,4.59373000));
+
+  // Check that the number of atoms and number of bonds were read correctly
+  EXPECT_EQ(molecule.atomCount(), 6);
+  EXPECT_EQ(molecule.bondCount(), 0);
+
+  // Check that the symbols were read correctly
+  EXPECT_EQ(molecule.atom(0).atomicNumber(), 8);
+  EXPECT_EQ(molecule.atom(1).atomicNumber(), 8);
+  EXPECT_EQ(molecule.atom(2).atomicNumber(), 8);
+  EXPECT_EQ(molecule.atom(3).atomicNumber(), 8);
+  EXPECT_EQ(molecule.atom(4).atomicNumber(), 22);
+  EXPECT_EQ(molecule.atom(5).atomicNumber(), 22);
+
+  // Check a couple of positions to make sure they were read correctly
+  // Need to convert to Fractional
+  Vector3 pos1 = uc->toFractional(molecule.atom(1).position3d());
+  Vector3 pos5 = uc->toFractional(molecule.atom(5).position3d());
+  EXPECT_DOUBLE_EQ(pos1.x(), 0.0);
+  EXPECT_DOUBLE_EQ(pos1.y(), 0.6947);
+  EXPECT_DOUBLE_EQ(pos1.z(), 0.6947);
+  EXPECT_DOUBLE_EQ(pos5.x(), 0.5);
+  EXPECT_DOUBLE_EQ(pos5.y(), 0.5);
+  EXPECT_DOUBLE_EQ(pos5.z(), 0.5);
+}
+
+TEST(PoscarTest, write)
+{
+  PoscarFormat poscar;
+  Molecule molecule;
+
+  molecule.setData("name", "TiO2 rutile");
+
+  Matrix3 mat;
+  mat.col(0) = Vector3(2.95812, 0.00000, 0.00000); // A
+  mat.col(1) = Vector3(0.00000, 4.59373, 0.00000); // B
+  mat.col(2) = Vector3(0.00000, 0.00000, 4.59373); // C
+
+  UnitCell *uc = new UnitCell(mat);
+
+  molecule.setUnitCell(uc);
+
+  molecule.addAtom(8).setPosition3d(uc->toCartesian(Vector3(0.0, 0.3053,
+                                                            0.3053)));
+  molecule.addAtom(8).setPosition3d(uc->toCartesian(Vector3(0.0, 0.6947,
+                                                            0.6947)));
+  molecule.addAtom(8).setPosition3d(uc->toCartesian(Vector3(0.5, 0.1947,
+                                                            0.8053)));
+  molecule.addAtom(8).setPosition3d(uc->toCartesian(Vector3(0.5, 0.8053,
+                                                            0.1947)));
+  molecule.addAtom(22).setPosition3d(uc->toCartesian(Vector3(0.0, 0.0, 0.0)));
+  molecule.addAtom(22).setPosition3d(uc->toCartesian(Vector3(0.5, 0.5, 0.5)));
+
+  std::string output;
+  EXPECT_TRUE(poscar.writeString(output, molecule));
+
+  // The output should be an exact match with the sample file.
+  std::istringstream outputStream(output);
+  std::ifstream refStream(AVOGADRO_DATA "/data/rutile.POSCAR");
+  char outputChar = '\0';
+  char refChar = '\0';
+  outputStream >> std::noskipws;
+  refStream >> std::noskipws;
+  bool checkedSomething = false;
+  while ((outputStream >> outputChar) && (refStream >> refChar)) {
+    ASSERT_EQ(refChar, outputChar);
+    checkedSomething = true;
+  }
+  EXPECT_TRUE(checkedSomething);
+}
+
+TEST(PoscarTest, modes)
+{
+  // This tests some of the mode setting/checking code, not explicitly Poscar but
+  // a concrete implementation is required in order to test.
+  PoscarFormat format;
+  format.open(AVOGADRO_DATA "/data/rutile.POSCAR", FileFormat::Read);
+  EXPECT_TRUE(format.isMode(FileFormat::Read));
+  EXPECT_TRUE(format.mode() & FileFormat::Read);
+  EXPECT_FALSE(format.isMode(FileFormat::Write));
+}
+


### PR DESCRIPTION
Added a POSCAR format reader and writer to the list of formats in Avogadro2.
Also added an "import crystal from clipboard" feature similar to that of
Avogadro1. It attempts to read the clipboard text using POSCAR format by
default. If a different format is to be used, the user can input that extension
and the crystal will be read for that format using obabel instead.