### PR TITLE
Fix an off by one error for molecular orbital calculations

### DIFF
--- a/avogadro/core/gaussiansettools.cpp
+++ b/avogadro/core/gaussiansettools.cpp
@@ -61,12 +61,11 @@ double GaussianSetTools::calculateMolecularOrbital(const Vector3& position,
 
   const MatrixX& matrix = m_basis->moMatrix();
   int matrixSize(static_cast<int>(matrix.rows()));
-  int indexMO(mo - 1);
 
   // Now calculate the value of the density at this point in space
   double result(0.0);
   for (int i = 0; i < matrixSize; ++i)
-    result += matrix(i, indexMO) * values[i];
+    result += matrix(i, mo) * values[i];
 
   return result;
 }


### PR DESCRIPTION
This fixes issue #180, thanks for the bug report.