### PR TITLE
Adjust hydrogens after releasing left click

### DIFF
--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -341,11 +341,8 @@ void Editor::atomLeftClick(QMouseEvent *e)
 
       Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Modified;
 
-      if (m_toolWidget->adjustHydrogens()) {
-        QtGui::HydrogenTools::adjustHydrogens(atom);
-
-        changes |= Molecule::Added | Molecule::Removed;
-      }
+      if (m_toolWidget->adjustHydrogens())
+        m_fixValenceLater = true;
 
       m_molecule->emitChanged(changes);
     }


### PR DESCRIPTION
The code is currently set up to adjust hydrogens
upon left clicking an atom. If we drag away from the
atom, and then release, it has to adjust hydrogens
again. So I think it is better to just adjust hydrogens
upon releasing left click rather than on left click. This
is how it was in Avogadro1.