### PR TITLE
Pair Distribution Function VTK chart 

### DIFF
--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -121,6 +121,7 @@ add_subdirectory(vrml)
 add_subdirectory(workflows)
 
 if(USE_VTK)
+  add_subdirectory(plotpdf)
   add_subdirectory(plotrmsd)
   add_subdirectory(plotxrd)
 endif()

--- a/avogadro/qtplugins/plotpdf/CMakeLists.txt
+++ b/avogadro/qtplugins/plotpdf/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(plotpdf_srcs
+  plotpdf.cpp
+  pdfoptionsdialog.cpp
+)
+
+set(plotpdf_uis
+  pdfoptionsdialog.ui
+)
+
+avogadro_plugin(PlotPdf
+  "Create a pair distribution plot."
+  ExtensionPlugin
+  plotpdf.h
+  PlotPdf
+  "${plotpdf_srcs}"
+  "${plotpdf_uis}"
+)
+
+target_link_libraries(PlotPdf LINK_PRIVATE AvogadroVtk)

--- a/avogadro/qtplugins/plotpdf/pdfoptionsdialog.cpp
+++ b/avogadro/qtplugins/plotpdf/pdfoptionsdialog.cpp
@@ -1,0 +1,60 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "pdfoptionsdialog.h"
+#include "ui_pdfoptionsdialog.h"
+
+#include <QtCore/QSettings>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+PdfOptionsDialog::PdfOptionsDialog(QWidget* aParent)
+  : QDialog(aParent)
+  , m_ui(new Ui::PdfOptionsDialog)
+{
+  m_ui->setupUi(this);
+
+  // Read the settings
+  QSettings settings;
+  m_ui->spin_maxRadius->setValue(
+    settings.value("plotpdfcurveoptions/maxRadius", 10.0).toDouble());
+  m_ui->spin_step->setValue(
+    settings.value("plotpdfcurveoptions/step", 0.1).toDouble());
+}
+
+PdfOptionsDialog::~PdfOptionsDialog() = default;
+
+double PdfOptionsDialog::maxRadius() const
+{
+  return m_ui->spin_maxRadius->value();
+}
+
+double PdfOptionsDialog::step() const
+{
+  return m_ui->spin_step->value();
+}
+
+void PdfOptionsDialog::accept()
+{
+  QSettings settings;
+  settings.setValue("plotpdfcurveoptions/maxRadius", maxRadius());
+  settings.setValue("plotpdfcurveoptions/step", step());
+  QDialog::accept();
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/plotpdf/pdfoptionsdialog.h
+++ b/avogadro/qtplugins/plotpdf/pdfoptionsdialog.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_PDFOPTIONSDIALOG_H
+#define AVOGADRO_QTPLUGINS_PDFOPTIONSDIALOG_H
+
+#include <QDialog>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+namespace Ui {
+class PdfOptionsDialog;
+}
+
+/**
+ * @brief Dialog to set options for PDF curve plotting.
+ */
+class PdfOptionsDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit PdfOptionsDialog(QWidget* parent = 0);
+  ~PdfOptionsDialog();
+
+  double maxRadius() const;
+  double step() const;
+
+protected slots:
+  void accept();
+
+private:
+  QScopedPointer<Ui::PdfOptionsDialog> m_ui;
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+#endif // AVOGADRO_QTPLUGINS_PDFOPTIONSDIALOG_H

--- a/avogadro/qtplugins/plotpdf/pdfoptionsdialog.ui
+++ b/avogadro/qtplugins/plotpdf/pdfoptionsdialog.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Avogadro::QtPlugins::PdfOptionsDialog</class>
+ <widget class="QDialog" name="Avogadro::QtPlugins::PdfOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>324</width>
+    <height>145</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>PDF Plot Options</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Maximum Radius:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="spin_maxRadius">
+       <property name="suffix">
+        <string> Å</string>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="minimum">
+        <double>0.00001</double>
+       </property>
+       <property name="maximum">
+        <double>100.00000</double>
+       </property>
+       <property name="value">
+        <double>10.00000</double>
+       </property>
+      </widget>
+   </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label2">
+      <property name="text">
+       <string>Step (dr):</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="spin_step">
+       <property name="suffix">
+        <string> Å</string>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="minimum">
+        <double>0.00001</double>
+       </property>
+       <property name="maximum">
+        <double>100.00000</double>
+       </property>
+       <property name="value">
+        <double>10.00000</double>
+       </property>
+      </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>   
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>spin_maxRadius</tabstop>
+  <tabstop>spin_step</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Avogadro::QtPlugins::PdfOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>161</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Avogadro::QtPlugins::PdfOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>204</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>161</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/avogadro/qtplugins/plotpdf/plotpdf.cpp
+++ b/avogadro/qtplugins/plotpdf/plotpdf.cpp
@@ -1,0 +1,217 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include <QAction>
+#include <QDialog>
+#include <QMessageBox>
+#include <QString>
+
+#include <avogadro/core/crystaltools.h>
+#include <avogadro/core/unitcell.h>
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/vtk/vtkplot.h>
+
+#include "pdfoptionsdialog.h"
+#include "plotpdf.h"
+
+using Avogadro::Core::CrystalTools;
+using Avogadro::Core::UnitCell;
+using Avogadro::QtGui::Molecule;
+
+using std::map;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+using Core::Array;
+
+PlotPdf::PlotPdf(QObject* parent_)
+  : Avogadro::QtGui::ExtensionPlugin(parent_)
+  , m_actions(QList<QAction*>())
+  , m_molecule(nullptr)
+  , m_pdfOptionsDialog(new PdfOptionsDialog(qobject_cast<QWidget*>(parent())))
+  , m_displayDialogAction(new QAction(this))
+{
+  m_displayDialogAction->setText(tr("Plot Pair Distribution Function..."));
+  connect(m_displayDialogAction.data(), &QAction::triggered, this,
+          &PlotPdf::displayDialog);
+  m_actions.push_back(m_displayDialogAction.data());
+  m_displayDialogAction->setProperty("menu priority", 70);
+
+  updateActions();
+}
+
+PlotPdf::~PlotPdf() = default;
+
+QList<QAction*> PlotPdf::actions() const
+{
+  return m_actions;
+}
+
+QStringList PlotPdf::menuPath(QAction*) const
+{
+  return QStringList() << tr("&Crystal");
+}
+
+void PlotPdf::setMolecule(QtGui::Molecule* mol)
+{
+  if (m_molecule == mol)
+    return;
+
+  if (m_molecule)
+    m_molecule->disconnect(this);
+
+  m_molecule = mol;
+
+  if (m_molecule)
+    connect(m_molecule, SIGNAL(changed(uint)), SLOT(moleculeChanged(uint)));
+
+  updateActions();
+}
+
+void PlotPdf::moleculeChanged(unsigned int c)
+{
+  Q_ASSERT(m_molecule == qobject_cast<Molecule*>(sender()));
+
+  Molecule::MoleculeChanges changes = static_cast<Molecule::MoleculeChanges>(c);
+
+  if (changes & Molecule::UnitCell) {
+    if (changes & Molecule::Added || changes & Molecule::Removed)
+      updateActions();
+  }
+}
+
+void PlotPdf::updateActions()
+{
+  // Disable everything for nullptr molecules.
+  if (!m_molecule) {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(false);
+    return;
+  }
+
+  // Only display the actions if there is a unit cell
+  if (m_molecule->unitCell()) {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(true);
+  } else {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(false);
+  }
+}
+
+void PlotPdf::displayDialog()
+{
+  // Do nothing if the user cancels
+  if (m_pdfOptionsDialog->exec() != QDialog::Accepted)
+    return;
+
+  // Otherwise, fetch the options and perform the run
+  double maxRadius = m_pdfOptionsDialog->maxRadius();
+  double step = m_pdfOptionsDialog->step();
+  // size_t numpoints = m_pdfOptionsDialog->numDataPoints();
+  // double max2theta = m_pdfOptionsDialog->max2Theta();
+
+  PdfData results;
+  QString err;
+  if (!generatePdfPattern(*m_molecule, results, err, maxRadius, step)) {
+    QMessageBox::critical(qobject_cast<QWidget*>(parent()),
+                          tr("Failed to generate PDF pattern"),
+                          tr("Error message: ") + err);
+    return;
+  }
+
+  // Now generate a plot with the data
+  std::vector<double> xData;
+  std::vector<double> yData;
+  for (const auto& item : results) {
+    xData.push_back(item.first);
+    yData.push_back(item.second);
+  }
+  std::vector<std::vector<double>> data{ xData, yData };
+
+  std::vector<std::string> lineLabels{ "PdfData" };
+
+  std::array<double, 4> color = { 255, 0, 0, 255 };
+  std::vector<std::array<double, 4>> lineColors{ color };
+
+  const char* xTitle = "r (Å)";
+  const char* yTitle = "g(r)";
+  const char* windowName = "Pair Distribution Function";
+
+  VTK::VtkPlot::generatePlot(data, lineLabels, lineColors, xTitle, yTitle,
+                             windowName);
+}
+
+bool PlotPdf::generatePdfPattern(QtGui::Molecule& mol, PdfData& results,
+                                 QString& err, double maxRadius, double step)
+{
+  Array<Vector3> refAtomCoords = mol.atomPositions3d();
+
+  size_t i, j;
+
+  UnitCell* uc = mol.unitCell();
+  if (!uc) {
+    err = "No unit cell found.";
+    return false;
+  }
+
+  size_t a = static_cast<size_t>(maxRadius / uc->a()) + 1;
+  size_t b = static_cast<size_t>(maxRadius / uc->b()) + 1;
+  size_t c = static_cast<size_t>(maxRadius / uc->c()) + 1;
+
+  Vector3 disp = a * uc->aVector() + b * uc->bVector() + c * uc->cVector();
+  for (i = 0; i < refAtomCoords.size(); ++i) {
+    refAtomCoords[i] += disp;
+  }
+
+  Molecule newMolecule = mol;
+  CrystalTools::buildSupercell(newMolecule, 2 * a + 1, 2 * b + 1, 2 * c + 1);
+
+  Array<Vector3> newAtomCoords = newMolecule.atomPositions3d();
+
+  map<size_t, size_t> pdfCount;
+  double dist, rStep = step;
+  size_t k, binIdx;
+
+  for (i = 0; i < refAtomCoords.size(); ++i) {
+    for (j = 0; j < newAtomCoords.size(); ++j) {
+      dist = (refAtomCoords.at(i) - newAtomCoords.at(j)).norm();
+      binIdx = static_cast<size_t>(dist / rStep);
+      if (pdfCount.find(binIdx) == pdfCount.end()) {
+        pdfCount.insert(std::make_pair(binIdx, 1));
+      } else {
+        pdfCount[binIdx]++;
+      }
+    }
+  }
+
+  for (k = 0; k < static_cast<size_t>(maxRadius / rStep); k++) {
+    if (pdfCount.find(k) == pdfCount.end()) {
+      results.push_back(std::make_pair(k * rStep, 0.0));
+    } else {
+      results.push_back(std::make_pair(
+        k * rStep, pdfCount[k] * newMolecule.unitCell()->volume() /
+                     (4 * M_PI * pow(k * rStep, 2) * rStep *
+                      refAtomCoords.size() * newAtomCoords.size())));
+    }
+  }
+
+  return true;
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/plotpdf/plotpdf.h
+++ b/avogadro/qtplugins/plotpdf/plotpdf.h
@@ -1,0 +1,84 @@
+/*******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2018 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_PLOTPDF_H
+#define AVOGADRO_QTPLUGINS_PLOTPDF_H
+
+#include <avogadro/qtgui/extensionplugin.h>
+
+// Forward declarations
+class QByteArray;
+class QStringList;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+class PdfOptionsDialog;
+
+// First item in the pair is radius. Second is the pdf value.
+typedef std::vector<std::pair<double, double>> PdfData;
+
+/**
+ * @brief Generate and plot a PDF curve
+ */
+class PlotPdf : public Avogadro::QtGui::ExtensionPlugin
+{
+  Q_OBJECT
+public:
+  explicit PlotPdf(QObject* parent_ = 0);
+  ~PlotPdf();
+
+  QString name() const { return tr("PlotPdf"); }
+  QString description() const;
+  QList<QAction*> actions() const;
+  QStringList menuPath(QAction*) const;
+
+public slots:
+  void setMolecule(QtGui::Molecule* mol);
+
+  void moleculeChanged(unsigned int changes);
+
+private slots:
+  void updateActions();
+
+  void displayDialog();
+
+private:
+  // Generate Pdf curve from a crystal
+  // Writes the results to @p results, which is a vector of pairs of doubles
+  // (see definition above).
+  // err will be set to an error string if the function fails.
+  // radius is in Angstroms.
+  static bool generatePdfPattern(QtGui::Molecule& mol, PdfData& results,
+                                 QString& err, double maxRadius = 10.0,
+                                 double step = 0.1);
+
+  QList<QAction*> m_actions;
+  QtGui::Molecule* m_molecule;
+
+  QScopedPointer<PdfOptionsDialog> m_pdfOptionsDialog;
+  QScopedPointer<QAction> m_displayDialogAction;
+};
+
+inline QString PlotPdf::description() const
+{
+  return tr("Generate and plot a Pair Distribution Function curve.");
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_PLOTPDF_H


### PR DESCRIPTION
This PR adds feature for plotting the Pair (Radial) distribution function. 

**How it works:**
As of now, only molecules having a box (unit cell) are allowed this feature. The maximum radius (say `maxRadius`) till which the PDF is to be computed and the step value are obtained as user input. A duplicate crystal is created by expanding the original crystal in such a way that spheres of radius `maxRadius` centered at each atom of the central crystal are completely filled without voids. Since the original crystal coordinates are still pivoted at the actual origin, they're displaced to the centre of the expanded crystal. Pairs of atoms are iteratively chosen with the centre atom from the centered crystal and the dangling atom from the expanded crystal, and the distances are calculated. Bins with spacing of `step` are created and the pairwise distances are binned. Subsequently, the PDF is calculated by taking average of the bin counts and dividing by the corresponding elemental volume.

**Sample Plot for crystalline alpha-Ti:**
![image](https://user-images.githubusercontent.com/10472699/42321945-2c0935f8-8078-11e8-8d1e-bcaa26da6b19.png)

**Sample Plot for Si melt:**
![image](https://user-images.githubusercontent.com/10472699/42322058-a33bc2ee-8078-11e8-950e-958c4c7f1c59.png)

The distinction between crystalline and amorphous / liquid phases is clearly derivable from the nature of the PDF plots.