### PR TITLE
Upgrade to clang-format-6.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,5 +3,7 @@
 BasedOnStyle: Mozilla
 AlwaysBreakAfterReturnType: None
 AlwaysBreakAfterDefinitionReturnType: None
+BinPackArguments: true
+BinPackParameters: true
 BreakConstructorInitializersBeforeComma: false
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ matrix:
       python: 2.7
       env: TASKS="clang-format"
 
-      dist: precise
+      dist: trusty
       addons:
         apt:
           sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.8
+          - llvm-toolchain-trusty-6.0
           packages:
-          - clang-format-3.8
+          - clang-format-6.0
 
     - compiler: gcc
       env: TASKS="ctest gcc-4.8"

--- a/scripts/travis/run_clang_format_diff.sh
+++ b/scripts/travis/run_clang_format_diff.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIFF=`git diff -U0 $1...$2 -- '*.h' '*.cpp' | clang-format-diff-3.8 -p1`
+DIFF=`git diff -U0 $1...$2 -- '*.h' '*.cpp' | clang-format-diff-6.0 -p1`
 if [ -z "$DIFF" ]; then
   exit 0
 else


### PR DESCRIPTION
Also added the following to .clang-format:

BinPackArguments: true
BinPackParameters: true

in order to improve consistency with previous settings
(these options were used by default in clang-format-3.8).