### PR TITLE
Use toLocal8Bit for filenames over Latin1

### DIFF
--- a/avogadro/molequeue/inputgeneratorwidget.cpp
+++ b/avogadro/molequeue/inputgeneratorwidget.cpp
@@ -484,7 +484,7 @@ void InputGeneratorWidget::saveSingleFile(const QString& fileName)
   QFile file(filePath);
   bool success = false;
   if (file.open(QFile::WriteOnly | QFile::Text)) {
-    if (file.write(edit->toPlainText().toLatin1()) > 0) {
+    if (file.write(edit->toPlainText().toLocal8Bit()) > 0) {
       success = true;
     }
     file.close();
@@ -595,7 +595,7 @@ void InputGeneratorWidget::saveDirectory()
     QFile file(dir.absoluteFilePath(fileName));
     bool success = false;
     if (file.open(QFile::WriteOnly | QFile::Text)) {
-      if (file.write(edit->toPlainText().toLatin1()) > 0) {
+      if (file.write(edit->toPlainText().toLocal8Bit()) > 0) {
         success = true;
       }
       file.close();

--- a/avogadro/qtplugins/apbs/apbsdialog.cpp
+++ b/avogadro/qtplugins/apbs/apbsdialog.cpp
@@ -198,7 +198,7 @@ void ApbsDialog::saveInputFile(const QString& fileName)
 
   QFile file(fileName);
   file.open(QFile::WriteOnly);
-  file.write(contents.toLatin1());
+  file.write(contents.toLocal8Bit());
   file.close();
 }
 

--- a/avogadro/qtplugins/gamessinput/gamessinputdialog.cpp
+++ b/avogadro/qtplugins/gamessinput/gamessinputdialog.cpp
@@ -677,7 +677,7 @@ void GamessInputDialog::generateClicked()
   QFile file(fileName);
   bool success = false;
   if (file.open(QFile::WriteOnly | QFile::Text)) {
-    if (file.write(ui.previewText->toPlainText().toLatin1()) > 0) {
+    if (file.write(ui.previewText->toPlainText().toLocal8Bit()) > 0) {
       success = true;
     }
     file.close();


### PR DESCRIPTION
This changed in Qt 5, fixes for non-Latin characters.