### PR TITLE
Fixed a compiling issue with array.h on Windows

### DIFF
--- a/avogadro/core/array.h
+++ b/avogadro/core/array.h
@@ -187,7 +187,7 @@ public:
     d->data.reserve(sz);
   }
 
-  void resize(const size_t& sz, ValueType t = ValueType())
+  void resize(const size_t& sz, const ValueType& t = ValueType())
   {
     detachWithCopy();
     d->data.resize(sz, t);


### PR DESCRIPTION
For some reason, I was experiencing the following error
for some template types for Array on Windows:

"formal parameter with requested alignment of 16 won't be aligned"

and the error occurred on the altered line.

I don't fully know why, but some sources online suggested to use a
reference to fix this issue. So I changed the function to pass the
type by a const reference, and it seems to fix it. It looks like it
might have something to do with it not working on 32-bit systems.

As far as I can tell, it seems like a reasonable fix. Let me know
if you think otherwise, though. This fixed the problems.