### PR TITLE
Clean up symmetry code to use const-correct version of libmsym.

### DIFF
--- a/avogadro/qtplugins/symmetry/CMakeLists.txt
+++ b/avogadro/qtplugins/symmetry/CMakeLists.txt
@@ -35,15 +35,3 @@ avogadro_plugin(SymmetryScene
 target_link_libraries(Symmetry LINK_PRIVATE ${LIBMSYM_LIBRARIES})
 target_link_libraries(SymmetryScene LINK_PRIVATE AvogadroRendering)
 
-
-#[[
-add_subdirectory(libmsym)
-
-
-need this in libmsym
-install(TARGETS libmsym
-    EXPORT "AvogadroLibsTargets"
-    RUNTIME DESTINATION "${INSTALL_RUNTIME_DIR}"
-    LIBRARY DESTINATION "${INSTALL_LIBRARY_DIR}/avogadro2/plugins"
-    ARCHIVE DESTINATION "${INSTALL_ARCHIVE_DIR}/avogadro2/staticplugins")
-]]

--- a/avogadro/qtplugins/symmetry/operationstablemodel.cpp
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.cpp
@@ -34,7 +34,7 @@ OperationsTableModel::~OperationsTableModel()
 }
 
 void OperationsTableModel::setOperations(
-  int operations_size, msym::msym_symmetry_operation_t* operations)
+  int operations_size, const msym::msym_symmetry_operation_t* operations)
 {
   beginResetModel();
   m_operations_size = operations_size;

--- a/avogadro/qtplugins/symmetry/operationstablemodel.h
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.h
@@ -57,11 +57,11 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation, int role) const;
 
   void setOperations(int operations_size,
-                     msym::msym_symmetry_operation_t* operations);
+                     const msym::msym_symmetry_operation_t* operations);
   void clearOperations();
 
 private:
-  msym::msym_symmetry_operation_t* m_operations;
+  const msym::msym_symmetry_operation_t* m_operations;
   int m_operations_size;
 };
 }

--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -197,8 +197,8 @@ void Symmetry::detectSymmetry()
   double cm[3], radius = 0.0, symerr = 0.0;
 
   /* Do not free these variables */
-  msym_symmetry_operation_t* msops = NULL;
-  msym_subgroup_t* msg = NULL;
+  const msym_symmetry_operation_t* msops = NULL;
+  const msym_subgroup_t* msg = NULL;
   int msgl = 0, msopsl = 0, mlength = 0;
 
   // initialize the c-style array of atom names and coordinates

--- a/avogadro/qtplugins/symmetry/symmetryutil.cpp
+++ b/avogadro/qtplugins/symmetry/symmetryutil.cpp
@@ -21,7 +21,7 @@ namespace QtPlugins {
 
 namespace SymmetryUtil {
 
-QString pointGroupSymbol(char* point_group)
+QString pointGroupSymbol(const char* point_group)
 {
   QString pointGroup(point_group);
   if (pointGroup.isEmpty())

--- a/avogadro/qtplugins/symmetry/symmetryutil.h
+++ b/avogadro/qtplugins/symmetry/symmetryutil.h
@@ -50,7 +50,7 @@ namespace Avogadro {
 namespace QtPlugins {
 
 namespace SymmetryUtil {
-QString pointGroupSymbol(char* point_group);
+QString pointGroupSymbol(const char* point_group);
 QString operationSymbol(const msym::msym_symmetry_operation_t* operation);
 }
 }

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -220,7 +220,7 @@ void SymmetryWidget::subgroupsSelectionChanged(const QItemSelection& selected,
   qDebug() << "index " << sgi;
   if (sgi < 0 || sgi >= m_sgl)
     return;
-  msym::msym_subgroup_t* sg = &m_sg[sgi];
+  const msym::msym_subgroup_t* sg = &m_sg[sgi];
   // m_ui->operationsTable->selectionModel()->clear();
 
   QItemSelectionModel* selectionModel = m_ui->operationsTable->selectionModel();
@@ -264,7 +264,7 @@ void SymmetryWidget::setPointGroupSymbol(QString pg)
 }
 
 void SymmetryWidget::setSymmetryOperations(
-  int sopsl, msym::msym_symmetry_operation_t* sops)
+  int sopsl, const msym::msym_symmetry_operation_t* sops)
 {
   m_sops = sops;
   m_sopsl = sopsl;
@@ -281,7 +281,7 @@ void SymmetryWidget::setSymmetryOperations(
 
 #include <stdio.h>
 
-void SymmetryWidget::setSubgroups(int sgl, msym::msym_subgroup_t* sg)
+void SymmetryWidget::setSubgroups(int sgl, const msym::msym_subgroup_t* sg)
 {
   m_sg = sg;
   m_sgl = sgl;

--- a/avogadro/qtplugins/symmetry/symmetrywidget.h
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.h
@@ -73,8 +73,9 @@ public slots:
   void moleculeChanged(unsigned int changes);
 
   void setPointGroupSymbol(QString pg);
-  void setSymmetryOperations(int sopsl, msym::msym_symmetry_operation_t* sops);
-  void setSubgroups(int sgl, msym::msym_subgroup_t* sg);
+  void setSymmetryOperations(int sopsl,
+                             const msym::msym_symmetry_operation_t* sops);
+  void setSubgroups(int sgl, const msym::msym_subgroup_t* sg);
   void setCenterOfMass(double cm[3]);
   void setRadius(double radius);
   msym::msym_thresholds_t* getThresholds() const;
@@ -92,8 +93,8 @@ private:
   QtGui::Molecule* m_molecule;
   QVector3D m_cm;
 
-  msym::msym_symmetry_operation_t* m_sops;
-  msym::msym_subgroup_t* m_sg;
+  const msym::msym_symmetry_operation_t* m_sops;
+  const msym::msym_subgroup_t* m_sg;
   int m_sopsl, m_sgl;
   double m_radius;
 


### PR DESCRIPTION
Should solve #242 exposed by building "native" libmsym.