### PR TITLE
Remove the dependency on MoleQueue

### DIFF
--- a/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
+++ b/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
@@ -1,7 +1,3 @@
-# Pull in MoleQueue -- just for QtJson right now...
-find_package(MoleQueue REQUIRED NO_MODULE)
-include_directories(${MoleQueue_INCLUDE_DIRS})
-
 set(scriptfileformats_srcs
   scriptfileformats.cpp
   fileformatscript.cpp


### PR DESCRIPTION
This was leftover from when we used Qt 4, and QJson was supplied by
MoleQueue. It is no longer needed. Fixes #241.