### PR TITLE
Cclib format script

### DIFF
--- a/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
+++ b/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(ScriptFileFormats LINK_PRIVATE AvogadroQuantumIO)
 # Bundled format scripts:
 set(format_scripts
   formatScripts/zyx.py
+  formatScripts/cclibScript.py
 )
 
 install(PROGRAMS ${format_scripts}

--- a/avogadro/qtplugins/scriptfileformats/formatScripts/cclibScript.py
+++ b/avogadro/qtplugins/scriptfileformats/formatScripts/cclibScript.py
@@ -1,7 +1,17 @@
 """
 /******************************************************************************
 
-    License information
+  This source file is part of the Avogadro project.
+
+  Copyright 2016 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
 ******************************************************************************/
 """

--- a/avogadro/qtplugins/scriptfileformats/formatScripts/cclibScript.py
+++ b/avogadro/qtplugins/scriptfileformats/formatScripts/cclibScript.py
@@ -1,0 +1,53 @@
+"""
+/******************************************************************************
+
+    License information
+
+******************************************************************************/
+"""
+import argparse
+import json
+import sys
+
+from cclib.io.ccio import ccopen
+from cclib.io.cjsonwriter import CJSON
+
+
+def getMetaData():
+  metaData = {}
+  metaData['inputFormat'] = 'cjson'
+  metaData['outputFormat'] = 'cjson'
+  metaData['operations'] = ['read']
+  metaData['identifier'] = 'CJSON writer'
+  metaData['name'] = 'CJSON Format'
+  metaData['description'] = "The cclib script provided by the cclib repository is used to " +\
+                            "write the CJSON format using the input file provided " +\
+                            "to Avogadro2."
+  metaData['fileExtensions'] = ['out', 'log', 'adfout', 'g09']
+  metaData['mimeTypes'] = ['To be filled']
+  return metaData
+
+def read():
+  # Pass the standard input to ccopen:
+  log = ccopen(sys.stdin)
+  ccdata = log.parse()
+
+  output_obj = CJSON(ccdata, terse=True)
+  output = output_obj.generate_repr()
+
+  return output
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser('Testing file format script.')
+  parser.add_argument('--metadata', action='store_true')
+  parser.add_argument('--read', action='store_true')
+  parser.add_argument('--write', action='store_true')
+  args = vars(parser.parse_args())
+
+  if args['metadata']:
+    print(json.dumps(getMetaData()))
+  elif args['read']:
+    print(read())
+  elif args['write']:
+    pass


### PR DESCRIPTION
The cclib integration script created as a ScriptFileFormat which calls the cclib library from the python path. Presently, for the script to work cclib needs to be installed on the host PC.

Usage:
The cclib script is programmed to be available as a reader to any .out, .log,. adfout, .g09 output file. The script generates a standardized cjson file which is parsed internally by avogadro.

To Do: Incorporate the cclib package in the Avogadro superbuild.
