### PR TITLE
Fix bug preventing keypress from changing bonds or elements.

### DIFF
--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -198,14 +198,18 @@ QUndoCommand *Editor::keyPressEvent(QKeyEvent *e)
   }
 
   bool ok = false;
-  int atomicNum = m_keyPressBuffer.toInt(&ok);
-  if (!ok || atomicNum <= 0 || atomicNum > Core::Elements::elementCount()) {
+  int atomicNum;
+  int bondOrder = m_keyPressBuffer.toInt(&ok);
+
+  if (ok && bondOrder > 0 && bondOrder <= 4) {
+    m_toolWidget->setBondOrder(static_cast<unsigned char>(bondOrder));
+  } else  {
     atomicNum = Core::Elements::atomicNumberFromSymbol(
           m_keyPressBuffer.toStdString());
-  }
 
-  if (atomicNum != Avogadro::InvalidElement)
-    m_toolWidget->setAtomicNumber(static_cast<unsigned char>(atomicNum));
+    if (atomicNum != Avogadro::InvalidElement)
+      m_toolWidget->setAtomicNumber(static_cast<unsigned char>(atomicNum));
+  }
 
   return NULL;
 }

--- a/avogadro/qtplugins/editor/editortoolwidget.cpp
+++ b/avogadro/qtplugins/editor/editortoolwidget.cpp
@@ -59,7 +59,8 @@ EditorToolWidget::~EditorToolWidget()
 
 void EditorToolWidget::setAtomicNumber(unsigned char atomicNum)
 {
-  m_currentElement = atomicNum;
+  selectElement(atomicNum);
+
   if (m_elementSelector)
     m_elementSelector->setElement(static_cast<int>(atomicNum));
 }
@@ -176,6 +177,13 @@ void EditorToolWidget::selectElement(unsigned char element)
   int curIndex = element > 0 ? m_ui->element->findData(element) : -1;
   if (curIndex >= 0)
     m_ui->element->setCurrentIndex(curIndex);
+  else {
+    addUserElement(element);
+    int curIndex = m_ui->element->findData(element);
+    if (curIndex >= 0)
+      m_ui->element->setCurrentIndex(curIndex);
+    // if we can't find it after adding it, something is very wrong!
+  }
 }
 
 void EditorToolWidget::buildElements()


### PR DESCRIPTION
Now, typing 1,2,3,4 = bond order, 0 = automatic.
Typing element selects element.

Previous code would silently discard atomicnum from keypress through the tool widget.
Now, the code properly updates the selector.