### PR TITLE
Change vector initialization to work with Clang

### DIFF
--- a/avogadro/qtplugins/crystal/importcrystaldialog.cpp
+++ b/avogadro/qtplugins/crystal/importcrystaldialog.cpp
@@ -73,7 +73,9 @@ bool ImportCrystalDialog::importCrystalClipboard(Avogadro::Core::Molecule &mol)
   else {
     // We don't need to set any of the info, so just put in empty strings for
     // most arguments (except the extension)
-    OBFileFormat ob("", "", "", "", vector<string>{ext}, vector<string>{""});
+    vector<string> fileExtensions, mimeTypes;
+    fileExtensions.push_back(ext);
+    OBFileFormat ob("", "", "", "", fileExtensions, mimeTypes);
     if (ob.read(s, mol))
       return true;
     // Print out the error messages from the read if we failed


### PR DESCRIPTION
Don't use vector<T>{list} to initialize vectors because
it doesn't work for every compiler.