### PR TITLE
Use the full path for the QtConcurrent components

### DIFF
--- a/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
@@ -24,7 +24,7 @@
 
 #include <QList>
 
-#include <QtConcurrentMap>
+#include <QtConcurrent/QtConcurrentMap>
 
 #include <QTemporaryFile>
 #include <QFile>

--- a/avogadro/qtplugins/qtaim/qtaimcubature.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimcubature.cpp
@@ -61,7 +61,7 @@
 #include <QVector3D>
 
 #include <QList>
-#include <QtConcurrentMap>
+#include <QtConcurrent/QtConcurrentMap>
 #include <QTemporaryFile>
 #include <QFile>
 #include <QDataStream>


### PR DESCRIPTION
This should be done for all of them, but these were causing include issues

Change-Id: I8750b98dd263c2f3a52912294253eb28a5180a78