### PR TITLE
Find Spglib under different name

### DIFF
--- a/cmake/FindSpglib.cmake
+++ b/cmake/FindSpglib.cmake
@@ -7,7 +7,7 @@
 #  SPGLIB_LIBRARY      - The Spglib library
 #
 find_path(SPGLIB_INCLUDE_DIR spglib/spglib.h)
-find_library(SPGLIB_LIBRARY NAMES spglib)
+find_library(SPGLIB_LIBRARY NAMES spglib symspg)
 
 set(SPGLIB_INCLUDE_DIRS "${SPGLIB_INCLUDE_DIR}")
 


### PR DESCRIPTION
I'm not entirely sure where the only listed name cmake searches for
originates from, but vanilla upstream only installs a libsymspg.

https://github.com/atztogo/spglib/blob/5a9ba105f4936000b8174093c10dc85ad423ebb0/CMakeLists.txt#L53
https://github.com/atztogo/spglib/blob/5a9ba105f4936000b8174093c10dc85ad423ebb0/src/Makefile.am#L1