### PR TITLE
Don't need the complete name for spglib

### DIFF
--- a/cmake/FindSpglib.cmake
+++ b/cmake/FindSpglib.cmake
@@ -7,7 +7,7 @@
 #  SPGLIB_LIBRARY      - The Spglib library
 #
 find_path(SPGLIB_INCLUDE_DIR spglib/spglib.h)
-find_library(SPGLIB_LIBRARY NAMES libspglib.a)
+find_library(SPGLIB_LIBRARY NAMES spglib)
 
 set(SPGLIB_INCLUDE_DIRS "${SPGLIB_INCLUDE_DIR}")
 


### PR DESCRIPTION
The find_library call will prepend lib on Unix systems, and the
appropriate ending (.a/.so on Linux, .a/.dylib on Mac, and .lib/.dll on
Windows platforms). This was not working on Windows as the library
generated is called spglib.lib there.