### PR TITLE
Adds local development path check for input generators

### DIFF
--- a/avogadro/qtplugins/quantuminput/quantuminput.cpp
+++ b/avogadro/qtplugins/quantuminput/quantuminput.cpp
@@ -38,6 +38,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QSettings>
+#include <QtCore/QStandardPaths>
 #include <QtCore/QStringList>
 #include <QtCore/QtPlugin>
 
@@ -209,6 +210,12 @@ void QuantumInput::updateInputGeneratorScripts()
   dirs << QCoreApplication::applicationDirPath() + "/../" +
             QtGui::Utilities::libraryDirectory() +
             "/avogadro2/scripts/inputGenerators";
+  QStringList stdPaths =
+    QStandardPaths::standardLocations(QStandardPaths::AppLocalDataLocation);
+  foreach (const QString& dirStr, stdPaths) {
+    QString path = dirStr + "/dev/inputGenerators";
+    dirs << path;
+  }
 
   foreach (const QString& dirStr, dirs) {
     qDebug() << "Checking for generator scripts in" << dirStr;


### PR DESCRIPTION
This commit adds search for generator scripts in local development paths contained by <QStandardPaths::AppLocalDataLocation>/dev/inputGenerators. 
