### PR TITLE
Add copy and exit buttons with keybindings to 3DMol interface

### DIFF
--- a/avogadro/qtplugins/3dmol/3dmoldialog.cpp
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.cpp
@@ -23,7 +23,6 @@
 #include <avogadro/io/fileformatmanager.h>
 
 #include <string>
-#include <QtGui/QClipboard>
 
 using Avogadro::QtGui::Molecule;
 

--- a/avogadro/qtplugins/3dmol/3dmoldialog.cpp
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.cpp
@@ -23,7 +23,7 @@
 #include <avogadro/io/fileformatmanager.h>
 
 #include <string>
-#include <QtDebug>
+#include <QtGui/QClipboard>
 
 using Avogadro::QtGui::Molecule;
 
@@ -59,6 +59,9 @@ void ThreeDMolDialog::setMolecule(QtGui::Molecule *mol)
 
   connect(m_molecule, SIGNAL(changed(unsigned int)), SLOT(updateLabels()));
   connect(m_molecule, SIGNAL(destroyed()), SLOT(moleculeDestroyed()));
+  connect(m_ui->exitButton, SIGNAL(clicked()), SLOT(close()));
+  connect(m_ui->copyButton, SIGNAL(clicked()), SLOT(copyToClipboard()));
+
   updateLabels();
 }
 
@@ -111,6 +114,11 @@ void ThreeDMolDialog::moleculeDestroyed()
 {
   m_molecule = nullptr;
   updateLabels();
+}
+
+void ThreeDMolDialog::copyToClipboard()
+{
+  QApplication::clipboard()->setText(m_ui->plainTextEdit->toPlainText()); 
 }
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/3dmol/3dmoldialog.cpp
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.cpp
@@ -24,6 +24,8 @@
 
 #include <string>
 
+#include <QtGui/QClipboard>
+
 using Avogadro::QtGui::Molecule;
 
 namespace Avogadro {

--- a/avogadro/qtplugins/3dmol/3dmoldialog.h
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.h
@@ -18,7 +18,6 @@
 #define AVOGADRO_QTGUI_ThreeDMOLDIALOG_H
 
 #include <QtWidgets/QDialog>
-#include <QtGui/QClipboard>
 
 namespace Avogadro {
 

--- a/avogadro/qtplugins/3dmol/3dmoldialog.h
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.h
@@ -18,6 +18,7 @@
 #define AVOGADRO_QTGUI_ThreeDMOLDIALOG_H
 
 #include <QtWidgets/QDialog>
+#include <QtGui/QClipboard>
 
 namespace Avogadro {
 
@@ -56,6 +57,7 @@ private slots:
   void updateLabels();
   void updateTextBrowser();
   void moleculeDestroyed();
+  void copyToClipboard();
 
 private:
   QtGui::Molecule *m_molecule;

--- a/avogadro/qtplugins/3dmol/3dmoldialog.ui
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.ui
@@ -14,30 +14,9 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>3DMol Dialog</string>
+   <string>3DMol HTML Snippet</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <pointsize>13</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;&amp;lt;body&amp;gt;Copy and Paste Here!&amp;lt;/body&amp;gt;&amp;quot;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="wordWrap">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
@@ -48,52 +27,33 @@
       </widget>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QPushButton" name="copyButton">
+         <property name="text">
+          <string>&amp;Copy to Clipboard</string>
+         </property>
+         <property name="shortcut">
+          <string>Ctrl+C</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="exitButton">
+         <property name="text">
+          <string>&amp;Exit</string>
+         </property>
+         <property name="shortcut">
+          <string>Ctrl+E</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>Avogadro::QtPlugins::ThreeDMolDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>Avogadro::QtPlugins::ThreeDMolDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
This is a very simple commit, ~~I believe I found a bug with the SDL writer though (I'll try to fix in a different PR). If the SDL writer writes a blank title, this dialog won't work.~~ Not SDL writer but Gaussian Cube reader. Fixed in https://github.com/OpenChemistry/avogadrolibs/pull/162