### PR TITLE
Fixed incorrect header guard

### DIFF
--- a/avogadro/io/mdlformat.h
+++ b/avogadro/io/mdlformat.h
@@ -65,4 +65,4 @@ public:
 } // end Io namespace
 } // end Avogadro namespace
 
-#endif // AVOGADRO_IO_XMLFORMAT_H
+#endif // AVOGADRO_IO_MDLFORMAT_H

--- a/avogadro/io/xyzformat.h
+++ b/avogadro/io/xyzformat.h
@@ -62,4 +62,4 @@ public:
 } // end Io namespace
 } // end Avogadro namespace
 
-#endif // AVOGADRO_IO_XMLFORMAT_H
+#endif // AVOGADRO_IO_XYZFORMAT_H


### PR DESCRIPTION
The comment at the end of the header guard was named incorrectly.