### PR TITLE
cppcheck: fix same expression

### DIFF
--- a/avogadro/qtgui/fileformatdialog.cpp
+++ b/avogadro/qtgui/fileformatdialog.cpp
@@ -150,7 +150,7 @@ const Io::FileFormat* FileFormatDialog::findFileFormat(
 
   if ((formatFlags & FileFormat::Read && formatFlags & FileFormat::Write) ||
       ((formatFlags & FileFormat::Read) == 0 &&
-       (formatFlags & FileFormat::Read) == 0)) {
+       (formatFlags & FileFormat::Write) == 0)) {
     // Both or neither read/write
     noun = tr("handlers", "File handlers");
     verb = tr("handle", "e.g. file handlers that can 'handle' this file.");


### PR DESCRIPTION
[avogadro/qtgui/fileformatdialog.cpp:152] -> [avogadro/qtgui/fileformatdialog.cpp:152]: (style) Same expression on both sides of '&&'.