### PR TITLE
Display symmetry equivalences

### DIFF
--- a/avogadro/qtplugins/symmetry/CMakeLists.txt
+++ b/avogadro/qtplugins/symmetry/CMakeLists.txt
@@ -35,15 +35,3 @@ avogadro_plugin(SymmetryScene
 target_link_libraries(Symmetry LINK_PRIVATE ${LIBMSYM_LIBRARIES})
 target_link_libraries(SymmetryScene LINK_PRIVATE AvogadroRendering)
 
-
-#[[
-add_subdirectory(libmsym)
-
-
-need this in libmsym
-install(TARGETS libmsym
-    EXPORT "AvogadroLibsTargets"
-    RUNTIME DESTINATION "${INSTALL_RUNTIME_DIR}"
-    LIBRARY DESTINATION "${INSTALL_LIBRARY_DIR}/avogadro2/plugins"
-    ARCHIVE DESTINATION "${INSTALL_ARCHIVE_DIR}/avogadro2/staticplugins")
-]]

--- a/avogadro/qtplugins/symmetry/operationstablemodel.cpp
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.cpp
@@ -34,7 +34,7 @@ OperationsTableModel::~OperationsTableModel()
 }
 
 void OperationsTableModel::setOperations(
-  int operations_size, msym::msym_symmetry_operation_t* operations)
+  int operations_size, const msym::msym_symmetry_operation_t* operations)
 {
   beginResetModel();
   m_operations_size = operations_size;

--- a/avogadro/qtplugins/symmetry/operationstablemodel.h
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.h
@@ -57,11 +57,11 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation, int role) const;
 
   void setOperations(int operations_size,
-                     msym::msym_symmetry_operation_t* operations);
+                     const msym::msym_symmetry_operation_t* operations);
   void clearOperations();
 
 private:
-  msym::msym_symmetry_operation_t* m_operations;
+  const msym::msym_symmetry_operation_t* m_operations;
   int m_operations_size;
 };
 }

--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -197,8 +197,8 @@ void Symmetry::detectSymmetry()
   double cm[3], radius = 0.0, symerr = 0.0;
 
   /* Do not free these variables */
-  msym_symmetry_operation_t* msops = NULL;
-  msym_subgroup_t* msg = NULL;
+  const msym_symmetry_operation_t* msops = NULL;
+  const msym_subgroup_t* msg = NULL;
   int msgl = 0, msopsl = 0, mlength = 0;
 
   // initialize the c-style array of atom names and coordinates

--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -199,7 +199,8 @@ void Symmetry::detectSymmetry()
   /* Do not free these variables */
   const msym_symmetry_operation_t* msops = NULL;
   const msym_subgroup_t* msg = NULL;
-  int msgl = 0, msopsl = 0, mlength = 0;
+  const msym_equivalence_set_t *mes = NULL;
+  int mesl = 0, msgl = 0, msopsl = 0, mlength = 0;
 
   // initialize the c-style array of atom names and coordinates
   msym_element_t* a;
@@ -230,6 +231,7 @@ void Symmetry::detectSymmetry()
   if (MSYM_SUCCESS != (ret = msymSetElements(m_ctx, length, elements))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -240,6 +242,7 @@ void Symmetry::detectSymmetry()
   if (MSYM_SUCCESS != (ret = msymFindSymmetry(m_ctx))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -252,6 +255,7 @@ void Symmetry::detectSymmetry()
       (ret = msymGetPointGroupName(m_ctx, sizeof(char[6]), point_group))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -263,6 +267,19 @@ void Symmetry::detectSymmetry()
       (ret = msymGetSymmetryOperations(m_ctx, &msopsl, &msops))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
+    m_symmetryWidget->setSymmetryOperations(0, NULL);
+    m_symmetryWidget->setSubgroups(0, NULL);
+    qDebug() << "Error:" << msymErrorString(ret) << " "
+             << msymGetErrorDetails();
+    return;
+  }
+
+  if (MSYM_SUCCESS !=
+      (ret = msymGetEquivalenceSets(m_ctx, &mesl, &mes)) ) {
+    free(elements);
+    m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -273,6 +290,7 @@ void Symmetry::detectSymmetry()
   if (MSYM_SUCCESS != (ret = msymGetCenterOfMass(m_ctx, cm))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -283,6 +301,7 @@ void Symmetry::detectSymmetry()
   if (MSYM_SUCCESS != (ret = msymGetRadius(m_ctx, &radius))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+    m_symmetryWidget->setEquivalenceSets(0, NULL);
     m_symmetryWidget->setSymmetryOperations(0, NULL);
     m_symmetryWidget->setSubgroups(0, NULL);
     qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -294,6 +313,7 @@ void Symmetry::detectSymmetry()
     if (MSYM_SUCCESS != (ret = msymGetSubgroups(m_ctx, &msgl, &msg))) {
       free(elements);
       m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
+      m_symmetryWidget->setEquivalenceSets(0, NULL);
       m_symmetryWidget->setSymmetryOperations(0, NULL);
       m_symmetryWidget->setSubgroups(0, NULL);
       qDebug() << "Error:" << msymErrorString(ret) << " "
@@ -310,6 +330,7 @@ void Symmetry::detectSymmetry()
   // for(int i = 0; i < msgl;i++) printf("\t [%d] %s\n",i+1,msg[i].name);
 
   m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(point_group));
+  m_symmetryWidget->setEquivalenceSets(mesl, mes);
   m_symmetryWidget->setSymmetryOperations(msopsl, msops);
   m_symmetryWidget->setSubgroups(msgl, msg);
   m_symmetryWidget->setCenterOfMass(cm);

--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -42,8 +42,10 @@ namespace Avogadro {
 namespace QtPlugins {
 
 Symmetry::Symmetry(QObject* parent_)
-  : Avogadro::QtGui::ExtensionPlugin(parent_), m_molecule(NULL),
-    m_symmetryWidget(nullptr), m_viewSymmetryAction(new QAction(this))
+  : Avogadro::QtGui::ExtensionPlugin(parent_)
+  , m_molecule(NULL)
+  , m_symmetryWidget(nullptr)
+  , m_viewSymmetryAction(new QAction(this))
 {
 
   m_ctx = msymCreateContext();
@@ -165,7 +167,8 @@ void Symmetry::viewSymmetry()
     m_symmetryWidget = new SymmetryWidget(qobject_cast<QWidget*>(parent()));
     m_symmetryWidget->setMolecule(m_molecule);
     connect(m_symmetryWidget, SIGNAL(detectSymmetry()), SLOT(detectSymmetry()));
-    connect(m_symmetryWidget, SIGNAL(symmetrizeMolecule()),
+    connect(m_symmetryWidget,
+            SIGNAL(symmetrizeMolecule()),
             SLOT(symmetrizeMolecule()));
   }
 
@@ -199,7 +202,7 @@ void Symmetry::detectSymmetry()
   /* Do not free these variables */
   const msym_symmetry_operation_t* msops = NULL;
   const msym_subgroup_t* msg = NULL;
-  const msym_equivalence_set_t *mes = NULL;
+  const msym_equivalence_set_t* mes = NULL;
   int mesl = 0, msgl = 0, msopsl = 0, mlength = 0;
 
   // initialize the c-style array of atom names and coordinates
@@ -275,8 +278,7 @@ void Symmetry::detectSymmetry()
     return;
   }
 
-  if (MSYM_SUCCESS !=
-      (ret = msymGetEquivalenceSets(m_ctx, &mesl, &mes)) ) {
+  if (MSYM_SUCCESS != (ret = msymGetEquivalenceSets(m_ctx, &mesl, &mes))) {
     free(elements);
     m_symmetryWidget->setPointGroupSymbol(pointGroupSymbol(0));
     m_symmetryWidget->setEquivalenceSets(0, NULL);

--- a/avogadro/qtplugins/symmetry/symmetryutil.cpp
+++ b/avogadro/qtplugins/symmetry/symmetryutil.cpp
@@ -21,7 +21,7 @@ namespace QtPlugins {
 
 namespace SymmetryUtil {
 
-QString pointGroupSymbol(char* point_group)
+QString pointGroupSymbol(const char* point_group)
 {
   QString pointGroup(point_group);
   if (pointGroup.isEmpty())

--- a/avogadro/qtplugins/symmetry/symmetryutil.h
+++ b/avogadro/qtplugins/symmetry/symmetryutil.h
@@ -50,7 +50,7 @@ namespace Avogadro {
 namespace QtPlugins {
 
 namespace SymmetryUtil {
-QString pointGroupSymbol(char* point_group);
+QString pointGroupSymbol(const char* point_group);
 QString operationSymbol(const msym::msym_symmetry_operation_t* operation);
 }
 }

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -98,7 +98,7 @@ SymmetryWidget::SymmetryWidget(QWidget* parent_)
           SIGNAL(symmetrizeMolecule()));
 
   connect(
-    m_ui->subgroupsTree->selectionModel(),
+    m_ui->equivalenceTree->selectionModel(),
     SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
     SLOT(
       equivalenceSelectionChanged(const QItemSelection&, const QItemSelection&)));
@@ -288,15 +288,24 @@ void SymmetryWidget::equivalenceSelectionChanged(const QItemSelection& selected,
 
   unsigned int length = m_molecule->atomCount();
   for (Index i = 0; i < length; ++i) {
+    qDebug() << "checking atom" << i << " for " << a->n;
+    m_molecule->setAtomSelected(i, false);
     if (m_molecule->atomicNumbers()[i] != a->n)
       continue;
 
     Vector3 ipos = m_molecule->atomPositions3d()[i];
-    if (a->v[0] == ipos[0]
-        && a->v[1] == ipos[1]
-        && a->v[2] == ipos[2])
-      m_molecule->setAtomSelected(i, true);
+    qDebug() << a->v[0] << ipos[0] - m_cm[0];
+    qDebug() << a->v[1] << ipos[1] - m_cm[1];
+    qDebug() << a->v[2] << ipos[2] - m_cm[2];
+    if ( fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
+        && fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
+        && fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
+       ) {
+          m_molecule->setAtomSelected(i, true);
+          qDebug() << " got one!";
+        }
   }
+  m_molecule->emitChanged(QtGui::Molecule::Atoms);
 }
 
 void SymmetryWidget::setRadius(double radius)

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -74,11 +74,18 @@ msym_thresholds_t sloppy_thresholds = {
 };
 
 SymmetryWidget::SymmetryWidget(QWidget* parent_)
-  : QWidget(parent_), m_ui(new Ui::SymmetryWidget), m_molecule(NULL),
-    m_equivalenceTreeModel(new QStandardItemModel(this)),
-    m_operationsTableModel(new OperationsTableModel(this)),
-    m_subgroupsTreeModel(new QStandardItemModel(this)),
-    m_es(NULL), m_sops(NULL), m_sg(NULL), m_sopsl(0), m_sgl(0), m_radius(0.0)
+  : QWidget(parent_)
+  , m_ui(new Ui::SymmetryWidget)
+  , m_molecule(NULL)
+  , m_equivalenceTreeModel(new QStandardItemModel(this))
+  , m_operationsTableModel(new OperationsTableModel(this))
+  , m_subgroupsTreeModel(new QStandardItemModel(this))
+  , m_es(NULL)
+  , m_sops(NULL)
+  , m_sg(NULL)
+  , m_sopsl(0)
+  , m_sgl(0)
+  , m_radius(0.0)
 {
   setWindowFlags(Qt::Dialog);
   m_ui->setupUi(this);
@@ -92,16 +99,17 @@ SymmetryWidget::SymmetryWidget(QWidget* parent_)
   m_ui->subgroupsTree->setModel(m_subgroupsTreeModel);
   m_ui->subgroupsTree->setItemDelegateForColumn(0, new RichTextDelegate(this));
 
-  connect(m_ui->detectSymmetryButton, SIGNAL(clicked()),
-          SIGNAL(detectSymmetry()));
-  connect(m_ui->symmetrizeMoleculeButton, SIGNAL(clicked()),
+  connect(
+    m_ui->detectSymmetryButton, SIGNAL(clicked()), SIGNAL(detectSymmetry()));
+  connect(m_ui->symmetrizeMoleculeButton,
+          SIGNAL(clicked()),
           SIGNAL(symmetrizeMolecule()));
 
   connect(
     m_ui->equivalenceTree->selectionModel(),
     SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-    SLOT(
-      equivalenceSelectionChanged(const QItemSelection&, const QItemSelection&)));
+    SLOT(equivalenceSelectionChanged(const QItemSelection&,
+                                     const QItemSelection&)));
 
   connect(
     m_ui->operationsTable->selectionModel(),
@@ -142,7 +150,8 @@ void SymmetryWidget::moleculeChanged(unsigned int changes)
 }
 
 void SymmetryWidget::operationsSelectionChanged(
-  const QItemSelection& selected, const QItemSelection& deselected)
+  const QItemSelection& selected,
+  const QItemSelection& deselected)
 {
 
   if (!m_molecule)
@@ -259,8 +268,9 @@ void SymmetryWidget::subgroupsSelectionChanged(const QItemSelection& selected,
   selectionModel->select(selection, QItemSelectionModel::ClearAndSelect);
 }
 
-void SymmetryWidget::equivalenceSelectionChanged(const QItemSelection& selected,
-                                               const QItemSelection& deselected)
+void SymmetryWidget::equivalenceSelectionChanged(
+  const QItemSelection& selected,
+  const QItemSelection& deselected)
 {
   QModelIndex i =
     m_ui->equivalenceTree->selectionModel()->selectedIndexes().first();
@@ -281,8 +291,8 @@ void SymmetryWidget::equivalenceSelectionChanged(const QItemSelection& selected,
   if (!m_molecule)
     return;
 
-  const msym_equivalence_set_t *smes = &m_es[group];
-  const msym_element_t *a = smes->elements[atomInGroup];
+  const msym_equivalence_set_t* smes = &m_es[group];
+  const msym_element_t* a = smes->elements[atomInGroup];
   if (a == NULL)
     return;
 
@@ -297,13 +307,12 @@ void SymmetryWidget::equivalenceSelectionChanged(const QItemSelection& selected,
     qDebug() << a->v[0] << ipos[0] - m_cm[0];
     qDebug() << a->v[1] << ipos[1] - m_cm[1];
     qDebug() << a->v[2] << ipos[2] - m_cm[2];
-    if ( fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
-        && fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
-        && fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05
-       ) {
-          m_molecule->setAtomSelected(i, true);
-          qDebug() << " got one!";
-        }
+    if (fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05 &&
+        fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05 &&
+        fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05) {
+      m_molecule->setAtomSelected(i, true);
+      qDebug() << " got one!";
+    }
   }
   m_molecule->emitChanged(QtGui::Molecule::Atoms);
 }
@@ -324,7 +333,8 @@ void SymmetryWidget::setPointGroupSymbol(QString pg)
 }
 
 void SymmetryWidget::setSymmetryOperations(
-  int sopsl, const msym::msym_symmetry_operation_t* sops)
+  int sopsl,
+  const msym::msym_symmetry_operation_t* sops)
 {
   m_sops = sops;
   m_sopsl = sopsl;
@@ -340,7 +350,7 @@ void SymmetryWidget::setSymmetryOperations(
 }
 
 void SymmetryWidget::setEquivalenceSets(int esl,
-  const msym::msym_equivalence_set_t* es)
+                                        const msym::msym_equivalence_set_t* es)
 {
   m_esl = esl;
   m_es = es;
@@ -351,11 +361,11 @@ void SymmetryWidget::setEquivalenceSets(int esl,
     parent->setText(label);
     parent->setData(i, Qt::UserRole);
     m_equivalenceTreeModel->appendRow(parent);
-    const msym_equivalence_set_t *smes = &es[i];
+    const msym_equivalence_set_t* smes = &es[i];
     for (int j = 0; j < smes->length; j++) {
       QStandardItem* const child = new QStandardItem;
-      label = tr("%1 %2").arg(smes->elements[j]->name)
-                 .arg(QString::number(j + 1));
+      label =
+        tr("%1 %2").arg(smes->elements[j]->name).arg(QString::number(j + 1));
       child->setText(label);
       child->setData(j, Qt::UserRole);
       parent->appendRow(child);

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -220,7 +220,7 @@ void SymmetryWidget::subgroupsSelectionChanged(const QItemSelection& selected,
   qDebug() << "index " << sgi;
   if (sgi < 0 || sgi >= m_sgl)
     return;
-  msym::msym_subgroup_t* sg = &m_sg[sgi];
+  const msym::msym_subgroup_t* sg = &m_sg[sgi];
   // m_ui->operationsTable->selectionModel()->clear();
 
   QItemSelectionModel* selectionModel = m_ui->operationsTable->selectionModel();
@@ -264,7 +264,7 @@ void SymmetryWidget::setPointGroupSymbol(QString pg)
 }
 
 void SymmetryWidget::setSymmetryOperations(
-  int sopsl, msym::msym_symmetry_operation_t* sops)
+  int sopsl, const msym::msym_symmetry_operation_t* sops)
 {
   m_sops = sops;
   m_sopsl = sopsl;
@@ -281,7 +281,7 @@ void SymmetryWidget::setSymmetryOperations(
 
 #include <stdio.h>
 
-void SymmetryWidget::setSubgroups(int sgl, msym::msym_subgroup_t* sg)
+void SymmetryWidget::setSubgroups(int sgl, const msym::msym_subgroup_t* sg)
 {
   m_sg = sg;
   m_sgl = sgl;

--- a/avogadro/qtplugins/symmetry/symmetrywidget.h
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.h
@@ -73,8 +73,9 @@ public slots:
   void moleculeChanged(unsigned int changes);
 
   void setPointGroupSymbol(QString pg);
-  void setSymmetryOperations(int sopsl, msym::msym_symmetry_operation_t* sops);
-  void setSubgroups(int sgl, msym::msym_subgroup_t* sg);
+  void setSymmetryOperations(int sopsl,
+                             const msym::msym_symmetry_operation_t* sops);
+  void setSubgroups(int sgl, const msym::msym_subgroup_t* sg);
   void setCenterOfMass(double cm[3]);
   void setRadius(double radius);
   msym::msym_thresholds_t* getThresholds() const;
@@ -92,8 +93,8 @@ private:
   QtGui::Molecule* m_molecule;
   QVector3D m_cm;
 
-  msym::msym_symmetry_operation_t* m_sops;
-  msym::msym_subgroup_t* m_sg;
+  const msym::msym_symmetry_operation_t* m_sops;
+  const msym::msym_subgroup_t* m_sg;
   int m_sopsl, m_sgl;
   double m_radius;
 

--- a/avogadro/qtplugins/symmetry/symmetrywidget.h
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.h
@@ -34,7 +34,8 @@
 // class QPlainTextEdit;
 
 namespace msym {
-extern "C" {
+extern "C"
+{
 #include <libmsym/msym.h>
 }
 }
@@ -73,19 +74,17 @@ public slots:
   void moleculeChanged(unsigned int changes);
 
   void setPointGroupSymbol(QString pg);
-  void setEquivalenceSets(int mesl,
-                          const msym::msym_equivalence_set_t* es);
+  void setEquivalenceSets(int mesl, const msym::msym_equivalence_set_t* es);
   void setSymmetryOperations(int sopsl,
                              const msym::msym_symmetry_operation_t* sops);
-  void setSubgroups(int sgl,
-                    const msym::msym_subgroup_t* sg);
+  void setSubgroups(int sgl, const msym::msym_subgroup_t* sg);
   void setCenterOfMass(double cm[3]);
   void setRadius(double radius);
   msym::msym_thresholds_t* getThresholds() const;
 
 private slots:
   void equivalenceSelectionChanged(const QItemSelection& selected,
-                                  const QItemSelection& deselected);
+                                   const QItemSelection& deselected);
   void operationsSelectionChanged(const QItemSelection& selected,
                                   const QItemSelection& deselected);
   void subgroupsSelectionChanged(const QItemSelection& selected,

--- a/avogadro/qtplugins/symmetry/symmetrywidget.h
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.h
@@ -73,14 +73,19 @@ public slots:
   void moleculeChanged(unsigned int changes);
 
   void setPointGroupSymbol(QString pg);
+  void setEquivalenceSets(int mesl,
+                          const msym::msym_equivalence_set_t* es);
   void setSymmetryOperations(int sopsl,
                              const msym::msym_symmetry_operation_t* sops);
-  void setSubgroups(int sgl, const msym::msym_subgroup_t* sg);
+  void setSubgroups(int sgl,
+                    const msym::msym_subgroup_t* sg);
   void setCenterOfMass(double cm[3]);
   void setRadius(double radius);
   msym::msym_thresholds_t* getThresholds() const;
 
 private slots:
+  void equivalenceSelectionChanged(const QItemSelection& selected,
+                                  const QItemSelection& deselected);
   void operationsSelectionChanged(const QItemSelection& selected,
                                   const QItemSelection& deselected);
   void subgroupsSelectionChanged(const QItemSelection& selected,
@@ -88,14 +93,16 @@ private slots:
 
 private:
   Ui::SymmetryWidget* m_ui;
+  QStandardItemModel* m_equivalenceTreeModel;
   OperationsTableModel* m_operationsTableModel;
   QStandardItemModel* m_subgroupsTreeModel;
   QtGui::Molecule* m_molecule;
   QVector3D m_cm;
 
+  const msym::msym_equivalence_set_t* m_es;
   const msym::msym_symmetry_operation_t* m_sops;
   const msym::msym_subgroup_t* m_sg;
-  int m_sopsl, m_sgl;
+  int m_esl, m_sopsl, m_sgl;
   double m_radius;
 
   void addSubgroup(QStandardItem*, msym::msym_subgroup_t*);

--- a/avogadro/qtplugins/symmetry/symmetrywidget.ui
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.ui
@@ -50,7 +50,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QTableView" name="esTable">
+        <widget class="QTreeView" name="equivalenceTree">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -63,11 +63,8 @@
          <property name="selectionBehavior">
           <enum>QAbstractItemView::SelectRows</enum>
          </property>
-         <attribute name="horizontalHeaderStretchLastSection">
-          <bool>true</bool>
-         </attribute>
-         <attribute name="verticalHeaderCascadingSectionResizes">
-          <bool>true</bool>
+         <attribute name="headerVisible">
+          <bool>false</bool>
          </attribute>
         </widget>
        </item>
@@ -75,6 +72,9 @@
         <layout class="QHBoxLayout" name="horizontalLayoutMolecule">
          <item>
           <widget class="QCheckBox" name="lockSymmetryCheckBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="text">
             <string>Lock Symmetry</string>
            </property>
@@ -160,6 +160,9 @@
          <property name="selectionBehavior">
           <enum>QAbstractItemView::SelectRows</enum>
          </property>
+         <attribute name="headerVisible">
+          <bool>false</bool>
+         </attribute>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
New code populates the first table of the symmetry widget, including nested groups for equivalent atoms.

<img width="487" alt="screen shot 2018-04-01 at 8 54 30 am" src="https://user-images.githubusercontent.com/41128/38173320-613bb4be-358a-11e8-9656-258f5470095d.png">

In principle, this can allow atoms from the symmetry widget to select atoms in the molecule. This isn't working yet.