### PR TITLE
Added symmetrize and cleaned up avospglib.cpp

### DIFF
--- a/avogadro/core/avospglib.cpp
+++ b/avogadro/core/avospglib.cpp
@@ -83,81 +83,24 @@ unsigned short AvoSpglib::getHallNumber(const Molecule &mol, double cartTol)
   return hallNumber;
 }
 
-
 bool AvoSpglib::reduceToPrimitive(Molecule &mol, double cartTol)
 {
-  if (!mol.unitCell())
-    return false;
-
-  const UnitCell *uc = mol.unitCell();
-  Matrix3 cellMat = uc->cellMatrix();
-
-  double lattice[3][3];
-  // Spglib expects column vectors
-  for (Index i = 0; i < 3; ++i) {
-    for (Index j = 0; j < 3; ++j) {
-      lattice[i][j] = cellMat(i,j);
-    }
-  }
-
-  Index numAtoms = mol.atomCount();
-  double (*positions)[3] = new double[numAtoms][3];
-  int *types = new int[numAtoms];
-
-  const Array<unsigned char> &atomicNums = mol.atomicNumbers();
-  const Array<Vector3> &pos = mol.atomPositions3d();
-
-  // Positions need to be in fractional coordinates
-  for (Index i = 0; i < numAtoms; ++i) {
-    Vector3 fracCoords = uc->toFractional(pos[i]);
-    positions[i][0] = fracCoords[0];
-    positions[i][1] = fracCoords[1];
-    positions[i][2] = fracCoords[2];
-    types[i] = atomicNums[i];
-  }
-
-  // Run the spglib algorithm
-  Index newNumAtoms = spg_find_primitive(lattice, positions, types,
-                                         numAtoms, cartTol);
-
-  // If 0 is returned, the algorithm failed.
-  if (newNumAtoms == 0) {
-    delete [] positions;
-    delete [] types;
-    return false;
-  }
-
-  // Let's create a new molecule with the primitive information
-  Molecule newMol;
-
-  // First, we will make the unit cell
-  Matrix3 newCellMat;
-  for (Index i = 0; i < 3; ++i) {
-    for (Index j = 0; j < 3; ++j) {
-      newCellMat(i,j) = lattice[i][j];
-    }
-  }
-  UnitCell *newCell = new UnitCell(newCellMat);
-  newMol.setUnitCell(newCell);
-
-  // Next, add in the atoms
-  for (Index i = 0; i < newNumAtoms; ++i) {
-    Atom newAtom = newMol.addAtom(types[i]);
-    Vector3 newAtomPos(positions[i][0], positions[i][1], positions[i][2]);
-    // We must convert it back to cartesian before adding it
-    newAtom.setPosition3d(newCell->toCartesian(newAtomPos));
-  }
-
-  delete [] positions;
-  delete [] types;
-
-  // Set the new molecule
-  mol = newMol;
-  return true;
+  return standardizeCell(mol, cartTol, true, false);
 }
 
 bool AvoSpglib::conventionalizeCell(Molecule &mol, double cartTol)
 {
+  return standardizeCell(mol, cartTol, false, true);
+}
+
+bool AvoSpglib::symmetrize(Molecule &mol, double cartTol)
+{
+  return standardizeCell(mol, cartTol, true, true);
+}
+
+bool AvoSpglib::standardizeCell(Molecule &mol, double cartTol,
+                                bool toPrimitive, bool idealize)
+{
   if (!mol.unitCell())
     return false;
 
@@ -173,12 +116,14 @@ bool AvoSpglib::conventionalizeCell(Molecule &mol, double cartTol)
   }
 
   Index numAtoms = mol.atomCount();
-  // spg_refine_cell() can cause the number of atoms to increase by
-  // as much as 4x. So, we must make these arrays at least 4x the number of
-  // atoms.
-  // See http://atztogo.github.io/spglib/api.html#spg-refine-cell
-  double (*positions)[3] = new double[numAtoms * 4][3];
-  int *types = new int[numAtoms * 4];
+  // spg_standardize_cell() can cause the number of atoms to increase by
+  // as much as 4x if toPrimitive is false.
+  // So, we must make these arrays at least 4x the number of atoms.
+  // If toPrimitive is true, then we will just use the number of atoms.
+  // See http://atztogo.github.io/spglib/api.html#spg-standardize-cell
+  int numAtomsMultiplier = toPrimitive ? 1 : 4;
+  double (*positions)[3] = new double[numAtoms * numAtomsMultiplier][3];
+  int *types = new int[numAtoms * numAtomsMultiplier];
 
   const Array<unsigned char> &atomicNums = mol.atomicNumbers();
   const Array<Vector3> &pos = mol.atomPositions3d();
@@ -193,8 +138,9 @@ bool AvoSpglib::conventionalizeCell(Molecule &mol, double cartTol)
   }
 
   // Run the spglib algorithm
-  Index newNumAtoms = spg_refine_cell(lattice, positions, types,
-                                      numAtoms, cartTol);
+  Index newNumAtoms = spg_standardize_cell(lattice, positions, types,
+                                           numAtoms, toPrimitive, !idealize,
+                                           cartTol);
 
   // If 0 is returned, the algorithm failed.
   if (newNumAtoms == 0) {
@@ -203,7 +149,7 @@ bool AvoSpglib::conventionalizeCell(Molecule &mol, double cartTol)
     return false;
   }
 
-  // Let's create a new molecule with the conventional information
+  // Let's create a new molecule with the information
   Molecule newMol;
 
   // First, we will make the unit cell

--- a/avogadro/core/avospglib.h
+++ b/avogadro/core/avospglib.h
@@ -46,7 +46,8 @@ public:
 
   /**
    * Use spglib to reduce the crystal to a primitive cell. Unless the molecule
-   * is missing its unit cell, it will be edited by spglib.
+   * is missing its unit cell, it will be edited by spglib. Positions are
+   * not idealized.
    *
    * @param mol The molecule to be reduced to its primitive cell.
    * @param cartTol The cartesian tolerance for spglib.
@@ -57,7 +58,8 @@ public:
 
   /**
    * Use spglib to refine the crystal to its conventional cell. Unless the
-   * molecule is missing its unit cell, it will be edited by spglib.
+   * molecule is missing its unit cell, it will be edited by spglib. Positions
+   * are idealized.
    *
    * @param mol The molecule to be conventionalized.
    * @param cartTol The cartesian tolerance for spglib.
@@ -66,6 +68,23 @@ public:
    */
   static bool conventionalizeCell(Molecule &mol, double cartTol = 1e-5);
 
+  /**
+   * Use spglib to symmetrize the crystal. Unless the molecule is missing
+   * its unit cell, it will be edited by spglib. It will be reduced
+   * to its primitive form, and positions will be idealized.
+   *
+   * @param mol The molecule to be conventionalized.
+   * @param cartTol The cartesian tolerance for spglib.
+   * @return False if the molecule has no unit cell or if the
+   *         spglib algorithm failed. True otherwise.
+   */
+  static bool symmetrize(Molecule &mol, double cartTol = 1e-5);
+
+private:
+  // Called by reduceToPrimitive(), conventionalizeCell(), and symmetrize()
+  // Calls spg_standardize_cell()
+  static bool standardizeCell(Molecule &mol, double cartTol,
+                              bool toPrimitive, bool idealize);
 };
 
 } // end Core namespace

--- a/avogadro/qtplugins/spacegroup/spacegroup.h
+++ b/avogadro/qtplugins/spacegroup/spacegroup.h
@@ -48,6 +48,7 @@ private slots:
   void perceiveSpaceGroup();
   void reduceToPrimitive();
   void conventionalizeCell();
+  void symmetrize();
   void setTolerance();
 
 private:
@@ -58,6 +59,7 @@ private:
   QAction *m_perceiveSpaceGroupAction;
   QAction *m_reduceToPrimitiveAction;
   QAction *m_conventionalizeCellAction;
+  QAction *m_symmetrizeAction;
   QAction *m_setToleranceAction;
 };
 


### PR DESCRIPTION
In avospglib: the spg_find_primitive() and spg_refine_cell() were
just wrappers for spg_standardize_cell(). So I combined them and
added a private function, standardizeCell(), to reduce the
amount of code and emphasize the differences between them. Now,
reduceToPrimitive() no longer idealizes atom positions. symmetrize()
is a new function that was added that reduces the atoms to their
primitive form AND idealizes the atom positions.
conventionalizeCell(), like before, just idealizes the positions
without reducing to primitive.