### PR TITLE
Added theoretical XRD pattern calculations

### DIFF
--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -120,6 +120,10 @@ add_subdirectory(spectra)
 add_subdirectory(vrml)
 add_subdirectory(workflows)
 
+if(USE_VTK)
+  add_subdirectory(plotxrd)
+endif()
+
 if(USE_MOLEQUEUE)
   add_subdirectory(apbs)
   add_subdirectory(mongochem)

--- a/avogadro/qtplugins/plotxrd/CMakeLists.txt
+++ b/avogadro/qtplugins/plotxrd/CMakeLists.txt
@@ -1,0 +1,31 @@
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
+
+# Download the executable if we are not to use the system one
+if(NOT USE_SYSTEM_GENXRDPATTERN)
+  include(DownloadGenXrdPattern)
+  DownloadGenXrdPattern()
+endif(NOT USE_SYSTEM_GENXRDPATTERN)
+
+set(plotxrd_srcs
+  plotxrd.cpp
+  xrdoptionsdialog.cpp
+  xrdvtkplot.cpp
+)
+
+set(plotxrd_uis
+  xrdoptionsdialog.ui
+)
+
+avogadro_plugin(PlotXrd
+  "Use ObjCryst++ to create an XRD plot."
+  ExtensionPlugin
+  plotxrd.h
+  PlotXrd
+  "${plotxrd_srcs}"
+  "${plotxrd_uis}"
+)
+
+target_link_libraries(PlotXrd LINK_PRIVATE ${VTK_LIBRARIES})

--- a/avogadro/qtplugins/plotxrd/plotxrd.cpp
+++ b/avogadro/qtplugins/plotxrd/plotxrd.cpp
@@ -1,0 +1,273 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include <QAction>
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDialog>
+#include <QFile>
+#include <QMessageBox>
+#include <QProcess>
+#include <QString>
+
+#include <avogadro/io/fileformatmanager.h>
+#include <avogadro/qtgui/molecule.h>
+
+#include "plotxrd.h"
+#include "xrdoptionsdialog.h"
+#include "xrdvtkplot.h"
+
+using Avogadro::QtGui::Molecule;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+PlotXrd::PlotXrd(QObject* parent_)
+  : Avogadro::QtGui::ExtensionPlugin(parent_), m_actions(QList<QAction*>()),
+    m_molecule(nullptr),
+    m_xrdOptionsDialog(new XrdOptionsDialog(qobject_cast<QWidget*>(parent()))),
+    m_displayDialogAction(new QAction(this))
+{
+  m_displayDialogAction->setText(tr("Plot Theoretical XRD Pattern..."));
+  connect(m_displayDialogAction.get(), &QAction::triggered, this,
+          &PlotXrd::displayDialog);
+  m_actions.push_back(m_displayDialogAction.get());
+  m_displayDialogAction->setProperty("menu priority", 90);
+
+  updateActions();
+}
+
+PlotXrd::~PlotXrd() = default;
+
+QList<QAction*> PlotXrd::actions() const
+{
+  return m_actions;
+}
+
+QStringList PlotXrd::menuPath(QAction*) const
+{
+  return QStringList() << tr("&Crystal");
+}
+
+void PlotXrd::setMolecule(QtGui::Molecule* mol)
+{
+  if (m_molecule == mol)
+    return;
+
+  if (m_molecule)
+    m_molecule->disconnect(this);
+
+  m_molecule = mol;
+
+  if (m_molecule)
+    connect(m_molecule, SIGNAL(changed(uint)), SLOT(moleculeChanged(uint)));
+
+  updateActions();
+}
+
+void PlotXrd::moleculeChanged(unsigned int c)
+{
+  Q_ASSERT(m_molecule == qobject_cast<Molecule*>(sender()));
+
+  Molecule::MoleculeChanges changes = static_cast<Molecule::MoleculeChanges>(c);
+
+  if (changes & Molecule::UnitCell) {
+    if (changes & Molecule::Added || changes & Molecule::Removed)
+      updateActions();
+  }
+}
+
+void PlotXrd::updateActions()
+{
+  // Disable everything for nullptr molecules.
+  if (!m_molecule) {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(false);
+    return;
+  }
+
+  // Only display the actions if there is a unit cell
+  if (m_molecule->unitCell()) {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(true);
+  } else {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(false);
+  }
+}
+
+void PlotXrd::displayDialog()
+{
+  // Do nothing if the user cancels
+  if (m_xrdOptionsDialog->exec() != QDialog::Accepted)
+    return;
+
+  // Otherwise, fetch the options and perform the run
+  double wavelength = m_xrdOptionsDialog->wavelength();
+  double peakwidth = m_xrdOptionsDialog->peakWidth();
+  size_t numpoints = m_xrdOptionsDialog->numDataPoints();
+  double max2theta = m_xrdOptionsDialog->max2Theta();
+
+  XrdData results;
+  QString err;
+  if (!generateXrdPattern(*m_molecule, results, err, wavelength, peakwidth,
+                          numpoints, max2theta)) {
+    QMessageBox::critical(qobject_cast<QWidget*>(parent()),
+                          tr("Failed to generate XRD pattern"),
+                          tr("Error message: ") + err);
+    return;
+  }
+
+  // Now generate a plot with the data
+  XrdVtkPlot::generatePlot(results);
+}
+
+bool PlotXrd::generateXrdPattern(const QtGui::Molecule& mol, XrdData& results,
+                                 QString& err, double wavelength,
+                                 double peakwidth, size_t numpoints,
+                                 double max2theta)
+{
+  // Get the molecule as a cif file
+  std::string cifData;
+  if (!Io::FileFormatManager::instance().writeString(mol, cifData, "cif")) {
+    err = tr("Failed to convert molecule to CIF format.");
+    qDebug() << "Error in" << __FUNCTION__ << ":" << err;
+    return false;
+  }
+
+  // Now, execute genXrdPattern with the given inputs
+  QStringList args;
+  args << "--read-from-stdin"
+       << "--wavelength=" + QString::number(wavelength)
+       << "--peakwidth=" + QString::number(peakwidth)
+       << "--numpoints=" + QString::number(numpoints)
+       << "--max2theta=" + QString::number(max2theta);
+
+  QByteArray output;
+  if (!executeGenXrdPattern(args, cifData.c_str(), output, err)) {
+    qDebug() << "Error in" << __FUNCTION__ << ":" << err;
+    return false;
+  }
+
+  // Store the results
+  results.clear();
+
+  // Find the section of data in the output
+  bool dataStarted = false;
+  QStringList lines =
+    QString(output).split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
+  for (const auto& line : lines) {
+    if (!dataStarted && line.contains("#    2Theta/TOF    ICalc")) {
+      dataStarted = true;
+      continue;
+    }
+
+    if (dataStarted) {
+      QStringList rowData = line.split(" ", QString::SkipEmptyParts);
+      if (rowData.size() != 2) {
+        err = tr("Data read from genXrdPattern appears to be corrupt!");
+        qDebug() << "Error in" << __FUNCTION__ << err;
+        qDebug() << "Data is:";
+        for (const auto& lineTmp : lines)
+          qDebug() << lineTmp;
+        return false;
+      }
+      results.push_back(
+        std::make_pair(rowData[0].toDouble(), rowData[1].toDouble()));
+    }
+  }
+
+  return true;
+}
+
+bool PlotXrd::executeGenXrdPattern(const QStringList& args,
+                                   const QByteArray& input, QByteArray& output,
+                                   QString& err)
+{
+  QString program;
+  // If the GENXRDPATTERN_EXECUTABLE environment variable is set, then
+  // use that
+  QByteArray xrdExec = qgetenv("GENXRDPATTERN_EXECUTABLE");
+  if (!xrdExec.isEmpty()) {
+    program = xrdExec;
+  } else {
+// Otherwise, search in the current directory, and then ../bin
+#ifdef _WIN32
+    QString executable = "genXrdPattern.exe";
+#else
+    QString executable = "genXrdPattern";
+#endif
+    QString path = QCoreApplication::applicationDirPath();
+    if (QFile::exists(path + "/" + executable))
+      program = path + "/" + executable;
+    else if (QFile::exists(path + "/../bin/" + executable))
+      program = path + "/../bin/" + executable;
+    else {
+      err = tr("Error: could not find genXrdPattern executable!");
+      qDebug() << err;
+      return false;
+    }
+  }
+
+  QProcess p;
+  p.start(program, args);
+
+  if (!p.waitForStarted()) {
+    err = tr("Error: " + program.toLocal8Bit() + " failed to start");
+    qDebug() << err;
+    return false;
+  }
+
+  // Give it the input!
+  p.write(input.data());
+
+  // Close the write channel
+  p.closeWriteChannel();
+
+  if (!p.waitForFinished()) {
+    err = tr("Error: " + program.toLocal8Bit() + " failed to finish");
+    qDebug() << err;
+    output = p.readAll();
+    qDebug() << "Output is as follows:\n" << output;
+    return false;
+  }
+
+  int exitStatus = p.exitStatus();
+  output = p.readAll();
+
+  if (exitStatus == QProcess::CrashExit) {
+    err = tr("Error: " + program.toLocal8Bit() + " crashed!");
+    qDebug() << err;
+    qDebug() << "Output is as follows:\n" << output;
+    return false;
+  }
+
+  if (exitStatus != QProcess::NormalExit) {
+    err = tr("Error: " + program.toLocal8Bit() +
+             " finished abnormally with exit code " +
+             QString::number(exitStatus).toLocal8Bit());
+    qDebug() << err;
+    qDebug() << "Output is as follows:\n" << output;
+    return false;
+  }
+
+  // We did it!
+  return true;
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/plotxrd/plotxrd.h
+++ b/avogadro/qtplugins/plotxrd/plotxrd.h
@@ -1,0 +1,99 @@
+/*******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_PLOTXRD_H
+#define AVOGADRO_QTPLUGINS_PLOTXRD_H
+
+#include <avogadro/qtgui/extensionplugin.h>
+
+#include <memory>
+
+// Forward declarations
+class QByteArray;
+class QStringList;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+class XrdOptionsDialog;
+
+// First item in the pair is 2*theta. Second is the intensity.
+typedef std::vector<std::pair<double, double>> XrdData;
+
+/**
+ * @brief Generate and plot a theoretical XRD pattern using ObjCryst++
+ */
+class PlotXrd : public Avogadro::QtGui::ExtensionPlugin
+{
+  Q_OBJECT
+public:
+  explicit PlotXrd(QObject* parent_ = 0);
+  ~PlotXrd();
+
+  QString name() const { return tr("PlotXrd"); }
+  QString description() const;
+  QList<QAction*> actions() const;
+  QStringList menuPath(QAction*) const;
+
+public slots:
+  void setMolecule(QtGui::Molecule* mol);
+
+  void moleculeChanged(unsigned int changes);
+
+private slots:
+  void updateActions();
+
+  void displayDialog();
+
+private:
+  // Generate an Xrd pattern from a crystal
+  // Writes the results to @p results, which is a vector of pairs of doubles
+  // (see definition above).
+  // err will be set to an error string if the function fails.
+  // wavelength is an Angstroms.
+  // peakwidth is in degrees.
+  // numpoints is an unsigned integer.
+  // max2theta is in degrees.
+  static bool generateXrdPattern(const QtGui::Molecule& mol, XrdData& results,
+                                 QString& err, double wavelength = 1.505600,
+                                 double peakwidth = 0.529580,
+                                 size_t numpoints = 1000,
+                                 double max2theta = 162.0);
+
+  // Use QProcess to execute genXrdPattern
+  // If the GENXRDPATTERN_EXECUTABLE environment variable is set, that will be
+  // used for the executable. Otherwise, it will search for the executable in
+  // some common places and use it if it can be found.
+  static bool executeGenXrdPattern(const QStringList& args,
+                                   const QByteArray& input, QByteArray& output,
+                                   QString& err);
+
+  QList<QAction*> m_actions;
+  QtGui::Molecule* m_molecule;
+
+  std::unique_ptr<XrdOptionsDialog> m_xrdOptionsDialog;
+  std::unique_ptr<QAction> m_displayDialogAction;
+};
+
+inline QString PlotXrd::description() const
+{
+  return tr("Generate and plot a theoretical XRD pattern using ObjCryst++.");
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_PLOTXRD_H

--- a/avogadro/qtplugins/plotxrd/xrdoptionsdialog.cpp
+++ b/avogadro/qtplugins/plotxrd/xrdoptionsdialog.cpp
@@ -1,0 +1,78 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "xrdoptionsdialog.h"
+#include "ui_xrdoptionsdialog.h"
+
+#include <QtCore/QSettings>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+XrdOptionsDialog::XrdOptionsDialog(QWidget* aParent)
+  : QDialog(aParent), m_ui(new Ui::XrdOptionsDialog)
+{
+  m_ui->setupUi(this);
+
+  // Read the settings
+  QSettings settings;
+  m_ui->spin_wavelength->setValue(
+    settings.value("plotxrdoptions/wavelength", 1.505600).toDouble());
+  m_ui->spin_peakWidth->setValue(
+    settings.value("plotxrdoptions/peakWidth", 0.529580).toDouble());
+  m_ui->spin_numDataPoints->setValue(
+    settings.value("plotxrdoptions/numDataPoints", 1000).toUInt());
+  m_ui->spin_max2Theta->setValue(
+    settings.value("plotxrdoptions/max2Theta", 162.0).toDouble());
+}
+
+XrdOptionsDialog::~XrdOptionsDialog() = default;
+
+double XrdOptionsDialog::wavelength() const
+{
+  return m_ui->spin_wavelength->value();
+}
+
+double XrdOptionsDialog::peakWidth() const
+{
+  return m_ui->spin_peakWidth->value();
+}
+
+size_t XrdOptionsDialog::numDataPoints() const
+{
+  return m_ui->spin_numDataPoints->value();
+}
+
+double XrdOptionsDialog::max2Theta() const
+{
+  return m_ui->spin_max2Theta->value();
+}
+
+void XrdOptionsDialog::accept()
+{
+  // Write the settings and accept
+  QSettings settings;
+  settings.setValue("plotxrdoptions/wavelength", wavelength());
+  settings.setValue("plotxrdoptions/peakWidth", peakWidth());
+  settings.setValue("plotxrdoptions/numDataPoints",
+                    static_cast<qlonglong>(numDataPoints()));
+  settings.setValue("plotxrdoptions/max2Theta", max2Theta());
+
+  QDialog::accept();
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/plotxrd/xrdoptionsdialog.h
+++ b/avogadro/qtplugins/plotxrd/xrdoptionsdialog.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_XRDOPTIONSDIALOG_H
+#define AVOGADRO_QTPLUGINS_XRDOPTIONSDIALOG_H
+
+#include <memory>
+
+#include <QDialog>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+namespace Ui {
+class XrdOptionsDialog;
+}
+
+/**
+ * @brief Dialog to set options for a theoretical XRD pattern calculation.
+ */
+class XrdOptionsDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit XrdOptionsDialog(QWidget* parent = 0);
+  ~XrdOptionsDialog();
+
+  double wavelength() const;
+  double peakWidth() const;
+  size_t numDataPoints() const;
+  double max2Theta() const;
+
+protected slots:
+  void accept();
+
+private:
+  std::unique_ptr<Ui::XrdOptionsDialog> m_ui;
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+#endif // AVOGADRO_QTPLUGINS_XRDOPTIONSDIALOG_H

--- a/avogadro/qtplugins/plotxrd/xrdoptionsdialog.ui
+++ b/avogadro/qtplugins/plotxrd/xrdoptionsdialog.ui
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Avogadro::QtPlugins::XrdOptionsDialog</class>
+ <widget class="QDialog" name="Avogadro::QtPlugins::XrdOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>324</width>
+    <height>237</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Theoretical XRD Pattern Options</string>
+  </property>
+  <property name="toolTip">
+   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The broadening of the peak at the base (in degrees).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1">
+    <widget class="QDoubleSpinBox" name="spin_max2Theta">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max 2theta value in degrees.&lt;/p&gt;&lt;p&gt;Default: 162.00°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>162.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QDoubleSpinBox" name="spin_peakWidth">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The broadening of the peaks at the base in degrees.&lt;/p&gt;&lt;p&gt;Default: 0.52958°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.529580000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Number of points:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Peak width:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Wavelength:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="spin_wavelength">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The wavelength of the x-ray in Angstroms. &lt;/p&gt;&lt;p&gt;Default: 1.50560 Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="suffix">
+      <string> Å</string>
+     </property>
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.505600000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="spin_numDataPoints">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of 2theta points to generate.&lt;/p&gt;&lt;p&gt;Default: 1000&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+     <property name="value">
+      <number>1000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="text">
+      <string>Max 2*theta:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>spin_wavelength</tabstop>
+  <tabstop>spin_peakWidth</tabstop>
+  <tabstop>spin_numDataPoints</tabstop>
+  <tabstop>spin_max2Theta</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Avogadro::QtPlugins::XrdOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>161</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Avogadro::QtPlugins::XrdOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>161</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/avogadro/qtplugins/plotxrd/xrdvtkplot.cpp
+++ b/avogadro/qtplugins/plotxrd/xrdvtkplot.cpp
@@ -1,0 +1,101 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include <vtkAxis.h>
+#include <vtkChartXY.h>
+#include <vtkContextScene.h>
+#include <vtkContextView.h>
+#include <vtkFloatArray.h>
+#include <vtkPlot.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+#include <vtkTextProperty.h>
+
+#include "xrdvtkplot.h"
+
+namespace Avogadro {
+namespace QtPlugins {
+
+void XrdVtkPlot::generatePlot(
+  const std::vector<std::pair<double, double>>& data)
+{
+  // Save the axes titles
+  const char* xTitle = "2 Theta";
+  const char* yTitle = "Intensity";
+
+  // Create a table and add two columns
+  vtkSmartPointer<vtkTable> table = vtkSmartPointer<vtkTable>::New();
+
+  vtkSmartPointer<vtkFloatArray> arrX = vtkSmartPointer<vtkFloatArray>::New();
+  arrX->SetName(xTitle);
+  table->AddColumn(arrX);
+
+  vtkSmartPointer<vtkFloatArray> arrY = vtkSmartPointer<vtkFloatArray>::New();
+  arrY->SetName(yTitle);
+  table->AddColumn(arrY);
+
+  // Put the data in the table
+  table->SetNumberOfRows(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    table->SetValue(i, 0, data[i].first);
+    table->SetValue(i, 1, data[i].second);
+  }
+
+  // Set up the view
+  vtkSmartPointer<vtkContextView> view = vtkSmartPointer<vtkContextView>::New();
+  view->GetRenderer()->SetBackground(1.0, 1.0, 1.0);
+  view->GetRenderWindow()->SetSize(600, 600);
+  view->GetRenderWindow()->SetWindowName("Theoretical XRD Pattern");
+
+  // Add the chart
+  vtkSmartPointer<vtkChartXY> chart = vtkSmartPointer<vtkChartXY>::New();
+  view->GetScene()->AddItem(chart);
+
+  vtkAxis* bottomAxis = chart->GetAxis(vtkAxis::BOTTOM);
+  vtkAxis* leftAxis = chart->GetAxis(vtkAxis::LEFT);
+
+  // Set the axis titles
+  bottomAxis->SetTitle(xTitle);
+  leftAxis->SetTitle(yTitle);
+
+  // Increase their title font sizes
+  bottomAxis->GetTitleProperties()->SetFontSize(20);
+  leftAxis->GetTitleProperties()->SetFontSize(20);
+
+  // Increase the tick font sizes
+  bottomAxis->GetLabelProperties()->SetFontSize(20);
+  leftAxis->GetLabelProperties()->SetFontSize(20);
+
+  // Adjust the range on the x axis
+  bottomAxis->SetBehavior(vtkAxis::FIXED);
+  bottomAxis->SetRange(data.front().first, data.back().first);
+
+  // Add the data to the chart
+  vtkPlot* line = chart->AddPlot(vtkChart::LINE);
+  line->SetInputData(table, 0, 1);
+  line->SetColor(255, 0, 0, 255);
+  line->SetWidth(2.0);
+
+  // Start interactor
+  view->GetInteractor()->Initialize();
+  view->GetInteractor()->Start();
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/plotxrd/xrdvtkplot.h
+++ b/avogadro/qtplugins/plotxrd/xrdvtkplot.h
@@ -28,7 +28,7 @@ namespace QtPlugins {
  */
 class XrdVtkPlot
 {
- public:
+public:
   static void generatePlot(const std::vector<std::pair<double, double>>& data);
 };
 

--- a/avogadro/qtplugins/plotxrd/xrdvtkplot.h
+++ b/avogadro/qtplugins/plotxrd/xrdvtkplot.h
@@ -1,0 +1,38 @@
+/*******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_XRDVTKPLOT_H
+#define AVOGADRO_QTPLUGINS_XRDVTKPLOT_H
+
+#include <utility>
+#include <vector>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+/**
+ * @brief Generate and plot using VTK
+ */
+class XrdVtkPlot
+{
+ public:
+  static void generatePlot(const std::vector<std::pair<double, double>>& data);
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_XRDVTKPLOT_H

--- a/cmake/DownloadGenXrdPattern.cmake
+++ b/cmake/DownloadGenXrdPattern.cmake
@@ -1,0 +1,65 @@
+# Written by Patrick S. Avery - 2018
+
+# Downloads the executable if it doesn't already exist
+macro(DownloadGenXrdPattern)
+
+  # Let's set the name. Windows likes to add '.exe' at the end
+  if(WIN32)
+    set(GENXRDPATTERN_NAME "genXrdPattern.exe")
+  else(WIN32)
+    set(GENXRDPATTERN_NAME "genXrdPattern")
+  endif(WIN32)
+
+  # If it already exists, don't download it again
+  if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/bin/${GENXRDPATTERN_NAME}")
+    set(GENXRDPATTERN_V "1.0-static")
+    # Linux
+    if(UNIX AND NOT APPLE)
+      set(GENXRDPATTERN_DOWNLOAD_LOCATION "https://github.com/psavery/genXrdPattern/releases/download/${GENXRDPATTERN_V}/linux64-genXrdPattern")
+      set(MD5 "e1b3c1d6b951ed83a037567490d75f1d")
+
+    # Apple
+    elseif(APPLE)
+      set(GENXRDPATTERN_DOWNLOAD_LOCATION "https://github.com/psavery/genXrdPattern/releases/download/${GENXRDPATTERN_V}/osx64-genXrdPattern")
+      set(MD5 "229b01c8efab981d812043684dae84fe")
+
+    # Windows
+    elseif(WIN32 AND NOT CYGWIN)
+      set(GENXRDPATTERN_DOWNLOAD_LOCATION "https://github.com/psavery/genXrdPattern/releases/download/${GENXRDPATTERN_V}/win64-genXrdPattern.exe")
+      set(MD5 "7b1a1e18a6044773c631189cbfd8b440")
+
+    else()
+      message(FATAL_ERROR
+              "GenXrdPattern is not supported with the current OS type!")
+    endif()
+
+    message(STATUS "Downloading genXrdPattern executable from ${GENXRDPATTERN_DOWNLOAD_LOCATION}")
+
+    # Install to a temporary directory so we can copy and change file
+    # permissions
+    file(DOWNLOAD "${GENXRDPATTERN_DOWNLOAD_LOCATION}"
+         "${CMAKE_CURRENT_BINARY_DIR}/tmp/${GENXRDPATTERN_NAME}"
+         SHOW_PROGRESS
+         EXPECTED_MD5 ${MD5})
+
+    # We need to change the permissions
+    file(COPY "${CMAKE_CURRENT_BINARY_DIR}/tmp/${GENXRDPATTERN_NAME}"
+         DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin/"
+         FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                          GROUP_READ GROUP_EXECUTE
+                          WORLD_READ WORLD_EXECUTE)
+
+    # Now remove the temporary directory
+    file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/tmp")
+
+  endif(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/bin/${GENXRDPATTERN_NAME}")
+
+  set(GENXRDPATTERN_DESTINATION "bin")
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bin/${GENXRDPATTERN_NAME}"
+          DESTINATION "${GENXRDPATTERN_DESTINATION}"
+          PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                      GROUP_READ GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE)
+
+endmacro(DownloadGenXrdPattern)


### PR DESCRIPTION
I added (as a plugin) the ability to calculate and plot a theoretical XRD pattern given a crystal.

This uses an external, static `genXrdPattern` executable to perform the calculation. The source for this program can be found [here](https://github.com/psavery/genXrdPattern).

The majority of the work comes from [ObjCryst++](https://github.com/vincefn/objcryst), though.

VTK is used to generate the plot. As such, this plugin will only be compiled if USE_VTK=ON (which also means that Travis-CI will not currently be testing it...).

Some images from Ubuntu:

![image](https://user-images.githubusercontent.com/9558430/35715983-dbff0788-07a3-11e8-859d-fd8dc093157f.png)

![image](https://user-images.githubusercontent.com/9558430/35715996-eb1b1b4e-07a3-11e8-8533-767e3cc00594.png)
(*Note: All of the dialog options have tooltips)

![image](https://user-images.githubusercontent.com/9558430/35715997-f046fa20-07a3-11e8-9397-0d12e7f78816.png)

The example shown is diamond. Note the [literature](http://rruff.info/Diamond/R050204) (although we have different x ranges):
![image](https://user-images.githubusercontent.com/9558430/35716129-b6928122-07a4-11e8-936c-9583a86d387a.png)

Note that compiling avogadroapp with -DUSE_VTK=ON only fully worked for me with [this pull request](https://github.com/OpenChemistry/avogadroapp/pull/66).

Also, the ability to interact with the VTK plot is pretty cool! But I think it blocks the Avogadro2 event loop (Avogadro2 will gray out in the background while the VTK plot is up, and it won't respond again until the VTK plot is closed). Maybe I should spawn the VTK plot in a separate thread? Let me know if there is a better option.

The static binaries are downloaded from [here](https://github.com/psavery/genXrdPattern/releases/tag/1.0-static), and they seem to work from the tests I've done on them.

Here are some outputs from some dynamic dependency analysis programs:
For Linux:
```
$ ldd linux64-genXrdPattern 
	not a dynamic executable
```

For Mac (compiled with backward compatibility to OS X 10.9):
```
$ otool -L osx64-genXrdPattern 
osx64-genXrdPattern:
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

For Windows:
```
>dumpbin /dependents win64-genXrdPattern.exe
Microsoft (R) COFF/PE Dumper Version 14.12.25834.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file win64-genXrdPattern.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    KERNEL32.dll
    msvcrt.dll
    USER32.dll
```

If the cmake option `USE_SYSTEM_GENXRDPATTERN` is set, the executable will not be downloaded.

When Avogadro2 is running, it searches for the `genXrdPattern` executable in the same directory as the `avogadro2` executable, and then it searches in `../bin/`. If the user has set the environment variable `GENXRDPATTERN_EXECUTABLE`, it will use that instead.

Please let me know what you think about all of this. Feel free to question any of my design decisions. I'm sure I can change several things around if needed. 