### PR TITLE
Fixed a bug when redo-ing Add Atom with no atoms

### DIFF
--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -88,9 +88,12 @@ public:
   /**
    * Add a new atom to the molecule.
    * @param atomicNumber The atomic number of the new atom.
+   * @param usingPositions Whether or not to use positions for this atom.
+   *                       Default is true. Set to false if the atom
+   *                       will not be using coordinates.
    * @return The new Atom object.
    */
-  AtomType addAtom(unsigned char atomicNumber);
+  AtomType addAtom(unsigned char atomicNumber, bool usingPositions = true);
 
   /**
    * Add a new atom to the molecule and set its position.


### PR DESCRIPTION
Before this fix: if a user had no atoms and tried to perform
a redo, addAtom() in RWMolecule would not add the atom correctly.
I added a boolean to AddAtomCommand to check and see if we are
using positions for the atom or not; it is set to true by default.
If we are not using positions (perhaps with something like SMILES),
it may be set to false as a second parameter for addAtom().

This boolean is basically what the "if (!positions.empty())"
statement was checking for - only it does it better because
the positions are unfortunately empty if there are presently
no atoms in the molecule.

There may be a better way to fix this, but this does work.
