### PR TITLE
Port the GL initialization code to the new API

### DIFF
--- a/tests/qtopengl/glwidgettest.cpp
+++ b/tests/qtopengl/glwidgettest.cpp
@@ -23,7 +23,8 @@
 #include <QtGui/QImage>
 #include <QtWidgets/QApplication>
 
-#include <QtOpenGL/QGLFormat>
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QSurfaceFormat>
 
 #include <iostream>
 
@@ -37,9 +38,9 @@ using Avogadro::VtkTesting::ImageRegressionTest;
 int glwidgettest(int argc, char* argv[])
 {
   // Set up the default format for our GL contexts.
-  QGLFormat defaultFormat = QGLFormat::defaultFormat();
-  defaultFormat.setSampleBuffers(true);
-  QGLFormat::setDefaultFormat(defaultFormat);
+  QSurfaceFormat defaultFormat = QSurfaceFormat::defaultFormat();
+  defaultFormat.setSamples(4);
+  QSurfaceFormat::setDefaultFormat(defaultFormat);
 
   QApplication app(argc, argv);
   GLWidget widget;

--- a/tests/qtopengl/qttextlabeltest.cpp
+++ b/tests/qtopengl/qttextlabeltest.cpp
@@ -26,7 +26,8 @@
 
 #include <avogadro/core/vector.h>
 
-#include <QtOpenGL/QGLFormat>
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QSurfaceFormat>
 
 #include <QtGui/QImage>
 #include <QtWidgets/QApplication>
@@ -50,9 +51,9 @@ using Avogadro::VtkTesting::ImageRegressionTest;
 int qttextlabeltest(int argc, char* argv[])
 {
   // Set up the default format for our GL contexts.
-  QGLFormat defaultFormat = QGLFormat::defaultFormat();
-  defaultFormat.setSampleBuffers(true);
-  QGLFormat::setDefaultFormat(defaultFormat);
+  QSurfaceFormat defaultFormat = QSurfaceFormat::defaultFormat();
+  defaultFormat.setSamples(4);
+  QSurfaceFormat::setDefaultFormat(defaultFormat);
 
   // Create and show widget
   QApplication app(argc, argv);


### PR DESCRIPTION
The QGL* classes won't help much now that the widgets use the new QOpenGL*
based classes, there are still some issues with these tests that need to
be looked at but they build/link successfully.