### PR TITLE
Fix for glitch in file writer error dialog

### DIFF
--- a/avogadro/qtgui/fileformatdialog.cpp
+++ b/avogadro/qtgui/fileformatdialog.cpp
@@ -120,7 +120,7 @@ FileFormatDialog::FormatFilePair FileFormatDialog::fileToWrite(
     result.first = format;
     result.second = fileName;
 
-  } while (false);
+  } while (true);
 
   return result;
 }


### PR DESCRIPTION
Fixes the glitch that rendered the "Retry" button in the file writer error dialog flawed.