### PR TITLE
Fix minor issue with GCC 6

### DIFF
--- a/cmake/GenerateExportHeader.cmake
+++ b/cmake/GenerateExportHeader.cmake
@@ -164,7 +164,7 @@ macro(_test_compiler_hidden_visibility)
   if(CMAKE_COMPILER_IS_GNUCXX)
     exec_program(${CMAKE_C_COMPILER} ARGS --version
       OUTPUT_VARIABLE _gcc_version_info)
-    string(REGEX MATCH "[345]\\.[0-9]\\.[0-9]"
+    string(REGEX MATCH "[3456]\\.[0-9]\\.[0-9]"
       _gcc_version "${_gcc_version_info}")
     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
     # patch level, handle this here:


### PR DESCRIPTION
I compiled avogadro today with GCC 6. Built just fine, minus the regex match below.