### PR TITLE
Modernize/simplify the Qt5 find calls

### DIFF
--- a/avogadro/molequeue/CMakeLists.txt
+++ b/avogadro/molequeue/CMakeLists.txt
@@ -7,8 +7,7 @@ find_package(Eigen3 REQUIRED)
 # compilers that support that notion.
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Network REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 set(HEADERS
   batchjob.h

--- a/avogadro/qtgui/CMakeLists.txt
+++ b/avogadro/qtgui/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Eigen3 REQUIRED)
 # compilers that support that notion.
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
-find_package(Qt5Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 # Provide some simple API to find the plugins, scripts, etc.
 if(APPLE)

--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -1,10 +1,7 @@
 find_package(Eigen3 REQUIRED)
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5OpenGL REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
+find_package(Qt5 COMPONENTS Widgets OpenGL Network Concurrent REQUIRED)
 include_directories(SYSTEM ${Qt5Widgets_INCLUDE_DIRS})
 add_definitions(${Qt5Widgets_DEFINITIONS})
 

--- a/avogadro/qtplugins/manipulator/CMakeLists.txt
+++ b/avogadro/qtplugins/manipulator/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(Qt5OpenGL REQUIRED)
-include_directories(SYSTEM ${Qt5OpenGL_INCLUDE_DIRS})
-
 set(manipulator_srcs
   manipulator.cpp
 )

--- a/avogadro/qtplugins/measuretool/CMakeLists.txt
+++ b/avogadro/qtplugins/measuretool/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(Qt5OpenGL REQUIRED)
-include_directories(SYSTEM ${Qt5OpenGL_INCLUDE_DIRS})
-
 set(measuretool_srcs
   measuretool.cpp
 )

--- a/avogadro/qtplugins/networkdatabases/CMakeLists.txt
+++ b/avogadro/qtplugins/networkdatabases/CMakeLists.txt
@@ -1,7 +1,3 @@
-find_package(Qt5Network REQUIRED)
-include_directories(SYSTEM ${Qt5Network_INCLUDE_DIRS})
-add_definitions(${Qt5Network_DEFINITIONS})
-
 set(srcs
   networkdatabases.cpp
 )

--- a/avogadro/qtplugins/qtaim/CMakeLists.txt
+++ b/avogadro/qtplugins/qtaim/CMakeLists.txt
@@ -1,7 +1,3 @@
-find_package(Qt5Concurrent REQUIRED)
-include_directories(SYSTEM ${Qt5Concurrent_INCLUDE_DIRS})
-add_definitions(${Qt5Concurrent_DEFINITIONS})
-
 set(qtaimextension_SRCS
     qtaimextension.cpp
     qtaimwavefunction.cpp

--- a/avogadro/qtplugins/quantumoutput/CMakeLists.txt
+++ b/avogadro/qtplugins/quantumoutput/CMakeLists.txt
@@ -1,7 +1,3 @@
-find_package(Qt5Concurrent REQUIRED)
-include_directories(SYSTEM ${Qt5Concurrent_INCLUDE_DIRS})
-add_definitions(${Qt5Concurrent_DEFINITIONS})
-
 set(quantumoutput_srcs
   gaussiansetconcurrent.cpp
   slatersetconcurrent.cpp

--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -9,7 +9,7 @@ if(WIN32 AND NOT BUILD_SHARED_LIBS)
   add_definitions(-DGLEW_STATIC)
 endif()
 
-find_package(Qt5OpenGL REQUIRED)
+find_package(Qt5 COMPONENTS OpenGL REQUIRED)
 
 find_package(VTK
   COMPONENTS

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -3,9 +3,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}"
   "${AvogadroLibs_BINARY_DIR}/avogadro/molequeue"
   "${AvogadroLibs_SOURCE_DIR}/tests/core")
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Test REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Network Test REQUIRED)
 
 # Pull in MoleQueue for QtJson
 find_package(MoleQueue REQUIRED NO_MODULE)

--- a/tests/qtopengl/CMakeLists.txt
+++ b/tests/qtopengl/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories("${AvogadroLibs_BINARY_DIR}/avogadro/qtgui"
 find_package(OpenGL REQUIRED)
 include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
 
-find_package(Qt5OpenGL REQUIRED)
+find_package(Qt5 COMPONENTS OpenGL REQUIRED)
 include_directories(SYSTEM ${Qt5OpenGL_INCLUDE_DIRS})
 add_definitions(${Qt5OpenGL_DEFINITIONS})
 


### PR DESCRIPTION
This makes it possible to just use Qt5_DIR, and is the recommended way
of finding Qt5.