### PR TITLE
Add name property to basis set

### DIFF
--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -20,6 +20,8 @@
 
 #include "avogadrocore.h"
 
+#include <string>
+
 namespace Avogadro {
 namespace Core {
 
@@ -90,6 +92,16 @@ public:
   const Molecule* molecule() const { return m_molecule; }
 
   /**
+   * Set the name of the basis set.
+   */
+  void setName(const std::string& name) { m_name = name; }
+
+  /**
+   * Get the name of the basis set.
+   */
+  std::string name() const { return m_name; }
+
+  /**
    * @return The number of molecular orbitals in the BasisSet.
    */
   virtual unsigned int molecularOrbitalCount(ElectronType type = Paired) = 0;
@@ -137,6 +149,12 @@ protected:
    * necessarily the case.
    */
   Molecule* m_molecule;
+
+  /**
+   * The name of the basis set, this is usually a string identifier referencing
+   * a standard basis set when only one is used.
+   */
+  std::string m_name;
 };
 
 inline void BasisSet::setElectronCount(unsigned int n, ElectronType type)

--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -102,6 +102,16 @@ public:
   std::string name() const { return m_name; }
 
   /**
+   * Set the name of the basis set.
+   */
+  void setTheoryName(const std::string& name) { m_theoryName = name; }
+
+  /**
+   * Get the name of the basis set.
+   */
+  std::string theoryName() const { return m_theoryName; }
+
+  /**
    * @return The number of molecular orbitals in the BasisSet.
    */
   virtual unsigned int molecularOrbitalCount(ElectronType type = Paired) = 0;
@@ -155,6 +165,11 @@ protected:
    * a standard basis set when only one is used.
    */
   std::string m_name;
+
+  /**
+   * The name of the theory used for the calculation.
+   */
+  std::string m_theoryName;
 };
 
 inline void BasisSet::setElectronCount(unsigned int n, ElectronType type)

--- a/avogadro/core/gaussianset.h
+++ b/avogadro/core/gaussianset.h
@@ -191,6 +191,16 @@ public:
   ScfType scfType() const { return m_scfType; }
 
   /**
+   * Set the functional name (if appplicable).
+   */
+  void setFunctionalName(const std::string& name) { m_functionalName = name; }
+
+  /**
+   * Get the functional name (empty if none used).
+   */
+  std::string functionalName() const { return m_functionalName; }
+
+  /**
    * Initialize the calculation, this must normally be done before anything.
    */
   void initCalculation();
@@ -321,6 +331,8 @@ private:
   bool m_init;           //! Has the calculation been initialised?
 
   ScfType m_scfType;
+
+  std::string m_functionalName;
 
   /**
    * @brief Generate the density matrix if we have the required information.

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -172,7 +172,7 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
     const GaussianSet* gaussian =
       dynamic_cast<const GaussianSet*>(molecule.basisSet());
     if (gaussian) {
-      basis["basisType"] = "GTO";
+      basis["basisType"] = "gto";
       string type = "unknown";
       switch (gaussian->scfType()) {
         case Core::Rhf:
@@ -192,6 +192,7 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
       Value properties(Json::objectValue);
       properties["functionalName"] = gaussian->functionalName();
       properties["electronCount"] = gaussian->electronCount();
+      properties["theory"] = gaussian->theoryName();
       properties["scfType"] = type;
 
       Value mo(Json::objectValue);

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -189,6 +189,7 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
       }
       basis["scfType"] = type;
       basis["electronCount"] = gaussian->electronCount();
+      basis["name"] = gaussian->name();
       Value mo(Json::objectValue);
 
       std::vector<double> energies = gaussian->moEnergy();

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -187,9 +187,13 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
         default:
           type = "unknown";
       }
-      basis["scfType"] = type;
-      basis["electronCount"] = gaussian->electronCount();
       basis["name"] = gaussian->name();
+
+      Value properties(Json::objectValue);
+      properties["functionalName"] = gaussian->functionalName();
+      properties["electronCount"] = gaussian->electronCount();
+      properties["scfType"] = type;
+
       Value mo(Json::objectValue);
 
       std::vector<double> energies = gaussian->moEnergy();
@@ -225,6 +229,7 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
 
       root["basisSet"] = basis;
       root["molecularOrbitals"] = mo;
+      root["properties"] = properties;
     }
   }
 

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -1024,7 +1024,13 @@ bool CjsonFormat::readVibrations(Value& root, Molecule& molecule)
     */
 
     // Assumption: chose the vibir attribute over the vibraman attribute
-    value = vibrations["intensities"]["IR"];
+    if (vibrations.isMember("intensities") &&
+        vibrations["intensities"].isObject()) {
+      value =  vibrations["intensities"]["IR"];
+    } else {
+      value = Value();
+    }
+
     if (!value.empty() && value.isArray()) {
       Array<double> intensities;
 

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -187,7 +187,9 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
         default:
           type = "unknown";
       }
-      basis["name"] = gaussian->name();
+      if (!gaussian->name().empty()) {
+        basis["name"] = gaussian->name();
+      }
 
       Value properties(Json::objectValue);
       properties["functionalName"] = gaussian->functionalName();

--- a/avogadro/quantumio/nwchemjson.cpp
+++ b/avogadro/quantumio/nwchemjson.cpp
@@ -113,7 +113,6 @@ bool NWChemJson::read(std::istream& file, Molecule& molecule)
         if (xcFunctional == "B3LYP Method XC Potential") {
           xcFunctional = "b3lyp";
         }
-        cout << "functional found: " << xcFunctional << endl;
       }
       if (calcSetup.isMember("waveFunctionTheory")) {
         theory = calcSetup["waveFunctionTheory"].asString();

--- a/avogadro/quantumio/nwchemjson.cpp
+++ b/avogadro/quantumio/nwchemjson.cpp
@@ -166,6 +166,7 @@ bool NWChemJson::read(std::istream& file, Molecule& molecule)
     // Now create the structure, and expand out the orbitals.
     GaussianSet* basis = new GaussianSet;
     basis->setMolecule(&molecule);
+    string basisSetName;
     for (size_t i = 0; i < atomSymbol.size(); ++i) {
       string symbol = atomSymbol[i];
       Value basisFunctions = basisSet["basisFunctions"];
@@ -187,6 +188,14 @@ bool NWChemJson::read(std::istream& file, Molecule& molecule)
 
       if (currentFunction.isNull())
         break;
+
+      if (currentFunction.isMember("basisSetName")) {
+        if (basisSetName.empty()) {
+          basisSetName = currentFunction["basisSetName"].asString();
+        } else if (basisSetName != currentFunction["basisSetName"].asString()) {
+          basisSetName = "Custom";
+        }
+      }
 
       Value contraction = currentFunction["basisSetContraction"];
       bool spherical =
@@ -249,6 +258,7 @@ bool NWChemJson::read(std::istream& file, Molecule& molecule)
     basis->setMolecularOrbitalOccupancy(occArray);
     basis->setMolecularOrbitalNumber(numArray);
     basis->setElectronCount(numberOfElectrons);
+    basis->setName(basisSetName);
     molecule.setBasisSet(basis);
   }
 

--- a/avogadro/quantumio/nwchemjson.cpp
+++ b/avogadro/quantumio/nwchemjson.cpp
@@ -111,14 +111,14 @@ bool NWChemJson::read(std::istream& file, Molecule& molecule)
           xcFunctional = functional["xcName"].asString();
         }
         if (xcFunctional == "B3LYP Method XC Potential") {
-          xcFunctional = "B3LYP";
+          xcFunctional = "b3lyp";
         }
         cout << "functional found: " << xcFunctional << endl;
       }
       if (calcSetup.isMember("waveFunctionTheory")) {
         theory = calcSetup["waveFunctionTheory"].asString();
         if (theory == "Density Functional Theory") {
-          theory = "DFT";
+          theory = "dft";
         }
       }
       if (!calcMol.isNull() && calcMol.isObject())


### PR DESCRIPTION
The name of a basis set is useful if it is a simple basis set applied to
all atoms in a calculation. Add a name property, and set it to the name
of the uniformly applied basis set, or to custom if more than one basis
set is observed in a given file.