### PR TITLE
Create properly versioned shared libraries

### DIFF
--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -6,8 +6,10 @@ function(avogadro_add_library name)
   if(${name} MATCHES "^AvogadroQt")
     set_target_properties(${name} PROPERTIES AUTOMOC TRUE)
   endif()
+  if(BUILD_SHARED_LIBS)
   set_target_properties(${name} PROPERTIES VERSION "${AvogadroLibs_VERSION_MAJOR}.${AvogadroLibs_VERSION_MINOR}.${AvogadroLibs_VERSION_PATCH}"
    					   SOVERSION ${AvogadroLibs_VERSION_MAJOR})
+  endif()
   string(TOLOWER ${name} lowerName)
   # Generate the necessary export headers.
   generate_export_header(${name} EXPORT_FILE_NAME ${lowerName}export.h)

--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -6,6 +6,8 @@ function(avogadro_add_library name)
   if(${name} MATCHES "^AvogadroQt")
     set_target_properties(${name} PROPERTIES AUTOMOC TRUE)
   endif()
+  set_target_properties(${name} PROPERTIES VERSION "${AvogadroLibs_VERSION_MAJOR}.${AvogadroLibs_VERSION_MINOR}.${AvogadroLibs_VERSION_PATCH}"
+   					   SOVERSION ${AvogadroLibs_VERSION_MAJOR})
   string(TOLOWER ${name} lowerName)
   # Generate the necessary export headers.
   generate_export_header(${name} EXPORT_FILE_NAME ${lowerName}export.h)


### PR DESCRIPTION
Avogadrolibs is being used by the KDE Application Kalzium. In order to be able to include Kalzium and Avogadrolibs in a distribution, it is very important to have properly versioned shared libraries. This would allow to have multiple versions installed on a system, so that dependent applications can still work properly despite that they have not been adjusted yet to a newer version of Avogadrolibs yet. 

This commit adds the required code and has been tested succesfully