### PR TITLE
Add priority IDs for tools, allowing the UI to sort consitently.

### DIFF
--- a/avogadro/qtgui/toolplugin.h
+++ b/avogadro/qtgui/toolplugin.h
@@ -66,6 +66,11 @@ public:
   virtual QString description() const = 0;
 
   /**
+   * A priority of the tool for sorting in the user interface.
+   */
+  virtual unsigned char priority() const = 0;
+
+  /**
    * @return The QAction that will cause this tool to become active.
    */
   virtual QAction * activateAction() const = 0;

--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
@@ -64,7 +64,7 @@ public:
 
   QString name() const AVO_OVERRIDE;
   QString description() const AVO_OVERRIDE;
-  unsigned char priority() const { return 4; }
+  unsigned char priority() const AVO_OVERRIDE { return 4; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
@@ -64,6 +64,7 @@ public:
 
   QString name() const AVO_OVERRIDE;
   QString description() const AVO_OVERRIDE;
+  unsigned char priority() const { return 4; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/editor/editor.h
+++ b/avogadro/qtplugins/editor/editor.h
@@ -44,7 +44,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Editor tool"); }
   QString description() const AVO_OVERRIDE { return tr("Editor tool"); }
-  unsigned char priority() const { return 2; }
+  unsigned char priority() const AVO_OVERRIDE { return 2; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/editor/editor.h
+++ b/avogadro/qtplugins/editor/editor.h
@@ -44,6 +44,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Editor tool"); }
   QString description() const AVO_OVERRIDE { return tr("Editor tool"); }
+  unsigned char priority() const { return 2; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -42,7 +42,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Manipulate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Manipulate tool"); }
-  unsigned char priority() const { return 3; }
+  unsigned char priority() const AVO_OVERRIDE { return 3; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -42,6 +42,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Manipulate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Manipulate tool"); }
+  unsigned char priority() const { return 3; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -47,7 +47,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Measure tool"); }
   QString description() const AVO_OVERRIDE { return tr("Measure tool"); }
-  unsigned char priority() const { return 6; }
+  unsigned char priority() const AVO_OVERRIDE { return 6; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -47,6 +47,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Measure tool"); }
   QString description() const AVO_OVERRIDE { return tr("Measure tool"); }
+  unsigned char priority() const { return 6; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -41,6 +41,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Navigate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Navigate tool"); }
+  unsigned char priority() const { return 1; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -41,7 +41,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Navigate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Navigate tool"); }
-  unsigned char priority() const { return 1; }
+  unsigned char priority() const AVO_OVERRIDE { return 1; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/playertool/playertool.h
+++ b/avogadro/qtplugins/playertool/playertool.h
@@ -43,7 +43,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Player tool"); }
   QString description() const AVO_OVERRIDE { return tr("Play back trajectories"); }
-  unsigned char priority() const { return 8; }
+  unsigned char priority() const AVO_OVERRIDE { return 8; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/playertool/playertool.h
+++ b/avogadro/qtplugins/playertool/playertool.h
@@ -43,6 +43,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Player tool"); }
   QString description() const AVO_OVERRIDE { return tr("Play back trajectories"); }
+  unsigned char priority() const { return 8; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 


### PR DESCRIPTION
- Navigate (tool 1)
- Draw (tool 2) - becomes active in new document
- Manipulate (tool 3)
- Bond Manipulate (tool 4)
- Select (tool 5)
- Measure (tool 6)
- Align (tool 7)
- Player (tool 8)