### PR TITLE
Automatically select all appended atoms

### DIFF
--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -1096,6 +1096,7 @@ void RWMolecule::appendMolecule(const Molecule &mol,
   for(size_t i = 0; i < mol.atomCount(); ++i) {
     Core::Atom atom = mol.atom(i);
     addAtom(atom.atomicNumber(), atom.position3d());
+    setAtomSelected(atomCount() - 1, true);
   }
   // now loop through and add the bonds
   for(size_t i = 0; i < mol.bondCount(); ++i) {

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -194,6 +194,7 @@ void CopyPaste::paste()
 
   // insert mol into m_molecule
   m_molecule->undoMolecule()->appendMolecule(mol, "Paste Molecule");
+  emit requestActiveTool("Manipulator");
 
   delete m_pastedFormat;
   m_pastedFormat = NULL;


### PR DESCRIPTION
This ensures that a paste or insert will always select new atoms.