### PR TITLE
(WIP) DCD trajectory support

### DIFF
--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 set(HEADERS
   cjsonformat.h
   cmlformat.h
+  dcdformat.h
   fileformat.h
   fileformatmanager.h
   gromacsformat.h
@@ -36,6 +37,7 @@ set(HEADERS
 set(SOURCES
   cjsonformat.cpp
   cmlformat.cpp
+  dcdformat.cpp
   fileformat.cpp
   fileformatmanager.cpp
   gromacsformat.cpp

--- a/avogadro/io/dcdformat.cpp
+++ b/avogadro/io/dcdformat.cpp
@@ -55,8 +55,8 @@ using std::isalpha;
 #endif
 
 #define DCD_MAGIC 84
-#define DCD_IS_CHARMM       0x01
-#define DCD_HAS_4DIMS       0x02
+#define DCD_IS_CHARMM 0x01
+#define DCD_HAS_4DIMS 0x02
 #define DCD_HAS_EXTRA_BLOCK 0x04
 
 int swap_integer(int inp)
@@ -80,9 +80,10 @@ DcdFormat::~DcdFormat() {}
 bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
 {
   char endian = '>', buff[BUFSIZ], fmt[BUFSIZ], raw[84];
-  char * remarks;
+  char* remarks;
   double DELTA;
-  int magic, charmm, NSET, ISTART, NSAVC, NAMNF, NTITLE, len_remarks, NATOMS, block_size;
+  int magic, charmm, NSET, ISTART, NSAVC, NAMNF, NTITLE, len_remarks, NATOMS,
+    block_size;
 
   // Determining size of file
   inStream.seekg(0, inStream.end);
@@ -93,7 +94,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   snprintf(fmt, sizeof(fmt), "%c1i", endian);
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &magic);
-  if(magic != DCD_MAGIC) {
+  if (magic != DCD_MAGIC) {
     magic = swap_integer(magic);
     endian = swap_endian(endian);
     if (magic != DCD_MAGIC) {
@@ -112,28 +113,29 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   }
 
   // Determining whether the trajectory file is from CHARMM or not
-  if (*((int *) (raw + 80)) != 0) {
+  if (*((int*)(raw + 80)) != 0) {
     charmm = DCD_IS_CHARMM;
-    if (*((int *) (raw + 44)) != 0)
+    if (*((int*)(raw + 44)) != 0)
       charmm |= DCD_HAS_EXTRA_BLOCK;
 
-    if (*((int *) (raw + 48)) == 1)
+    if (*((int*)(raw + 48)) == 1)
       charmm |= DCD_HAS_4DIMS;
   } else {
     charmm = 0;
   }
 
-  // number of fixed atoms 
-  NAMNF = *((int *) (raw + 36));
+  // number of fixed atoms
+  NAMNF = *((int*)(raw + 36));
 
-  // DELTA (timestep) is stored as a double with X-PLOR but as a float with CHARMM 
-  if ((charmm) & DCD_IS_CHARMM) {
+  // DELTA (timestep) is stored as a double with X-PLOR but as a float with
+  // CHARMM
+  if ((charmm)&DCD_IS_CHARMM) {
     float ftmp;
-    ftmp = *((float *)(raw+40)); 
+    ftmp = *((float*)(raw + 40));
 
     DELTA = (double)ftmp;
   } else {
-    (DELTA) = *((double *)(raw + 40));
+    (DELTA) = *((double*)(raw + 40));
   }
 
   snprintf(fmt, sizeof(fmt), "%c1i", endian);
@@ -144,12 +146,12 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &block_size);
 
-  if (((block_size-4) % 80) == 0) {
+  if (((block_size - 4) % 80) == 0) {
     // Read NTITLE, the number of 80 character title strings
     snprintf(fmt, sizeof(fmt), "%c1i", endian);
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &NTITLE);
-    len_remarks = NTITLE*80;
+    len_remarks = NTITLE * 80;
     remarks = (char*)malloc(len_remarks);
     snprintf(fmt, sizeof(fmt), "%c%ds", endian, len_remarks);
     inStream.read(buff, struct_calcsize(fmt));
@@ -160,15 +162,15 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     int end_size;
     struct_unpack(buff, fmt, &end_size);
   } else {
-      appendError("Block size must be 4 plus a multiple of 80.");
-      return false;
+    appendError("Block size must be 4 plus a multiple of 80.");
+    return false;
   }
 
   snprintf(fmt, sizeof(fmt), "%c1i", endian);
   inStream.read(buff, struct_calcsize(fmt));
   int four_input;
   struct_unpack(buff, fmt, &four_input);
-  if(four_input != 4) {
+  if (four_input != 4) {
     // Error
   }
 
@@ -179,13 +181,13 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   snprintf(fmt, sizeof(fmt), "%c1i", endian);
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &four_input);
-  if(four_input != 4) {
+  if (four_input != 4) {
     appendError("Expected token 4. Read token " + to_string(four_input));
     return false;
   }
 
   if (NAMNF != 0) {
-    int **FREEINDEXES = (int **) calloc((NATOMS-NAMNF), sizeof(int));
+    int** FREEINDEXES = (int**)calloc((NATOMS - NAMNF), sizeof(int));
     if (*FREEINDEXES == NULL) {
       appendError("MALLOC failed.");
       return false;
@@ -197,11 +199,10 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     int arr_size;
     struct_unpack(buff, fmt, &arr_size);
 
-    if (arr_size != (NATOMS-NAMNF)*4) {
+    if (arr_size != (NATOMS - NAMNF) * 4) {
       appendError("DCD file contains bad format.");
       return false;
     }
-
 
     snprintf(fmt, sizeof(fmt), "%c%di", endian, (NATOMS - NAMNF));
     inStream.read(buff, struct_calcsize(fmt));
@@ -211,30 +212,31 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &arr_size);
 
-    if (arr_size != (NATOMS-NAMNF)*4) {
+    if (arr_size != (NATOMS - NAMNF) * 4) {
       appendError("DCD file contains bad format.");
       return false;
     }
-
   }
 
-  // CHARMM trajectories have an extra block to be read, that contains information about the unit cell
+  // CHARMM trajectories have an extra block to be read, that contains
+  // information about the unit cell
   if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
     snprintf(fmt, sizeof(fmt), "%c1i", endian);
     inStream.read(buff, struct_calcsize(fmt));
     int leading_num;
     struct_unpack(buff, fmt, &leading_num);
 
-    if(leading_num == 48) {
+    if (leading_num == 48) {
       double unitcell[6];
-      for(int aa = 0; aa < 6; aa++) {
+      for (int aa = 0; aa < 6; aa++) {
         snprintf(fmt, sizeof(fmt), "%c%dd", endian, 1);
         inStream.read(buff, struct_calcsize(fmt));
         struct_unpack(buff, fmt, &unitcell[aa]);
       }
-      mol.setUnitCell(new UnitCell(unitcell[0], unitcell[1], unitcell[2], acos(unitcell[3]), acos(unitcell[4]), acos(unitcell[5])));
-    }
-    else {
+      mol.setUnitCell(new UnitCell(unitcell[0], unitcell[1], unitcell[2],
+                                   acos(unitcell[3]), acos(unitcell[4]),
+                                   acos(unitcell[5])));
+    } else {
       inStream.read(buff, leading_num);
     }
     inStream.read(buff, sizeof(int));
@@ -248,8 +250,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &formatint[0]);
 
-  for (int i = 0; i < NATOMS; ++i)
-  {
+  for (int i = 0; i < NATOMS; ++i) {
     // X coordinates
     snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
     inStream.read(buff, struct_calcsize(fmt));
@@ -261,8 +262,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &formatint[1], &formatint[2]);
 
-  for (int i = 0; i < NATOMS; ++i)
-  {
+  for (int i = 0; i < NATOMS; ++i) {
     // Y coordinates
     snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
     inStream.read(buff, struct_calcsize(fmt));
@@ -273,8 +273,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   inStream.read(buff, struct_calcsize(fmt));
   struct_unpack(buff, fmt, &formatint[3], &formatint[4]);
 
-  for (int i = 0; i < NATOMS; ++i)
-  {
+  for (int i = 0; i < NATOMS; ++i) {
     // Z coordinates
     snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
     inStream.read(buff, struct_calcsize(fmt));
@@ -289,13 +288,11 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
   AtomTypeMap atomTypes;
   unsigned char customElementCounter = CustomElementMin;
 
-  for (int i = 0; i < NATOMS; ++i)
-  {
+  for (int i = 0; i < NATOMS; ++i) {
     Vector3 pos(cx[i], cy[i], cz[i]);
 
     AtomTypeMap::const_iterator it;
-    atomTypes.insert(
-      std::make_pair(to_string(i), customElementCounter++));
+    atomTypes.insert(std::make_pair(to_string(i), customElementCounter++));
     it = atomTypes.find(to_string(i));
     // if (customElementCounter > CustomElementMax) {
     //   appendError("Custom element type limit exceeded.");
@@ -330,20 +327,18 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
 
   mol.setCoordinate3d(mol.atomPositions3d(), 0);
 
-
   // Do we have an animation?
   int coordSet = 1;
-  while(inStream.tellg() != file_len) {
+  while (inStream.tellg() != file_len) {
     // Reading the atom coordinates
     Array<Vector3> positions;
     positions.reserve(NATOMS);
-    
+
     snprintf(fmt, sizeof(fmt), "%c1i", endian);
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &formatint[0]);
 
-    for (int i = 0; i < NATOMS; ++i)
-    {
+    for (int i = 0; i < NATOMS; ++i) {
       // X coordinates
       snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
       inStream.read(buff, struct_calcsize(fmt));
@@ -354,8 +349,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &formatint[1], &formatint[2]);
 
-    for (int i = 0; i < NATOMS; ++i)
-    {
+    for (int i = 0; i < NATOMS; ++i) {
       // Y coordinates
       snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
       inStream.read(buff, struct_calcsize(fmt));
@@ -366,8 +360,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &formatint[3], &formatint[4]);
 
-    for (int i = 0; i < NATOMS; ++i)
-    {
+    for (int i = 0; i < NATOMS; ++i) {
       // Z coordinates
       snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
       inStream.read(buff, struct_calcsize(fmt));
@@ -378,8 +371,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
     inStream.read(buff, struct_calcsize(fmt));
     struct_unpack(buff, fmt, &formatint[5]);
 
-    for (int i = 0; i < NATOMS; ++i)
-    {
+    for (int i = 0; i < NATOMS; ++i) {
       Vector3 pos(cx[i], cy[i], cz[i]);
       positions.push_back(pos);
     }
@@ -398,7 +390,7 @@ bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
 
     mol.setCoordinate3d(positions, coordSet++);
   }
-  
+
   return true;
 }
 

--- a/avogadro/io/dcdformat.cpp
+++ b/avogadro/io/dcdformat.cpp
@@ -1,0 +1,425 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "dcdformat.h"
+#include "struct.h"
+
+#include <avogadro/core/elements.h>
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/unitcell.h>
+#include <avogadro/core/utilities.h>
+#include <avogadro/core/vector.h>
+
+#include <cmath>
+#include <iomanip>
+#include <istream>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+using std::endl;
+using std::getline;
+using std::map;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace Avogadro {
+namespace Io {
+
+using Core::Array;
+using Core::Atom;
+using Core::Elements;
+using Core::lexicalCast;
+using Core::Molecule;
+using Core::split;
+using Core::trimmed;
+using Core::UnitCell;
+
+#ifndef _WIN32
+using std::isalpha;
+#endif
+
+#define DCD_MAGIC 84
+#define DCD_IS_CHARMM       0x01
+#define DCD_HAS_4DIMS       0x02
+#define DCD_HAS_EXTRA_BLOCK 0x04
+
+int swap_integer(int inp)
+{
+  return (((inp << 24) & 0xff000000) | ((inp << 8) & 0x00ff0000) |
+          ((inp >> 8) & 0x0000ff00) | ((inp >> 24) & 0x000000ff));
+}
+
+char swap_endian(char endian)
+{
+  if (endian == '>')
+    return '<';
+  else
+    return '>';
+}
+
+DcdFormat::DcdFormat() {}
+
+DcdFormat::~DcdFormat() {}
+
+bool DcdFormat::read(std::istream& inStream, Core::Molecule& mol)
+{
+  char endian = '>', buff[BUFSIZ], fmt[BUFSIZ], raw[84];
+  char * remarks;
+  double DELTA;
+  int magic, charmm, NSET, ISTART, NSAVC, NAMNF, NTITLE, len_remarks, NATOMS, block_size;
+
+  // Determining size of file
+  inStream.seekg(0, inStream.end);
+  int file_len = inStream.tellg();
+  inStream.seekg(0, inStream.beg);
+
+  // Reading magic number
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &magic);
+  if(magic != DCD_MAGIC) {
+    magic = swap_integer(magic);
+    endian = swap_endian(endian);
+    if (magic != DCD_MAGIC) {
+      appendError("File does not start with magic number 84.");
+      return false;
+    }
+  }
+
+  // CORD
+  snprintf(fmt, sizeof(fmt), "%c%ds", endian, magic);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, raw);
+  if (raw[0] != 'C' || raw[1] != 'O' || raw[2] != 'R' || raw[3] != 'D') {
+    appendError("Keyword CORD not found.");
+    return false;
+  }
+
+  // Determining whether the trajectory file is from CHARMM or not
+  if (*((int *) (raw + 80)) != 0) {
+    charmm = DCD_IS_CHARMM;
+    if (*((int *) (raw + 44)) != 0)
+      charmm |= DCD_HAS_EXTRA_BLOCK;
+
+    if (*((int *) (raw + 48)) == 1)
+      charmm |= DCD_HAS_4DIMS;
+  } else {
+    charmm = 0;
+  }
+
+  // number of fixed atoms 
+  NAMNF = *((int *) (raw + 36));
+
+  // DELTA (timestep) is stored as a double with X-PLOR but as a float with CHARMM 
+  if ((charmm) & DCD_IS_CHARMM) {
+    float ftmp;
+    ftmp = *((float *)(raw+40)); 
+
+    DELTA = (double)ftmp;
+  } else {
+    (DELTA) = *((double *)(raw + 40));
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &magic);
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &block_size);
+
+  if (((block_size-4) % 80) == 0) {
+    // Read NTITLE, the number of 80 character title strings
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &NTITLE);
+    len_remarks = NTITLE*80;
+    remarks = (char*)malloc(len_remarks);
+    snprintf(fmt, sizeof(fmt), "%c%ds", endian, len_remarks);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, remarks);
+
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    int end_size;
+    struct_unpack(buff, fmt, &end_size);
+  } else {
+      appendError("Block size must be 4 plus a multiple of 80.");
+      return false;
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  int four_input;
+  struct_unpack(buff, fmt, &four_input);
+  if(four_input != 4) {
+    // Error
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &NATOMS);
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &four_input);
+  if(four_input != 4) {
+    appendError("Expected token 4. Read token " + to_string(four_input));
+    return false;
+  }
+
+  if (NAMNF != 0) {
+    int **FREEINDEXES = (int **) calloc((NATOMS-NAMNF), sizeof(int));
+    if (*FREEINDEXES == NULL) {
+      appendError("MALLOC failed.");
+      return false;
+    }
+
+    /* Read in index array size */
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    int arr_size;
+    struct_unpack(buff, fmt, &arr_size);
+
+    if (arr_size != (NATOMS-NAMNF)*4) {
+      appendError("DCD file contains bad format.");
+      return false;
+    }
+
+
+    snprintf(fmt, sizeof(fmt), "%c%di", endian, (NATOMS - NAMNF));
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, *FREEINDEXES);
+
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &arr_size);
+
+    if (arr_size != (NATOMS-NAMNF)*4) {
+      appendError("DCD file contains bad format.");
+      return false;
+    }
+
+  }
+
+  // CHARMM trajectories have an extra block to be read, that contains information about the unit cell
+  if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    int leading_num;
+    struct_unpack(buff, fmt, &leading_num);
+
+    if(leading_num == 48) {
+      double unitcell[6];
+      for(int aa = 0; aa < 6; aa++) {
+        snprintf(fmt, sizeof(fmt), "%c%dd", endian, 1);
+        inStream.read(buff, struct_calcsize(fmt));
+        struct_unpack(buff, fmt, &unitcell[aa]);
+      }
+      mol.setUnitCell(new UnitCell(unitcell[0], unitcell[1], unitcell[2], acos(unitcell[3]), acos(unitcell[4]), acos(unitcell[5])));
+    }
+    else {
+      inStream.read(buff, leading_num);
+    }
+    inStream.read(buff, sizeof(int));
+  }
+
+  // Reading the atom coordinates
+  int formatint[6];
+  float cx[NATOMS], cy[NATOMS], cz[NATOMS];
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &formatint[0]);
+
+  for (int i = 0; i < NATOMS; ++i)
+  {
+    // X coordinates
+    snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &cx[i]);
+    /* code */
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c2i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &formatint[1], &formatint[2]);
+
+  for (int i = 0; i < NATOMS; ++i)
+  {
+    // Y coordinates
+    snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &cy[i]);
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c2i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &formatint[3], &formatint[4]);
+
+  for (int i = 0; i < NATOMS; ++i)
+  {
+    // Z coordinates
+    snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &cz[i]);
+  }
+
+  snprintf(fmt, sizeof(fmt), "%c1i", endian);
+  inStream.read(buff, struct_calcsize(fmt));
+  struct_unpack(buff, fmt, &formatint[5]);
+
+  typedef map<string, unsigned char> AtomTypeMap;
+  AtomTypeMap atomTypes;
+  unsigned char customElementCounter = CustomElementMin;
+
+  for (int i = 0; i < NATOMS; ++i)
+  {
+    Vector3 pos(cx[i], cy[i], cz[i]);
+
+    AtomTypeMap::const_iterator it;
+    atomTypes.insert(
+      std::make_pair(to_string(i), customElementCounter++));
+    it = atomTypes.find(to_string(i));
+    // if (customElementCounter > CustomElementMax) {
+    //   appendError("Custom element type limit exceeded.");
+    //   return false;
+    // }
+    Atom newAtom = mol.addAtom(it->second);
+    newAtom.setPosition3d(pos);
+  }
+
+  // Skipping fourth dimension block
+  if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    int size_to_read;
+    struct_unpack(buff, fmt, &size_to_read);
+
+    inStream.read(buff, size_to_read);
+
+    inStream.read(buff, sizeof(int));
+  }
+
+  // Set the custom element map if needed
+  if (!atomTypes.empty()) {
+    Molecule::CustomElementMap elementMap;
+    for (AtomTypeMap::const_iterator it = atomTypes.begin(),
+                                     itEnd = atomTypes.end();
+         it != itEnd; ++it) {
+      elementMap.insert(std::make_pair(it->second, "Atom " + it->first));
+    }
+    mol.setCustomElementMap(elementMap);
+  }
+
+  mol.setCoordinate3d(mol.atomPositions3d(), 0);
+
+
+  // Do we have an animation?
+  int coordSet = 1;
+  while(inStream.tellg() != file_len) {
+    // Reading the atom coordinates
+    Array<Vector3> positions;
+    positions.reserve(NATOMS);
+    
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &formatint[0]);
+
+    for (int i = 0; i < NATOMS; ++i)
+    {
+      // X coordinates
+      snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+      inStream.read(buff, struct_calcsize(fmt));
+      struct_unpack(buff, fmt, &cx[i]);
+    }
+
+    snprintf(fmt, sizeof(fmt), "%c2i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &formatint[1], &formatint[2]);
+
+    for (int i = 0; i < NATOMS; ++i)
+    {
+      // Y coordinates
+      snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+      inStream.read(buff, struct_calcsize(fmt));
+      struct_unpack(buff, fmt, &cy[i]);
+    }
+
+    snprintf(fmt, sizeof(fmt), "%c2i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &formatint[3], &formatint[4]);
+
+    for (int i = 0; i < NATOMS; ++i)
+    {
+      // Z coordinates
+      snprintf(fmt, sizeof(fmt), "%c%df", endian, 1);
+      inStream.read(buff, struct_calcsize(fmt));
+      struct_unpack(buff, fmt, &cz[i]);
+    }
+
+    snprintf(fmt, sizeof(fmt), "%c1i", endian);
+    inStream.read(buff, struct_calcsize(fmt));
+    struct_unpack(buff, fmt, &formatint[5]);
+
+    for (int i = 0; i < NATOMS; ++i)
+    {
+      Vector3 pos(cx[i], cy[i], cz[i]);
+      positions.push_back(pos);
+    }
+
+    // Skipping fourth dimension block
+    if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
+      snprintf(fmt, sizeof(fmt), "%c1i", endian);
+      inStream.read(buff, struct_calcsize(fmt));
+      int size_to_read;
+      struct_unpack(buff, fmt, &size_to_read);
+
+      inStream.read(buff, size_to_read);
+
+      inStream.read(buff, sizeof(int));
+    }
+
+    mol.setCoordinate3d(positions, coordSet++);
+  }
+  
+  return true;
+}
+
+bool DcdFormat::write(std::ostream& outStream, const Core::Molecule& mol)
+{
+  return false;
+}
+
+std::vector<std::string> DcdFormat::fileExtensions() const
+{
+  std::vector<std::string> ext;
+  ext.push_back("dcd");
+  return ext;
+}
+
+std::vector<std::string> DcdFormat::mimeTypes() const
+{
+  std::vector<std::string> mime;
+  mime.push_back("application/octet-stream");
+  return mime;
+}
+
+} // end Io namespace
+} // end Avogadro namespace

--- a/avogadro/io/dcdformat.h
+++ b/avogadro/io/dcdformat.h
@@ -47,10 +47,7 @@ public:
     return "CHARMM/NAMD/LAMMPS DCD Trajectory format.";
   }
 
-  std::string specificationUrl() const override
-  {
-    return "";
-  }
+  std::string specificationUrl() const override { return ""; }
 
   std::vector<std::string> fileExtensions() const override;
   std::vector<std::string> mimeTypes() const override;

--- a/avogadro/io/dcdformat.h
+++ b/avogadro/io/dcdformat.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_DCDFORMAT_H
+#define AVOGADRO_IO_DCDFORMAT_H
+
+#include "fileformat.h"
+
+namespace Avogadro {
+namespace Io {
+
+/**
+ * @class DcdFormat dcdformat.h <avogadro/io/dcdformat.h>
+ * @brief Implementation of the generic dcd trajectory format.
+ * @author Adarsh B
+ */
+
+class AVOGADROIO_EXPORT DcdFormat : public FileFormat
+{
+public:
+  DcdFormat();
+  ~DcdFormat() override;
+
+  Operations supportedOperations() const override
+  {
+    return ReadWrite | MultiMolecule | File | Stream | String;
+  }
+
+  FileFormat* newInstance() const override { return new DcdFormat; }
+  std::string identifier() const override { return "Avogadro: DCD"; }
+  std::string name() const override { return "DCD"; }
+  std::string description() const override
+  {
+    return "CHARMM/NAMD/LAMMPS DCD Trajectory format.";
+  }
+
+  std::string specificationUrl() const override
+  {
+    return "";
+  }
+
+  std::vector<std::string> fileExtensions() const override;
+  std::vector<std::string> mimeTypes() const override;
+
+  bool read(std::istream& inStream, Core::Molecule& molecule) override;
+  bool write(std::ostream& outStream, const Core::Molecule& molecule) override;
+};
+
+} // end Io namespace
+} // end Avogadro namespace
+
+#endif // AVOGADRO_IO_DCDFORMAT_H

--- a/avogadro/io/fileformatmanager.cpp
+++ b/avogadro/io/fileformatmanager.cpp
@@ -20,6 +20,7 @@
 
 #include "cjsonformat.h"
 #include "cmlformat.h"
+#include "dcdformat.h"
 #include "gromacsformat.h"
 #include "mdlformat.h"
 #include "poscarformat.h"
@@ -290,6 +291,7 @@ FileFormatManager::FileFormatManager()
   addFormat(new MdlFormat);
   addFormat(new PoscarFormat);
   addFormat(new XyzFormat);
+  addFormat(new DcdFormat);
 }
 
 FileFormatManager::~FileFormatManager()

--- a/avogadro/io/fileformatmanager.cpp
+++ b/avogadro/io/fileformatmanager.cpp
@@ -159,7 +159,7 @@ bool FileFormatManager::addFormat(FileFormat* format)
 namespace {
 // Lookup each key from "keys" in "map", and remove "val" from the Map's
 // data value (which is a vector of ValueType)
-template <typename Map, typename VectorOfKeys, typename ValueType>
+template<typename Map, typename VectorOfKeys, typename ValueType>
 void removeFromMap(Map& map, const VectorOfKeys& keys, const ValueType& val)
 {
   typedef typename VectorOfKeys::const_iterator KeysIter;
@@ -249,8 +249,8 @@ std::vector<const FileFormat*> FileFormatManager::fileFormats(
 {
   std::vector<const FileFormat*> result;
 
-  for (std::vector<FileFormat *>::const_iterator it = m_formats.begin(),
-                                                 itEnd = m_formats.end();
+  for (std::vector<FileFormat*>::const_iterator it = m_formats.begin(),
+                                                itEnd = m_formats.end();
        it != itEnd; ++it) {
     if (filter == FileFormat::None ||
         (filter & (*it)->supportedOperations()) == filter) {


### PR DESCRIPTION
DCD is a trajectory extension supported by several software like OpenMM, CHARMM, NAMD, LAMMPS etc. This PR aims at providing support in Avogadro for reading DCD trajectory files.