### PR TITLE
Update scene radius and center to fix clipping.

### DIFF
--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -119,6 +119,7 @@ void GLRenderer::resetCamera()
 
 void GLRenderer::resetGeometry()
 {
+  m_scene.setDirty(true);
   m_center = m_scene.center();
   m_radius = m_scene.radius();
 }


### PR DESCRIPTION
The description of resetGeomtry() in GLRenderer says "Reset the
scene geometry, this should be done when the scene geometry has
changed in order to ensure correct clipping." Unfortunately,
since caching was added to the Scene class, resetGeometry() does
not appear to do anything. This is because the radius and center
from Scene are cached, and it does not get set to "dirty" when
the group node is edited. Because they are being cached, they
do not get updated with the changes in geometry, and the radius
and the center do not get changed in GLRenderer::resetGeometry().
This results in clipping when a large molecule or crystal is
constructed. This update fixes that by forcing a re-calculation
of the center and radius of the scene before setting them in
GLRenderer.