### PR TITLE
Render molecule previews as PNG data instead of QWebEngineView

### DIFF
--- a/avogadro/qtplugins/importpqr/CMakeLists.txt
+++ b/avogadro/qtplugins/importpqr/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Qt5 COMPONENTS WebEngineWidgets REQUIRED)
-
 include_directories(SYSTEM "${AvogadroLibs_SOURCE_DIR}/thirdparty/jsoncpp")
 
 # Extension
@@ -19,4 +17,4 @@ avogadro_plugin(ImportPQR
   ""
 )
 
-target_link_libraries(ImportPQR LINK_PRIVATE ${Qt5Network_LIBRARIES} ${Qt5WebEngineWidgets_LIBRARIES})
+target_link_libraries(ImportPQR LINK_PRIVATE ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/importpqr/importpqr.h
+++ b/avogadro/qtplugins/importpqr/importpqr.h
@@ -66,7 +66,7 @@ private:
   const Io::FileFormat *m_outputFormat;
   QString m_moleculeName;
   QString m_moleculePath;
-	QByteArray m_moleculeData;
+  QByteArray m_moleculeData;
 };
 
 }

--- a/avogadro/qtplugins/importpqr/pqrrequest.cpp
+++ b/avogadro/qtplugins/importpqr/pqrrequest.cpp
@@ -51,15 +51,7 @@ void PQRRequest::sendRequest(QString url)
 */
 void PQRRequest::sendRequest(QString url, QString mol2)
 {
-  QUrl httpRequest(url);
-  QNetworkRequest request;
-  request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-  request.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36");
-  request.setRawHeader("Accept-Language", "en - US, en; q = 0.8");
-  request.setUrl(httpRequest); // Set the url
-
-  reply = oNetworkAccessManager->get(request);
-
+  reply = oNetworkAccessManager->get(QNetworkRequest(QUrl(url)));
   currentMolName = nameDisplay->text(); //needed to load mol into Avogadro
   connect(reply, SIGNAL(finished()), this, SLOT(getFile()));
 }
@@ -70,15 +62,7 @@ void PQRRequest::sendRequest(QString url, QString mol2)
 */
 void PQRRequest::sendPNGRequest(QString url)
 {
-  QUrl httpRequest(url);
-  QNetworkRequest request;
-  request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-  request.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36");
-  request.setRawHeader("Accept-Language", "en - US, en; q = 0.8");
-  request.setUrl(httpRequest); // Set the url
-
-  reply = oNetworkAccessManager->get(request);
-
+  reply = oNetworkAccessManager->get(QNetworkRequest(QUrl(url)));
   connect(reply, SIGNAL(finished()), this, SLOT(SetPNG()));
 }
 

--- a/avogadro/qtplugins/importpqr/pqrrequest.cpp
+++ b/avogadro/qtplugins/importpqr/pqrrequest.cpp
@@ -9,11 +9,11 @@ namespace QtPlugins {
 * @brief Constuctor to initialize the NetworkAcessManager and set pointers to
 * the widget's ui elements.
 */
-PQRRequest::PQRRequest(QTableWidget* tw, QWebEngineView* gv, QLineEdit* nd, QLabel* fd, PQRWidget* w)
+PQRRequest::PQRRequest(QTableWidget* tw, QLabel* gv, QLineEdit* nd, QLabel* fd, PQRWidget* w)
 {
   //set pointers to ui elements now instead of in individual functions
   table = tw; //pointer to ui table
-  svgPreview = gv; //svg GraphicsView
+  pngPreview = gv; //png QLabel
   nameDisplay = nd; //name
   formulaDisplay = fd; //formula
 
@@ -65,6 +65,24 @@ void PQRRequest::sendRequest(QString url, QString mol2)
 }
 
 /**
+* @brief Sends a network request to download a png form PQR
+* @param url The url to send the request to
+*/
+void PQRRequest::sendPNGRequest(QString url)
+{
+  QUrl httpRequest(url);
+  QNetworkRequest request;
+  request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+  request.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36");
+  request.setRawHeader("Accept-Language", "en - US, en; q = 0.8");
+  request.setUrl(httpRequest); // Set the url
+
+  reply = oNetworkAccessManager->get(request);
+
+  connect(reply, SIGNAL(finished()), this, SLOT(SetPNG()));
+}
+
+/**
 * @brief Called when a molecule is selected to display information about the
 * molecule and start grabbing the SVG preview.
 * @param num The row number of the table result selected
@@ -76,7 +94,8 @@ QString PQRRequest::molSelected(int num)
     return QString("N/A");
 
   QString mol2 = results[num].mol2url;
-  QString url = "https://pqr.pitt.edu/static/data/svg/"+ mol2 + ".svg";
+  QString url = "https://pqr.pitt.edu/static/data/png/"+ mol2 + ".png";
+	sendPNGRequest(url);
 
   formulaDisplay->setText(parseSubscripts(results[num].formula));
   nameDisplay->setText(results[num].name);
@@ -148,6 +167,16 @@ void PQRRequest::getFile()
 {
   QByteArray molData = reply->readAll();
   widget->loadMolecule(molData, currentMolName);
+  reply->deleteLater();
+}
+
+/**
+* @brief Loads PNG data after sending a request
+*/
+void PQRRequest::SetPNG()
+{
+  QByteArray pngData = reply->readAll();
+  widget->loadPNG(pngData);
   reply->deleteLater();
 }
 

--- a/avogadro/qtplugins/importpqr/pqrrequest.cpp
+++ b/avogadro/qtplugins/importpqr/pqrrequest.cpp
@@ -95,7 +95,7 @@ QString PQRRequest::molSelected(int num)
 
   QString mol2 = results[num].mol2url;
   QString url = "https://pqr.pitt.edu/static/data/png/"+ mol2 + ".png";
-	sendPNGRequest(url);
+  sendPNGRequest(url);
 
   formulaDisplay->setText(parseSubscripts(results[num].formula));
   nameDisplay->setText(results[num].name);

--- a/avogadro/qtplugins/importpqr/pqrrequest.h
+++ b/avogadro/qtplugins/importpqr/pqrrequest.h
@@ -17,8 +17,6 @@
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QLabel>
 
-#include <QtWebEngineWidgets/QWebEngineView>
-
 #include <cctype>
 
 #include <json/json.h>
@@ -44,7 +42,7 @@ public:
   * @param nd Pointer to the name display
   * @param fd Pointer to the formula display
   */
-  PQRRequest(QTableWidget*, QWebEngineView*, QLineEdit*, QLabel*, PQRWidget*);
+  PQRRequest(QTableWidget*, QLabel*, QLineEdit*, QLabel*, PQRWidget*);
 
 	/**
 	* @brief Free the ui pointers
@@ -64,6 +62,12 @@ public:
   */
   void sendRequest(QString, QString);
 
+	/**
+	* @brief Sends a network request to download a png form PQR
+	* @param url The url to send the request to
+	*/
+	void sendPNGRequest(QString url);
+
   /**
   * @brief Called when a molecule is selected to display information about the
   * molecule and start grabbing the SVG preview.
@@ -82,6 +86,11 @@ private slots:
   * @brief Creates a file after requesting a file from PQR
   */
   void getFile();
+
+	/**
+	* @brief Loads PNG data after sending a request
+	*/
+	void SetPNG();
 
 private:
   /**
@@ -116,7 +125,7 @@ private:
   QTableWidget* table;
   QLineEdit* nameDisplay;
   QLabel* formulaDisplay;
-  QWebEngineView* svgPreview;
+  QLabel* pngPreview;
 
   /** Variables to fold file downlaod information for getFile() */
   QString currentMolName;

--- a/avogadro/qtplugins/importpqr/pqrrequest.h
+++ b/avogadro/qtplugins/importpqr/pqrrequest.h
@@ -44,9 +44,9 @@ public:
   */
   PQRRequest(QTableWidget*, QLabel*, QLineEdit*, QLabel*, PQRWidget*);
 
-	/**
-	* @brief Free the ui pointers
-	*/
+  /**
+  * @brief Free the ui pointers
+  */
   ~PQRRequest();
 
   /**
@@ -62,11 +62,11 @@ public:
   */
   void sendRequest(QString, QString);
 
-	/**
-	* @brief Sends a network request to download a png form PQR
-	* @param url The url to send the request to
-	*/
-	void sendPNGRequest(QString url);
+  /**
+  * @brief Sends a network request to download a png form PQR
+  * @param url The url to send the request to
+  */
+  void sendPNGRequest(QString url);
 
   /**
   * @brief Called when a molecule is selected to display information about the
@@ -87,10 +87,10 @@ private slots:
   */
   void getFile();
 
-	/**
-	* @brief Loads PNG data after sending a request
-	*/
-	void SetPNG();
+  /**
+  * @brief Loads PNG data after sending a request
+  */
+  void SetPNG();
 
 private:
   /**

--- a/avogadro/qtplugins/importpqr/pqrwidget.cpp
+++ b/avogadro/qtplugins/importpqr/pqrwidget.cpp
@@ -24,7 +24,7 @@ PQRWidget::PQRWidget(QWidget* parent, ImportPQR* p) :
   connect(ui->tableWidget, SIGNAL(cellClicked(int, int)),
     this, SLOT(molSelected(int, int)));
 
-  request = new PQRRequest(ui->tableWidget, ui->svgPreview, ui->nameDisplay, ui->formulaDisplay, this);
+  request = new PQRRequest(ui->tableWidget, ui->pngPreview, ui->nameDisplay, ui->formulaDisplay, this);
 }
 
 PQRWidget::~PQRWidget()
@@ -56,17 +56,18 @@ void PQRWidget::molSelected(int row, int col)
     return;
 
 	ui->downloadButton->setEnabled(true);
+}
 
-  QString url = "https://pqr.pitt.edu/static/data/svg/"+ currentlySelectedMol + ".svg";
-  ui->svgPreview->load(url);
-  //center svg
-  ui->svgPreview->setZoomFactor(1.5);
-  //remove scrollbars
-  ui->svgPreview->page()->runJavaScript("document.getElementById('topsvg').style.overflow='hidden';");
-
-  ui->svgPreview->show();
-
-
+/**
+* @brief Called when PNG data is ready to be loaded
+*/
+void PQRWidget::loadPNG(QByteArray& data)
+{
+	QPixmap pixmap;
+	pixmap.loadFromData(data, "PNG");
+	pixmap = pixmap.scaled(300, 300);
+	ui->pngPreview->setPixmap(pixmap);
+	ui->pngPreview->show();
 }
 
 /**

--- a/avogadro/qtplugins/importpqr/pqrwidget.cpp
+++ b/avogadro/qtplugins/importpqr/pqrwidget.cpp
@@ -55,7 +55,7 @@ void PQRWidget::molSelected(int row, int col)
   if (currentlySelectedMol == "N/A")
     return;
 
-	ui->downloadButton->setEnabled(true);
+  ui->downloadButton->setEnabled(true);
 }
 
 /**
@@ -63,11 +63,11 @@ void PQRWidget::molSelected(int row, int col)
 */
 void PQRWidget::loadPNG(QByteArray& data)
 {
-	QPixmap pixmap;
-	pixmap.loadFromData(data, "PNG");
-	pixmap = pixmap.scaled(300, 300);
-	ui->pngPreview->setPixmap(pixmap);
-	ui->pngPreview->show();
+  QPixmap pixmap;
+  pixmap.loadFromData(data, "PNG");
+  pixmap = pixmap.scaled(300, 300);
+  ui->pngPreview->setPixmap(pixmap);
+  ui->pngPreview->show();
 }
 
 /**

--- a/avogadro/qtplugins/importpqr/pqrwidget.h
+++ b/avogadro/qtplugins/importpqr/pqrwidget.h
@@ -43,7 +43,7 @@ public:
   PQRWidget(QWidget *parent = 0, ImportPQR* p = nullptr);
   ~PQRWidget();
   void loadMolecule(QByteArray&, QString);
-	void loadPNG(QByteArray&);
+  void loadPNG(QByteArray&);
 
 private slots:
 

--- a/avogadro/qtplugins/importpqr/pqrwidget.h
+++ b/avogadro/qtplugins/importpqr/pqrwidget.h
@@ -8,6 +8,8 @@
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QGraphicsRectItem>
 
+#include <QtGui/QPixmap>
+
 #include <QtNetwork/QNetworkReply>
 
 #include <QtCore/QFile>
@@ -41,6 +43,7 @@ public:
   PQRWidget(QWidget *parent = 0, ImportPQR* p = nullptr);
   ~PQRWidget();
   void loadMolecule(QByteArray&, QString);
+	void loadPNG(QByteArray&);
 
 private slots:
 
@@ -70,7 +73,6 @@ private:
   Ui::PQRWidget *ui;
   /** Pointer to a PQRRequest object to handle network requests */
   PQRRequest *request;
-
   /** Pointer to the plugin that opened the dialog */
   ImportPQR *plugin;
 };

--- a/avogadro/qtplugins/importpqr/pqrwidget.ui
+++ b/avogadro/qtplugins/importpqr/pqrwidget.ui
@@ -73,36 +73,6 @@
        </item>
       </widget>
      </item>
-     <item row="3" column="5" colspan="2">
-      <widget class="QWebEngineView" name="svgPreview">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>300</width>
-         <height>300</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>300</width>
-         <height>300</height>
-        </size>
-       </property>
-       <property name="url">
-        <url>
-         <string>about:blank</string>
-        </url>
-       </property>
-       <property name="zoomFactor">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="sizePolicy">
@@ -113,6 +83,27 @@
        </property>
        <property name="text">
         <string>Search By: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="6">
+      <widget class="QLineEdit" name="nameDisplay">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="6">
+      <widget class="QLabel" name="formulaDisplay">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="5">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Formula:</string>
        </property>
       </widget>
      </item>
@@ -129,27 +120,6 @@
          <width>750</width>
          <height>500</height>
         </size>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="5">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Formula:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="6">
-      <widget class="QLabel" name="formulaDisplay">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="6">
-      <widget class="QLineEdit" name="nameDisplay">
-       <property name="readOnly">
-        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -170,17 +140,35 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="5" colspan="2">
+      <widget class="QLabel" name="pngPreview">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>300</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>300</width>
+         <height>300</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
@ghutchis 
Removes QWebEngineView/Chromium as a necessity for importing molecules via PQR by rendering molecule previews as a PNG.

Screenshot:
![](https://i.gyazo.com/bf852755bce78d361c1a1d46db8515c5.png)