### PR TITLE
Improve the libmsym find calls

### DIFF
--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -8,11 +8,6 @@ if(USE_LIBSPG)
   include_directories(SYSTEM ${SPGLIB_INCLUDE_DIR})
 endif()
 
-if(USE_LIBMSYM)
-  find_package(Libmsym REQUIRED)
-  include_directories(SYSTEM ${LIBMSYM_INCLUDE_DIR})
-endif()
-
 # configure the version header
 configure_file("${PROJECT_SOURCE_DIR}/cmake/version.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/version.h")

--- a/avogadro/qtplugins/symmetry/CMakeLists.txt
+++ b/avogadro/qtplugins/symmetry/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(libmsym REQUIRED)
+find_package(libmsym NO_MODULE)
+if(NOT DEFINED LIBMSYM_INCLUDE_DIRS)
+  find_package(libmsym REQUIRED)
+endif()
 include_directories(${LIBMSYM_INCLUDE_DIRS})
 
 message("msym include dir " ${LIBMSYM_INCLUDE_DIRS})

--- a/cmake/Findlibmsym.cmake
+++ b/cmake/Findlibmsym.cmake
@@ -4,7 +4,7 @@
 #
 #  LIBMSYM_FOUND        - system has LIBMSYM
 #  LIBMSYM_INCLUDE_DIRS - the LIBMSYM include directories
-#  LIBMSYM_LIBRARY      - The LIBMSYM library
+#  LIBMSYM_LIBRARIES    - The LIBMSYM library
 #
 find_path(LIBMSYM_INCLUDE_DIR libmsym/msym.h)
 find_library(LIBMSYM_LIBRARY NAMES libmsym)


### PR DESCRIPTION
They should both just use lower case, and find should only be called
from the place where it is being used - the symmetry plugin. This logic
now finds the libmsym CMake config for the superbuild, and if not found
will use the CMake find package to look for a system copy.