### PR TITLE
Print the clang-format config info on failure

### DIFF
--- a/scripts/travis/run_clang_format_diff.sh
+++ b/scripts/travis/run_clang_format_diff.sh
@@ -4,5 +4,6 @@ if [ -z "$DIFF" ]; then
   exit 0
 else
   printf "ERROR: clang-format-diff detected formatting issues. Please run clang-format on your branch.\nThe following formatting changes are suggested:\n\n%s" "$DIFF"
+  printf "\n\nThe following is the clang-format configuration:\n%s\n" "`clang-format-3.8 -dump-config`"
   exit 1
 fi


### PR DESCRIPTION
Some versions of clang-format use different
settings (even with the same "BasedOnStyle" flag).

Printing the clang-format configuration upon failure
can speed up the process of fixing clang-format issues.