### PR TITLE
Export to VRML

### DIFF
--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -119,6 +119,7 @@ add_subdirectory(select)
 add_subdirectory(selectiontool)
 add_subdirectory(spacegroup)
 add_subdirectory(spectra)
+add_subdirectory(vrml)
 add_subdirectory(workflows)
 
 if(USE_MOLEQUEUE)

--- a/avogadro/qtplugins/vrml/CMakeLists.txt
+++ b/avogadro/qtplugins/vrml/CMakeLists.txt
@@ -1,0 +1,10 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+avogadro_plugin(VRML
+  "Render the scene using VRML."
+  ExtensionPlugin
+  vrml.h
+  VRML
+  "vrml.cpp"
+  ""
+)

--- a/avogadro/qtplugins/vrml/vrml.cpp
+++ b/avogadro/qtplugins/vrml/vrml.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2014 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "vrml.h"
+
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/rendering/camera.h>
+#include <avogadro/rendering/scene.h>
+#include <avogadro/rendering/vrmlvisitor.h>
+
+#include <QtCore/QTextStream>
+#include <QtGui/QClipboard>
+#include <QtGui/QIcon>
+#include <QtGui/QKeySequence>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMessageBox>
+
+#include <string>
+#include <vector>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+VRML::VRML(QObject* p)
+  : Avogadro::QtGui::ExtensionPlugin(p), m_molecule(nullptr), m_scene(nullptr),
+    m_camera(nullptr), m_action(new QAction(tr("VRML Render"), this))
+{
+  connect(m_action, SIGNAL(triggered()), SLOT(render()));
+}
+
+VRML::~VRML()
+{
+}
+
+QList<QAction*> VRML::actions() const
+{
+  QList<QAction*> result;
+  return result << m_action;
+}
+
+QStringList VRML::menuPath(QAction*) const
+{
+  return QStringList() << tr("&File") << tr("&Export");
+}
+
+void VRML::setMolecule(QtGui::Molecule* mol)
+{
+  m_molecule = mol;
+}
+
+void VRML::setScene(Rendering::Scene* scene)
+{
+  m_scene = scene;
+}
+
+void VRML::setCamera(Rendering::Camera* camera)
+{
+  m_camera = camera;
+}
+
+void VRML::render()
+{
+  if (!m_scene || !m_camera)
+    return;
+
+  QString filename = QFileDialog::getSaveFileName(
+    qobject_cast<QWidget*>(parent()), tr("Save File"), QDir::homePath(),
+    tr("VRML (*.wrl);;Text file (*.txt)"));
+  QFile file(filename);
+  if (!file.open(QIODevice::WriteOnly))
+    return;
+
+  QTextStream fileStream(&file);
+  Rendering::VRMLVisitor visitor(*m_camera);
+  visitor.begin();
+  m_scene->rootNode().accept(visitor);
+  fileStream << visitor.end().c_str();
+
+  file.close();
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/vrml/vrml.h
+++ b/avogadro/qtplugins/vrml/vrml.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2017 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_VRML_H
+#define AVOGADRO_QTPLUGINS_VRML_H
+
+#include <avogadro/core/avogadrocore.h>
+#include <avogadro/qtgui/extensionplugin.h>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+/**
+ * @brief The VRML class performs VRML operations
+ */
+class VRML : public QtGui::ExtensionPlugin
+{
+  Q_OBJECT
+public:
+  explicit VRML(QObject* p = 0);
+  ~VRML() override;
+
+  QString name() const override { return tr("VRML"); }
+
+  QString description() const override
+  {
+    return tr("Render the scene using VRML.");
+  }
+
+  QList<QAction*> actions() const override;
+
+  QStringList menuPath(QAction* action) const override;
+
+public slots:
+  void setMolecule(QtGui::Molecule* mol) override;
+  void setScene(Rendering::Scene* scene) override;
+  void setCamera(Rendering::Camera* camera) override;
+
+private slots:
+  void render();
+
+private:
+  QtGui::Molecule* m_molecule;
+  Rendering::Scene* m_scene;
+  Rendering::Camera* m_camera;
+
+  QAction* m_action;
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_VRML_H

--- a/avogadro/rendering/CMakeLists.txt
+++ b/avogadro/rendering/CMakeLists.txt
@@ -40,6 +40,7 @@ set(HEADERS
   transformnode.h
   visitor.h
   volumegeometry.h
+	vrmlvisitor.h
 )
 
 set(SOURCES
@@ -69,6 +70,7 @@ set(SOURCES
   transformnode.cpp
   visitor.cpp
   volumegeometry.cpp
+	vrmlvisitor.cpp
   ambientocclusionspheregeometry.cpp
 )
 

--- a/avogadro/rendering/CMakeLists.txt
+++ b/avogadro/rendering/CMakeLists.txt
@@ -40,7 +40,7 @@ set(HEADERS
   transformnode.h
   visitor.h
   volumegeometry.h
-	vrmlvisitor.h
+  vrmlvisitor.h
 )
 
 set(SOURCES
@@ -70,7 +70,7 @@ set(SOURCES
   transformnode.cpp
   visitor.cpp
   volumegeometry.cpp
-	vrmlvisitor.cpp
+  vrmlvisitor.cpp
   ambientocclusionspheregeometry.cpp
 )
 

--- a/avogadro/rendering/vrmlvisitor.cpp
+++ b/avogadro/rendering/vrmlvisitor.cpp
@@ -1,0 +1,196 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2017 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "vrmlvisitor.h"
+
+#include "ambientocclusionspheregeometry.h"
+#include "cylindergeometry.h"
+#include "linestripgeometry.h"
+#include "meshgeometry.h"
+#include "spheregeometry.h"
+
+#include <iostream>
+#include <ostream>
+
+namespace Avogadro {
+namespace Rendering {
+
+using std::cout;
+using std::string;
+using std::endl;
+using std::ostringstream;
+using std::ostream;
+using std::ofstream;
+
+namespace {
+ostream& operator<<(ostream& os, const Vector3f& v)
+{
+  os << v[0] << " " << v[1] << " " << v[2];
+  return os;
+}
+
+ostream& operator<<(ostream& os, const Vector3ub& color)
+{
+  os << color[0] / 255.0f << "\t" << color[1] / 255.0f << "\t"
+     << color[2] / 255.0f;
+  return os;
+}
+}
+
+VRMLVisitor::VRMLVisitor(const Camera& c)
+  : m_camera(c), m_backgroundColor(255, 255, 255),
+    m_ambientColor(100, 100, 100), m_aspectRatio(800.0f / 600.0f)
+{
+}
+
+VRMLVisitor::~VRMLVisitor()
+{
+}
+
+void VRMLVisitor::begin()
+{
+
+  // Initialise the VRML scene
+  Vector3f cameraT = -(m_camera.modelView().linear().adjoint() *
+                       m_camera.modelView().translation());
+  Vector3f cameraX =
+    m_camera.modelView().linear().row(0).transpose().normalized();
+  Vector3f cameraY =
+    m_camera.modelView().linear().row(1).transpose().normalized();
+  Vector3f cameraZ =
+    -m_camera.modelView().linear().row(2).transpose().normalized();
+
+  double huge = 100;
+
+  Vector3f light0pos =
+    huge * (m_camera.modelView().linear().adjoint() * Vector3f(0, 1, 0));
+
+  // Output the POV-Ray initialisation code
+  // orientation should be set
+  // http://cgvr.informatik.uni-bremen.de/teaching/vr_literatur/Calculating%20VRML%20Viewpoints.html
+  ostringstream str;
+  str << "#VRML V2.0 utf8\n"
+      << "DEF DefaultView Viewpoint {\n"
+      << "position " << cameraT << " \n"
+      << "fieldOfView 0.785398\n}\n";
+
+  m_sceneData = str.str();
+}
+
+string VRMLVisitor::end()
+{
+  return m_sceneData;
+}
+
+void VRMLVisitor::visit(Drawable& geometry)
+{
+  // geometry.render(m_camera);
+}
+
+void VRMLVisitor::visit(SphereGeometry& geometry)
+{
+  ostringstream str;
+  for (size_t i = 0; i < geometry.spheres().size(); ++i) {
+    Rendering::SphereColor s = geometry.spheres()[i];
+
+    str << "Transform {\n"
+        << "\ttranslation\t" << s.center[0] << "\t" << s.center[1] << "\t"
+        << s.center[2] << "\n\tchildren Shape {\n"
+        << "\t\tgeometry Sphere {\n\t\t\tradius\t" << s.radius << "\n\t\t}\n"
+        << "\t\tappearance Appearance {\n"
+        << "\t\t\tmaterial Material {\n"
+        << "\t\t\t\tdiffuseColor\t" << s.color << "\n\t\t\t}\n\t\t}\n\t}\n}\n";
+  }
+  m_sceneData += str.str();
+}
+
+void VRMLVisitor::visit(AmbientOcclusionSphereGeometry& geometry)
+{
+  // geometry.render(m_camera);
+}
+
+void VRMLVisitor::visit(CylinderGeometry& geometry)
+{
+  ostringstream str;
+  for (size_t i = 0; i < geometry.cylinders().size(); ++i) {
+    Rendering::CylinderColor c = geometry.cylinders()[i];
+
+    // double scale = 1.0;
+    double x1, x2, y1, y2, z1, z2;
+    x1 = c.end1[0];
+    x2 = c.end2[0];
+    y1 = c.end1[1];
+    y2 = c.end2[1];
+    z1 = c.end1[2];
+    z2 = c.end2[2];
+
+    double dx = x2 - x1;
+    double dy = y2 - y1;
+    double dz = z2 - z1;
+
+    double length = sqrt(dx * dx + dy * dy + dz * dz);
+    double tx = dx / 2 + x1;
+    double ty = dy / 2 + y1;
+    double tz = dz / 2 + z1;
+
+    dx = dx / length;
+    dy = dy / length;
+    dz = dz / length;
+
+    double ax, ay, az, angle;
+
+    if (dy > 0.999) {
+      ax = 1.0;
+      ay = 0.0;
+      az = 0.0;
+      angle = 0.0;
+    } else if (dy < -0.999) {
+      ax = 1.0;
+      ay = 0.0;
+      az = 0.0;
+      angle = 3.14159265359;
+    } else {
+      ax = dz;
+      ay = 0.0;
+      az = dx * -1.0;
+      angle = acos(dy);
+    }
+    length = length / 2.0;
+
+    str << "Transform {\n"
+        << "\ttranslation\t" << tx << "\t" << ty << "\t" << tz << "\n\tscale "
+        << " 1 " << length << " 1"
+        << "\n\trotation " << ax << " " << ay << " " << az << " " << angle
+        << "\n\tchildren Shape {\n"
+        << "\t\tgeometry Cylinder {\n\t\t\tradius\t" << c.radius << "\n\t\t}\n"
+        << "\t\tappearance Appearance {\n"
+        << "\t\t\tmaterial Material {\n"
+        << "\t\t\t\tdiffuseColor\t" << c.color << "\n\t\t\t}\n\t\t}\n\t}\n}\n";
+  }
+  m_sceneData += str.str();
+}
+
+void VRMLVisitor::visit(MeshGeometry& geometry)
+{
+}
+
+void VRMLVisitor::visit(LineStripGeometry& geometry)
+{
+  // geometry.render(m_camera);
+}
+
+} // End namespace Rendering
+} // End namespace Avogadro

--- a/avogadro/rendering/vrmlvisitor.h
+++ b/avogadro/rendering/vrmlvisitor.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2017 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_RENDERING_VRMLVISITOR_H
+#define AVOGADRO_RENDERING_VRMLVISITOR_H
+
+#include "visitor.h"
+
+#include "avogadrorendering.h"
+#include "camera.h"
+#include <string>
+
+namespace Avogadro {
+namespace Rendering {
+
+/**
+ * @class VRMLVisitor vrmlvisitor.h <avogadro/rendering/vrmlvisitor.h>
+ * @brief Visitor that visits scene elements and creates a VRML input file.
+ *
+ * This visitor will render elements in the scene to a text file that contains
+ * elements that can be rendered as VRML.
+ */
+
+class AVOGADRORENDERING_EXPORT VRMLVisitor : public Visitor
+{
+public:
+  VRMLVisitor(const Camera& camera);
+  ~VRMLVisitor() override;
+
+  void begin();
+  std::string end();
+
+  /**
+   * The overloaded visit functions, the base versions of which do nothing.
+   */
+  void visit(Node&) override { return; }
+  void visit(GroupNode&) override { return; }
+  void visit(GeometryNode&) override { return; }
+  void visit(Drawable&) override;
+  void visit(SphereGeometry&) override;
+  void visit(AmbientOcclusionSphereGeometry&) override;
+  void visit(CylinderGeometry&) override;
+  void visit(MeshGeometry&) override;
+  void visit(TextLabel2D&) override { return; }
+  void visit(TextLabel3D&) override { return; }
+  void visit(LineStripGeometry& geometry) override;
+
+  void setCamera(const Camera& c) { m_camera = c; }
+  Camera camera() const { return m_camera; }
+
+  void setBackgroundColor(const Vector3ub& c) { m_backgroundColor = c; }
+  void setAmbientColor(const Vector3ub& c) { m_ambientColor = c; }
+  void setAspectRatio(float ratio) { m_aspectRatio = ratio; }
+
+private:
+  Camera m_camera;
+  Vector3ub m_backgroundColor;
+  Vector3ub m_ambientColor;
+  float m_aspectRatio;
+  std::string m_sceneData;
+};
+
+} // End namespace Rendering
+} // End namespace Avogadro
+
+#endif // AVOGADRO_RENDERING_VRMLVISITOR_H


### PR DESCRIPTION
This PR allows for spheres and cylinders to be exported to VRML (.wrl) format, similar to the Pov-Ray renderer. It is available under File->Export->VRML Render.

Example molecule in the Avogadro scene: 
![https://i.gyazo.com/6ed5a15060632a5258572a3a2749f850.png](https://i.gyazo.com/6ed5a15060632a5258572a3a2749f850.png)

After exporting to VRML:
![https://i.gyazo.com/5f0a29b357630ecbc14f6faa877caf59.png](https://i.gyazo.com/5f0a29b357630ecbc14f6faa877caf59.png)

Unlike the Pov-Ray renderer, this currently doesn't change the camera orientation. In the Pov-Ray format it looked as simple as listing the cameraX/Y/Z coordinates, but in VRML it uses a single quaternion orientation. I was able to calculate this [here](http://cgvr.informatik.uni-bremen.de/teaching/vr_literatur/Calculating%20VRML%20Viewpoints.html) after printing out the cameraY/Z vectors. I wasn't able to find the original C version they used (looks like it was written in 1995), although I was able to look over the Javascript version they use on their site. 

Is the camera orientation important for this feature? I wouldn't think it would be necessary for simply making 3D models, but if it's going to be used similarly to the Pov-Ray renderer then I can look into recreating how the site calculates the orientation.

