### PR TITLE
Update to use new VTK classes

### DIFF
--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -9,12 +9,12 @@ if(WIN32 AND NOT BUILD_SHARED_LIBS)
   add_definitions(-DGLEW_STATIC)
 endif()
 
-find_package(Qt5 COMPONENTS OpenGL REQUIRED)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 find_package(VTK
   COMPONENTS
-    vtkRenderingOpenGL vtkGUISupportQtOpenGL vtkDomainsChemistry
-    vtkRenderingVolumeOpenGL vtkViewsCore vtkRenderingFreeType
+    vtkRenderingOpenGL2 vtkGUISupportQt vtkDomainsChemistry
+    vtkRenderingVolumeOpenGL2 vtkViewsCore vtkRenderingFreeType
   REQUIRED)
 include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${VTK_DEFINITIONS})
@@ -30,8 +30,8 @@ set(SOURCES
 )
 
 avogadro_add_library(AvogadroVtk ${HEADERS} ${SOURCES})
-qt5_use_modules(AvogadroVtk OpenGL)
+qt5_use_modules(AvogadroVtk Widgets)
 set_target_properties(AvogadroVtk PROPERTIES AUTOMOC TRUE)
 target_link_libraries(AvogadroVtk AvogadroRendering AvogadroQtGui
-  vtkRenderingOpenGL vtkGUISupportQtOpenGL vtkRenderingVolumeOpenGL
-  vtkRenderingFreeType)
+  vtkRenderingOpenGL2 vtkGUISupportQt vtkRenderingVolumeOpenGL2
+  vtkRenderingFreeType vtkInteractionStyle)

--- a/avogadro/vtk/vtkglwidget.cpp
+++ b/avogadro/vtk/vtkglwidget.cpp
@@ -144,9 +144,8 @@ vtkVolume* cubeVolume(Core::Cube* cube)
   return volume;
 }
 
-vtkGLWidget::vtkGLWidget(QWidget* p, const QGLWidget* shareWidget,
-                         Qt::WindowFlags f)
-  : QVTKWidget2(p, shareWidget, f), m_activeTool(nullptr),
+vtkGLWidget::vtkGLWidget(QWidget* p, Qt::WindowFlags f)
+  : QVTKOpenGLWidget(p, f), m_activeTool(nullptr),
     m_defaultTool(nullptr)
 {
   setFocusPolicy(Qt::ClickFocus);
@@ -225,7 +224,7 @@ void vtkGLWidget::updateScene()
     }
 
     m_renderer.resetGeometry();
-    updateGL();
+    update();
   }
   if (mol != m_molecule)
     delete mol;
@@ -239,7 +238,7 @@ void vtkGLWidget::clearScene()
 void vtkGLWidget::resetCamera()
 {
   m_renderer.resetCamera();
-  updateGL();
+  update();
 }
 
 void vtkGLWidget::resetGeometry()

--- a/avogadro/vtk/vtkglwidget.h
+++ b/avogadro/vtk/vtkglwidget.h
@@ -18,7 +18,8 @@
 #define AVOGADRO_VTKGLWIDGET_H
 
 #include "avogadrovtkexport.h"
-#include <QVTKWidget2.h>
+
+#include <QVTKOpenGLWidget.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
@@ -42,13 +43,12 @@ class ToolPlugin;
 
 namespace VTK {
 
-class AVOGADROVTK_EXPORT vtkGLWidget : public QVTKWidget2
+class AVOGADROVTK_EXPORT vtkGLWidget : public QVTKOpenGLWidget
 {
   Q_OBJECT
 
 public:
-  vtkGLWidget(QWidget* p = nullptr, const QGLWidget* shareWidget = 0,
-              Qt::WindowFlags f = 0);
+  vtkGLWidget(QWidget* p = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
   ~vtkGLWidget();
 
   /** Set the molecule the widget will render. */


### PR DESCRIPTION
This is a minimal port to get our code compiling with VTK master from
today. It uses the OpenGL2 backend (OpenGL is deprecated). It switches
to the new QVTKOpenGLWidget as a base, which is based on the newer
QOpenGLWidget from Qt. This removes the Qt OpeGL module dependency
too.