### PR TITLE
Added adjustHydrogens to RWMolecule

### DIFF
--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -93,6 +93,14 @@ public:
   AtomType addAtom(unsigned char atomicNumber);
 
   /**
+   * Add a new atom to the molecule and set its position.
+   * @param atomicNumber The atomic number of the new atom.
+   * @param position3d The position of the atom.
+   * @return The new Atom object.
+   */
+  AtomType addAtom(unsigned char atomicNumber, const Vector3 &position3d);
+
+  /**
    * Obtain an atom object.
    * @param atomId The index of the atom to return.
    * @return The requested atom object. Will be invalid if @a atomId >= @a
@@ -142,6 +150,21 @@ public:
    * @note This also removes all bonds.
    */
   void clearAtoms();
+
+  /**
+   * Adjust hydrogens for an atom.
+   * @param atomId The index of the atom.
+   * @note Checks to make sure the atom is valid before adjusting the hydrogens.
+   */
+  void adjustHydrogens(Index atomId);
+
+  /**
+   * Adjust hydrogens for multiple atoms.
+   * @param atomIds The indices for the atoms.
+   * @note Checks to make sure the atoms are valid before adjusting the
+   * hydrogens.
+   */
+  void adjustHydrogens(const Core::Array<Index>& atomIds);
 
   /**
    * @return An array containing atomic numbers for all atoms in the molecule,

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -275,18 +275,14 @@ void Editor::reset()
     if (a2 > a3)
       std::swap(a2, a3);
 
-    RWAtom atom = m_molecule->atom(a3);
-    if (atom.isValid()) {
-      QtGui::HydrogenTools::adjustHydrogens(atom);
-    }
-    atom = m_molecule->atom(a2);
-    if (atom.isValid()) {
-      QtGui::HydrogenTools::adjustHydrogens(atom);
-    }
-    atom = m_molecule->atom(a1);
-    if (atom.isValid()) {
-      QtGui::HydrogenTools::adjustHydrogens(atom);
-    }
+    // This preserves the order so they are adjusted in order.
+    Core::Array<Index> atomIds;
+    atomIds.push_back(a3);
+    atomIds.push_back(a2);
+    atomIds.push_back(a1);
+    // This function checks to make sure the ids are valid, so no need
+    // to check out here.
+    m_molecule->adjustHydrogens(atomIds);
 
     Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Added;
     changes |= Molecule::Bonds | Molecule::Added | Molecule::Removed;
@@ -313,8 +309,8 @@ void Editor::emptyLeftClick(QMouseEvent *e)
   // Add an atom at the clicked position
   Vector2f windowPos(e->localPos().x(), e->localPos().y());
   Vector3f atomPos = m_renderer->camera().unProject(windowPos);
-  RWAtom newAtom = m_molecule->addAtom(m_toolWidget->atomicNumber());
-  newAtom.setPosition3d(atomPos.cast<double>());
+  RWAtom newAtom = m_molecule->addAtom(m_toolWidget->atomicNumber(),
+                                       atomPos.cast<double>());
 
   Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Modified;
 


### PR DESCRIPTION
Added adjustHydrogens to RWMolecule as an undo command.
Also added adjustHydrogens for multiple atoms as a single
undo command. In addition, added a new addAtom() that combines
adding the atoms and setting its position into one command. This
reduces the number of undo commands that appear while drawing. More
still needs to be done to reduce the number of undo commads further,
but I believe this is a good start.