### PR TITLE
Filename change in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ install(FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindEigen3.cmake"
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindGLEW.cmake"
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibArchive.cmake"
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibmsym.cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findlibmsym.cmake"
   DESTINATION "${INSTALL_LIBRARY_DIR}/cmake/avogadrolibs")
 install(EXPORT "AvogadroLibsTargets"
   DESTINATION "${INSTALL_LIBRARY_DIR}/cmake/avogadrolibs")


### PR DESCRIPTION
The filename in cmakelists.txt https://github.com/OpenChemistry/avogadrolibs/blob/c23bc8155ef709659d3c2a30217a5170600d1baf/CMakeLists.txt#L101 is different from the actual filename https://github.com/OpenChemistry/avogadrolibs/blob/master/cmake/Findlibmsym.cmake