### PR TITLE
WIP: Enable POV-Ray export command. Only writes to std::cout

### DIFF
--- a/avogadro/qtplugins/povray/povray.cpp
+++ b/avogadro/qtplugins/povray/povray.cpp
@@ -37,7 +37,7 @@ namespace QtPlugins {
 POVRay::POVRay(QObject *p) :
   Avogadro::QtGui::ExtensionPlugin(p),
   m_molecule(NULL), m_scene(NULL), m_camera(NULL),
-  m_action(new QAction(tr("Render with POV-Ray"), this))
+  m_action(new QAction(tr("POV-Ray Render"), this))
 {
   connect(m_action, SIGNAL(triggered()), SLOT(render()));
 }
@@ -49,12 +49,12 @@ POVRay::~POVRay()
 QList<QAction *> POVRay::actions() const
 {
   QList<QAction *> result;
-  return result;// << m_action;
+  return result << m_action;
 }
 
 QStringList POVRay::menuPath(QAction *) const
 {
-  return QStringList() << tr("&File");
+  return QStringList() << tr("&File") << tr("&Export");
 }
 
 void POVRay::setMolecule(QtGui::Molecule *mol)
@@ -76,6 +76,8 @@ void POVRay::render()
 {
   if (!m_scene || !m_camera)
     return;
+
+  // TODO: Needs to save to a file!
 
   Rendering::POVRayVisitor visitor(*m_camera);
   visitor.begin();


### PR DESCRIPTION
At a minimum, this needs to pop up a save dialog and write to a POV-Ray file.

I'd like to see the POV-Ray visitor class move from rendering/ to the extension (e.g., so an SVG or VRML variant can use the code as a template).

It's also not clear how complete the POV-Ray visitor class is.