### PR TITLE
Multiply tool priorities by 10.

### DIFF
--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
@@ -64,7 +64,7 @@ public:
 
   QString name() const AVO_OVERRIDE;
   QString description() const AVO_OVERRIDE;
-  unsigned char priority() const AVO_OVERRIDE { return 4; }
+  unsigned char priority() const AVO_OVERRIDE { return 40; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/editor/editor.h
+++ b/avogadro/qtplugins/editor/editor.h
@@ -44,7 +44,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Editor tool"); }
   QString description() const AVO_OVERRIDE { return tr("Editor tool"); }
-  unsigned char priority() const AVO_OVERRIDE { return 2; }
+  unsigned char priority() const AVO_OVERRIDE { return 20; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -42,7 +42,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Manipulate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Manipulate tool"); }
-  unsigned char priority() const AVO_OVERRIDE { return 3; }
+  unsigned char priority() const AVO_OVERRIDE { return 30; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -47,7 +47,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Measure tool"); }
   QString description() const AVO_OVERRIDE { return tr("Measure tool"); }
-  unsigned char priority() const AVO_OVERRIDE { return 6; }
+  unsigned char priority() const AVO_OVERRIDE { return 60; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -41,7 +41,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Navigate tool"); }
   QString description() const AVO_OVERRIDE { return tr("Navigate tool"); }
-  unsigned char priority() const AVO_OVERRIDE { return 1; }
+  unsigned char priority() const AVO_OVERRIDE { return 10; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -89,12 +89,13 @@ QWidget * PlayerTool::toolWidget() const
     m_animationFPS->setValue(5);
     m_animationFPS->setMinimum(0);
     m_animationFPS->setMaximum(100);
+    m_animationFPS->setSuffix(tr(" FPS", "frames per second"));
     frames->addWidget(m_animationFPS);
     layout->addLayout(frames);
 
     QHBoxLayout *bonding = new QHBoxLayout;
     bonding->addStretch(1);
-    m_dynamicBonding = new QCheckBox("Dynamic bonding?");
+    m_dynamicBonding = new QCheckBox(tr("Dynamic bonding?"));
     m_dynamicBonding->setChecked(true);
     bonding->addWidget(m_dynamicBonding);
     bonding->addStretch(1);

--- a/avogadro/qtplugins/playertool/playertool.h
+++ b/avogadro/qtplugins/playertool/playertool.h
@@ -43,7 +43,7 @@ public:
 
   QString name() const AVO_OVERRIDE { return tr("Player tool"); }
   QString description() const AVO_OVERRIDE { return tr("Play back trajectories"); }
-  unsigned char priority() const AVO_OVERRIDE { return 8; }
+  unsigned char priority() const AVO_OVERRIDE { return 80; }
   QAction * activateAction() const AVO_OVERRIDE { return m_activateAction; }
   QWidget * toolWidget() const AVO_OVERRIDE;
 


### PR DESCRIPTION
This conserves the current sorting order, but makes it easy to
insert new tools in between the existing ones.