### PR TITLE
Set all editing tools to use interactive edits between drags.

### DIFF
--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
@@ -400,6 +400,10 @@ QUndoCommand * BondCentricTool::mousePressEvent(QMouseEvent *e)
   if (!atomIsInBond && !atomIsNearBond)
     return NULL;
 
+  if (m_molecule) {
+    m_molecule->setInteractive(true);
+  }
+
   // If the hit is a left click on an atom in the selected bond, prepare to
   // rotate the clicked bond around the other atom in the bond.
   if (atomIsInBond && e->button() == Qt::LeftButton)
@@ -460,6 +464,10 @@ QUndoCommand * BondCentricTool::mouseReleaseEvent(QMouseEvent *)
   if (m_moveState != IgnoreMove) {
     reset(KeepBond);
     emit drawablesChanged();
+
+    if (m_molecule) {
+      m_molecule->setInteractive(false); // allow an undo now
+    }
   }
 
   return NULL;

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -109,6 +109,10 @@ QUndoCommand *Editor::mousePressEvent(QMouseEvent *e)
   updatePressedButtons(e, false);
   m_clickPosition = e->pos();
 
+  if (m_molecule) {
+    m_molecule->setInteractive(true);
+  }
+
   if (m_pressedButtons & Qt::LeftButton) {
     m_clickedObject = m_renderer->hit(e->pos().x(), e->pos().y());
 
@@ -148,6 +152,10 @@ QUndoCommand *Editor::mouseReleaseEvent(QMouseEvent *e)
     return NULL;
 
   updatePressedButtons(e, true);
+
+  if (m_molecule) {
+    m_molecule->setInteractive(false);
+  }
 
   if (m_clickedObject.type == Rendering::InvalidType)
     return NULL;

--- a/avogadro/qtplugins/manipulator/manipulator.cpp
+++ b/avogadro/qtplugins/manipulator/manipulator.cpp
@@ -73,6 +73,10 @@ QUndoCommand * Manipulator::mousePressEvent(QMouseEvent *e)
   updatePressedButtons(e, false);
   m_lastMousePosition = e->pos();
 
+  if (m_molecule) {
+    m_molecule->setInteractive(true);
+  }
+
   if (m_pressedButtons & Qt::LeftButton) {
     m_object = m_renderer->hit(e->pos().x(), e->pos().y());
 
@@ -97,6 +101,10 @@ QUndoCommand * Manipulator::mouseReleaseEvent(QMouseEvent *e)
 
   if (m_object.type == Rendering::InvalidType)
     return NULL;
+
+  if (m_molecule) {
+    m_molecule->setInteractive(false);
+  }
 
   switch (e->button()) {
   case Qt::LeftButton:


### PR DESCRIPTION
From mouse down to mouse up is one undo state.
Right now RWMolecule doesn't fully coalesce all modifications,
but we'll set the tools correctly for now.