### PR TITLE
Added undo features for all crystal operations

### DIFF
--- a/avogadro/core/crystaltools.cpp
+++ b/avogadro/core/crystaltools.cpp
@@ -672,7 +672,6 @@ bool CrystalTools::setCellMatrix(Molecule &molecule,
                                  const Matrix3 &newCellColMatrix,
                                  Options opt)
 {
-
   if (opt & TransformAtoms && molecule.unitCell()) {
     const Matrix3 xform(newCellColMatrix
                         * molecule.unitCell()->cellMatrix().inverse());

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -28,6 +28,7 @@
 #include <avogadro/core/atom.h>
 #include <avogadro/core/avogadrocore.h>
 #include <avogadro/core/bond.h>
+#include <avogadro/core/crystaltools.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/core/vector.h>
 
@@ -398,6 +399,86 @@ public:
    * index is less than the second.
    */
   bool setBondPair(Index bondId, const std::pair<Index, Index> &pair);
+
+  /**
+   * Add a default unit cell to the molecule. Does nothing if there already
+   * is a unit cell. Changes are emitted.
+   */
+  void addUnitCell();
+
+  /**
+   * Remove the unit cell from the molecule. Does nothing if there is
+   * no unit cell. Changes are emitted.
+   */
+  void removeUnitCell();
+
+  /**
+   * Generic edit that changes the current molecule to be @a newMolecule.
+   * Also sets the text for the undo command to be @a undoText. Changes are
+   * emitted.
+   * @param newMolecule The new molecule to be set.
+   * @param changes The changes to be emitted.
+   * @param undoText The text description for the undo command.
+   */
+  void modifyMolecule(const Molecule &newMolecule,
+                      Molecule::MoleculeChanges changes,
+                      const QString &undoText = "Modify Molecule");
+
+  /**
+   * Edit the unit cell by replacing the current cell matrix with a new cell
+   * matrix. Changes are emitted.
+   * @param cellMatrix The new cell matrix to be set.
+   * @param opts If TransformAtoms is specified, the atoms in @a molecule are
+   * adjusted so that their fractional (lattice) coordinates are preserved. This
+   * option is ignored if the input molecule has no unit cell.
+   */
+  void editUnitCell(Matrix3 cellMatrix, Core::CrystalTools::Options opts);
+
+  /**
+   * Wrap atoms to the unit cell. Changes are emitted.
+   */
+  void wrapAtomsToCell();
+
+  /**
+   * Rotate cell to standard orientation. Changes are emitted.
+   */
+  void rotateCellToStandardOrientation();
+
+  /**
+   * Scale a cell's volume. Changes are emitted.
+   * @param newVolume The new volume to be set.
+   * @param options If CrystalTools::TransformAtoms is set, then
+   *                the atoms will be transformed during the scaling.
+   */
+  void setCellVolume(double newVolume, Core::CrystalTools::Options options);
+
+  /**
+   * Build a supercell. Changes are emitted.
+   * @param a The final number of units along the A vector (at least 1).
+   * @param b The final number of units along the B vector (at least 1).
+   * @param c The final number of units along the C vector (at least 1).
+   */
+  void buildSupercell(unsigned int a, unsigned int b, unsigned int c);
+
+  /**
+   * Perform a Niggli reduction on the cell. Changes are emitted.
+   */
+  void niggliReduceCell();
+
+  /**
+   * Use spglib to reduce the cell to its primitive form. Changes are emitted.
+   * @param cartTol Cartesian tolerance for primitive reduction.
+   * @return True if the algorithm succeeded, and false if it failed.
+   */
+  bool reduceCellToPrimitive(double cartTol = 1e-5);
+
+  /**
+   * Use spglib to convert the cell to its conventional form. Changes are
+   * emitted.
+   * @param cartTol Cartesian tolerance for conventionalization.
+   * @return True if the algorithm succeeded, and false if it failed.
+   */
+  bool conventionalizeCell(double cartTol = 1e-5);
 
   /**
    * @brief Begin or end an interactive edit.

--- a/avogadro/qtplugins/crystal/supercelldialog.cpp
+++ b/avogadro/qtplugins/crystal/supercelldialog.cpp
@@ -20,6 +20,9 @@
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/crystaltools.h>
 
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/rwmolecule.h>
+
 using Avogadro::Core::CrystalTools;
 
 namespace Avogadro {
@@ -37,7 +40,7 @@ SupercellDialog::~SupercellDialog()
   delete m_ui;
 }
 
-bool SupercellDialog::buildSupercell(Avogadro::Core::Molecule &mol)
+bool SupercellDialog::buildSupercell(Avogadro::QtGui::Molecule &mol)
 {
   // If the user rejected, just return false
   if (this->exec() == QDialog::Rejected)
@@ -53,7 +56,8 @@ bool SupercellDialog::buildSupercell(Avogadro::Core::Molecule &mol)
     return true;
 
   // Run the supercell-building tool
-  return CrystalTools::buildSupercell(mol, a, b, c);
+  mol.undoMolecule()->buildSupercell(a, b, c);
+  return true;
 }
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/crystal/supercelldialog.h
+++ b/avogadro/qtplugins/crystal/supercelldialog.h
@@ -23,7 +23,7 @@
 
 namespace Avogadro {
 
-namespace Core {
+namespace QtGui {
 class Molecule;
 }
 
@@ -45,7 +45,7 @@ public:
   SupercellDialog(QWidget *p = 0);
   ~SupercellDialog();
 
-  bool buildSupercell(Avogadro::Core::Molecule &mol);
+  bool buildSupercell(Avogadro::QtGui::Molecule &mol);
 
   void displayInvalidFormatMessage();
 

--- a/avogadro/qtplugins/crystal/unitcelldialog.cpp
+++ b/avogadro/qtplugins/crystal/unitcelldialog.cpp
@@ -18,6 +18,7 @@
 #include "ui_unitcelldialog.h"
 
 #include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/rwmolecule.h>
 
 #include <avogadro/core/crystaltools.h>
 #include <avogadro/core/unitcell.h>
@@ -143,14 +144,9 @@ void UnitCellDialog::apply()
     break;
   default: {
     Core::CrystalTools::Options options = Core::CrystalTools::None;
-    Molecule::MoleculeChanges changes = Molecule::UnitCell | Molecule::Modified;
-    if (m_ui->transformAtoms->isChecked()) {
+    if (m_ui->transformAtoms->isChecked())
       options |= Core::CrystalTools::TransformAtoms;
-      changes |= Molecule::Atoms | Molecule::Modified;
-    }
-    Core::CrystalTools::setCellMatrix(*m_molecule, m_tempCell.cellMatrix(),
-                                      options);
-    m_molecule->emitChanged(changes);
+    m_molecule->undoMolecule()->editUnitCell(m_tempCell.cellMatrix(), options);
     break;
   }
   }

--- a/avogadro/qtplugins/spacegroup/spacegroup.cpp
+++ b/avogadro/qtplugins/spacegroup/spacegroup.cpp
@@ -22,6 +22,7 @@
 #include <avogadro/core/spacegroups.h>
 
 #include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/rwmolecule.h>
 
 #include <QtWidgets/QAction>
 #include <QtWidgets/QInputDialog>
@@ -190,7 +191,7 @@ void SpaceGroup::reduceToPrimitive()
     setTolerance();
 
   // Primitive reduction!
-  bool success = AvoSpglib::reduceToPrimitive(*m_molecule, m_spgTol);
+  bool success = m_molecule->undoMolecule()->reduceCellToPrimitive(m_spgTol);
 
   if (!success) {
     // Print an error message.
@@ -199,10 +200,6 @@ void SpaceGroup::reduceToPrimitive()
                          "Please check your crystal and try again "
                          "with a different tolerance."));
     retMsgBox.exec();
-  }
-  else {
-    m_molecule->emitChanged(Molecule::Added |
-                            Molecule::Atoms | Molecule::UnitCell);
   }
 }
 
@@ -219,7 +216,7 @@ void SpaceGroup::conventionalizeCell()
     setTolerance();
 
   // Conventionalize the cell!
-  bool success = AvoSpglib::conventionalizeCell(*m_molecule, m_spgTol);
+  bool success = m_molecule->undoMolecule()->conventionalizeCell(m_spgTol);
 
   if (!success) {
     // Print an error message.
@@ -228,10 +225,6 @@ void SpaceGroup::conventionalizeCell()
                          "Please check your crystal and try again "
                          "with a different tolerance."));
     retMsgBox.exec();
-  }
-  else {
-    m_molecule->emitChanged(Molecule::Added |
-                            Molecule::Atoms | Molecule::UnitCell);
   }
 }
 


### PR DESCRIPTION
Added undo and redo commands for all crystal operations in RWMolecule.
They are also now all called so that the undo stack gets updated with
the changes.