### PR TITLE
Add appveyor configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+configuration:
+- Release
+clone_folder: C:/openchemistry/avogadrolibs
+init:
+- cmd:
+environment:
+  PATH: '%PATH%;%QTDIR%\bin'
+  matrix:
+  - CMAKE_GENERATOR: '"Visual Studio 14 2015 Win64"'
+    QTDIR: C:\Qt\5.6\msvc2015_64
+    platform: x64
+build_script:
+- cmd: >-
+    cd ..
+
+    git init .
+
+    git remote add origin git://github.com/OpenChemistry/openchemistry.git
+
+    git pull origin master
+
+    git -c submodule.avogadrolibs.update=none submodule update --init
+
+    cd ../
+
+    mkdir openchemistry-build
+
+    cd openchemistry-build
+
+    cmake -G %CMAKE_GENERATOR% ../openchemistry
+
+    cmake --build . --target avogadrolibs --config Release -- /verbosity:detailed


### PR DESCRIPTION
This adds an appveyor.yml configuration file to allow PRs and branches to be tested for compilation automatically via [Appveyor](https://www.appveyor.com/). This repository will need to be added via the Appveyor website by one of the owners. 

An example of this working can be seen on my fork [here](https://github.com/etp12/avogadrolibs/pulls). workingBranch is a regular branch of the repository which compiles while brokenBranch has syntax errors that will cause the compilation to fail.

There is one build job that uses x64 architecture targeting Release. Each build takes roughly 20 minutes.