### PR TITLE
Write Pov-Ray to file

### DIFF
--- a/avogadro/qtplugins/povray/povray.cpp
+++ b/avogadro/qtplugins/povray/povray.cpp
@@ -36,8 +36,8 @@ namespace QtPlugins {
 
 POVRay::POVRay(QObject *p) :
   Avogadro::QtGui::ExtensionPlugin(p),
-  m_molecule(nullptr), m_scene(nullptr), m_camera(nullptr),
-  m_action(new QAction(tr("Render with POV-Ray"), this))
+  m_molecule(NULL), m_scene(NULL), m_camera(NULL),
+  m_action(new QAction(tr("POV-Ray Render"), this))
 {
   connect(m_action, SIGNAL(triggered()), SLOT(render()));
 }
@@ -49,12 +49,12 @@ POVRay::~POVRay()
 QList<QAction *> POVRay::actions() const
 {
   QList<QAction *> result;
-  return result;// << m_action;
+  return result << m_action;
 }
 
 QStringList POVRay::menuPath(QAction *) const
 {
-  return QStringList() << tr("&File");
+  return QStringList() << tr("&File") << tr("&Export");
 }
 
 void POVRay::setMolecule(QtGui::Molecule *mol)
@@ -76,6 +76,8 @@ void POVRay::render()
 {
   if (!m_scene || !m_camera)
     return;
+
+  // TODO: Needs to save to a file!
 
   Rendering::POVRayVisitor visitor(*m_camera);
   visitor.begin();

--- a/avogadro/qtplugins/povray/povray.cpp
+++ b/avogadro/qtplugins/povray/povray.cpp
@@ -80,7 +80,7 @@ void POVRay::render()
     return;
 
   QString filename = QFileDialog::getSaveFileName(qobject_cast<QWidget*>(parent()), tr("Save File"),
-    QDir::homePath(), tr("Pov-Ray (*.pov);;Text file (*.txt)"));
+    QDir::homePath(), tr("POV-Ray (*.pov);;Text file (*.txt)"));
   QFile file(filename);
   if (!file.open(QIODevice::WriteOnly))
     return;

--- a/avogadro/qtplugins/povray/povray.cpp
+++ b/avogadro/qtplugins/povray/povray.cpp
@@ -38,7 +38,7 @@ namespace QtPlugins {
 
 POVRay::POVRay(QObject *p) :
   Avogadro::QtGui::ExtensionPlugin(p),
-  m_molecule(NULL), m_scene(NULL), m_camera(NULL),
+  m_molecule(nullptr), m_scene(nullptr), m_camera(nullptr),
   m_action(new QAction(tr("POV-Ray Render"), this))
 {
   connect(m_action, SIGNAL(triggered()), SLOT(render()));

--- a/avogadro/qtplugins/povray/povray.cpp
+++ b/avogadro/qtplugins/povray/povray.cpp
@@ -27,6 +27,8 @@
 #include <QtGui/QIcon>
 #include <QtGui/QKeySequence>
 #include <QtWidgets/QMessageBox>
+#include <QtWidgets/QFileDialog>
+#include <QtCore/QTextStream>
 
 #include <string>
 #include <vector>
@@ -77,12 +79,19 @@ void POVRay::render()
   if (!m_scene || !m_camera)
     return;
 
-  // TODO: Needs to save to a file!
+  QString filename = QFileDialog::getSaveFileName(qobject_cast<QWidget*>(parent()), tr("Save File"),
+    QDir::homePath(), tr("Pov-Ray (*.pov);;Text file (*.txt)"));
+  QFile file(filename);
+  if (!file.open(QIODevice::WriteOnly))
+    return;
 
+  QTextStream fileStream(&file);
   Rendering::POVRayVisitor visitor(*m_camera);
   visitor.begin();
   m_scene->rootNode().accept(visitor);
-  visitor.end();
+  fileStream << visitor.end().c_str();
+
+  file.close();
 }
 
 

--- a/avogadro/rendering/povrayvisitor.cpp
+++ b/avogadro/rendering/povrayvisitor.cpp
@@ -29,9 +29,11 @@ namespace Avogadro {
 namespace Rendering {
 
 using std::cout;
+using std::string;
 using std::endl;
 using std::ostringstream;
 using std::ostream;
+using std::ofstream;
 
 namespace {
 ostream& operator<<(ostream& os, const Vector3f &v)
@@ -108,8 +110,9 @@ void POVRayVisitor::begin()
   m_sceneData = str.str();
 }
 
-void POVRayVisitor::end()
+string POVRayVisitor::end()
 {
+  return m_sceneData;
 }
 
 void POVRayVisitor::visit(Drawable &geometry)
@@ -127,8 +130,6 @@ void POVRayVisitor::visit(SphereGeometry &geometry)
         << "\n\tpigment { rgbt <" << s.color << ", 0.0> }\n}\n";
   }
   m_sceneData += str.str();
-
-  cout << "POV data:\n" << m_sceneData << endl;
 }
 
 void POVRayVisitor::visit(AmbientOcclusionSphereGeometry &geometry)
@@ -147,8 +148,6 @@ void POVRayVisitor::visit(CylinderGeometry &geometry)
       << "\n\tpigment { rgbt <" << c.color << ", 0.0> }\n}\n";
   }
   m_sceneData += str.str();
-
-  cout << "POV data:\n" << m_sceneData << endl;
 }
 
 void POVRayVisitor::visit(MeshGeometry &geometry)

--- a/avogadro/rendering/povrayvisitor.h
+++ b/avogadro/rendering/povrayvisitor.h
@@ -21,7 +21,6 @@
 
 #include "avogadrorendering.h"
 #include "camera.h"
-
 #include <string>
 
 namespace Avogadro {
@@ -42,7 +41,7 @@ public:
   ~POVRayVisitor() override;
 
   void begin();
-  void end();
+  std::string end();
 
   /**
    * The overloaded visit functions, the base versions of which do nothing.
@@ -71,7 +70,6 @@ private:
   Vector3ub m_backgroundColor;
   Vector3ub m_ambientColor;
   float m_aspectRatio;
-
   std::string m_sceneData;
 };
 


### PR DESCRIPTION
This is related to #130 and enables users to export the current molecule as a Pov-Ray file. This adds a QFileDialog for users to select an output file/directory that defaults to the user's home directory:
![](https://i.gyazo.com/b25471c6a2c34fd56f255cf4d7e88f87.png)

It was mentioned that povrayvisitor wasn't working correctly, specifically there were issues with the camera. However it seems to work well for spheres and cylinders. For example: 
![](https://i.gyazo.com/d151faedc28586702dce63a92e7aa5b8.png)

As well as when I rotate the molecule:
![](https://i.gyazo.com/320f92919989abdece731baf5100f8db.png)

I tested this with a number of molecules, but if I missed a specific case that has issues I can take some time to look into it.

Originally I was planning on passing a stream for povrayvisitor to write to, but in the end I figured it would be easier to change PovRayVisitor::end() to simply return a string and allow the caller to deal with writing to the file. I can change this if it's not preferred.