### PR TITLE
Initialize member in copy constructor

### DIFF
--- a/avogadro/qtgui/molecule.cpp
+++ b/avogadro/qtgui/molecule.cpp
@@ -28,8 +28,11 @@ Molecule::Molecule(QObject *parent_)
 }
 
 Molecule::Molecule(const Molecule &other)
-  : QObject(), Core::Molecule(other)
+  : QObject()
+  , Core::Molecule(other)
+  , m_undoMolecule(new RWMolecule(*this, this))
 {
+  m_undoMolecule->setInteractive(true);
   // Now assign the unique ids
   for (Index i = 0; i < atomCount(); i++)
     m_atomUniqueIds.push_back(i);


### PR DESCRIPTION
When loading a Core::Molecule and using the copy constructor to convert
it to a Gui::Molecule for using it within the Editor plugin, a non-
initialized m_undoMolecule leads to a crash.
