### PR TITLE
Updated QOpenGLWidget::grabFrameBuffer() call

### DIFF
--- a/tests/qtopengl/glwidgettest.cpp
+++ b/tests/qtopengl/glwidgettest.cpp
@@ -66,7 +66,7 @@ int glwidgettest(int argc, char* argv[])
   app.exec();
 
   // Grab the frame buffer of the GLWidget and save it to a QImage.
-  QImage image = widget.grabFrameBuffer(false);
+  QImage image = widget.grabFramebuffer();
 
   // Set up the image regression test.
   ImageRegressionTest test(argc, argv);

--- a/tests/qtopengl/qttextlabeltest.cpp
+++ b/tests/qtopengl/qttextlabeltest.cpp
@@ -194,7 +194,7 @@ int qttextlabeltest(int argc, char* argv[])
   app.exec();
 
   // Grab the frame buffer of the GLWidget and save it to a QImage.
-  QImage image = widget.grabFrameBuffer(false);
+  QImage image = widget.grabFramebuffer();
 
   // Set up the image regression test.
   ImageRegressionTest test(argc, argv);


### PR DESCRIPTION
The name was changed to "grabFramebuffer()" with a
lower-case "b" in "buffer", and it takes no arguments.