### PR TITLE
Use clang-tidy modernize-use-override

### DIFF
--- a/avogadro/io/poscarformat.h
+++ b/avogadro/io/poscarformat.h
@@ -55,8 +55,8 @@ public:
   std::vector<std::string> fileExtensions() const override;
   std::vector<std::string> mimeTypes() const override;
 
-  bool read(std::istream& inStream, Core::Molecule& mol);
-  bool write(std::ostream& outStream, const Core::Molecule& mol);
+  bool read(std::istream& inStream, Core::Molecule& mol) override;
+  bool write(std::ostream& outStream, const Core::Molecule& mol) override;
 };
 
 } // end Io namespace

--- a/avogadro/molequeue/inputgenerator.h
+++ b/avogadro/molequeue/inputgenerator.h
@@ -466,7 +466,7 @@ public:
   explicit InputGenerator(const QString& scriptFilePath_,
                           QObject* parent_ = nullptr);
   explicit InputGenerator(QObject* parent_ = nullptr);
-  ~InputGenerator();
+  ~InputGenerator() override;
 
   /**
    * @return True if debugging is enabled.

--- a/avogadro/molequeue/molequeuedialog.h
+++ b/avogadro/molequeue/molequeuedialog.h
@@ -164,7 +164,7 @@ public:
   /** @} */
 
 public slots:
-  void done(int r);
+  void done(int r) override;
 
 private:
   typedef QPair<QObject*, const char*> MetaMethod;

--- a/avogadro/molequeue/molequeuequeuelistmodel.h
+++ b/avogadro/molequeue/molequeuequeuelistmodel.h
@@ -95,7 +95,8 @@ public:
   // QAbstractItemModel virtuals
   QVariant data(const QModelIndex& idx, int role) const override;
   Qt::ItemFlags flags(const QModelIndex& idx = QModelIndex()) const override;
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role) const override;
   QModelIndex index(int row, int column,
                     const QModelIndex& parent_ = QModelIndex()) const override;
   QModelIndex parent(const QModelIndex& child) const override;

--- a/avogadro/molequeue/molequeuequeuelistmodel.h
+++ b/avogadro/molequeue/molequeuequeuelistmodel.h
@@ -55,7 +55,7 @@ class AVOGADROMOLEQUEUE_EXPORT MoleQueueQueueListModel
 {
   Q_OBJECT
 public:
-  ~MoleQueueQueueListModel();
+  ~MoleQueueQueueListModel() override;
 
   /**
    * @return A list of the available queues.
@@ -93,14 +93,14 @@ public:
                      QString& programName) const;
 
   // QAbstractItemModel virtuals
-  QVariant data(const QModelIndex& idx, int role) const;
-  Qt::ItemFlags flags(const QModelIndex& idx = QModelIndex()) const;
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+  QVariant data(const QModelIndex& idx, int role) const override;
+  Qt::ItemFlags flags(const QModelIndex& idx = QModelIndex()) const override;
+  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
   QModelIndex index(int row, int column,
-                    const QModelIndex& parent_ = QModelIndex()) const;
-  QModelIndex parent(const QModelIndex& child) const;
-  int rowCount(const QModelIndex& parent_ = QModelIndex()) const;
-  int columnCount(const QModelIndex& parent_ = QModelIndex()) const;
+                    const QModelIndex& parent_ = QModelIndex()) const override;
+  QModelIndex parent(const QModelIndex& child) const override;
+  int rowCount(const QModelIndex& parent_ = QModelIndex()) const override;
+  int columnCount(const QModelIndex& parent_ = QModelIndex()) const override;
 
 protected:
   friend class MoleQueueManager;

--- a/avogadro/qtgui/containerwidget.h
+++ b/avogadro/qtgui/containerwidget.h
@@ -39,7 +39,7 @@ class AVOGADROQTGUI_EXPORT ContainerWidget : public QWidget
 
 public:
   explicit ContainerWidget(QWidget* parent = 0, Qt::WindowFlags f = 0);
-  ~ContainerWidget();
+  ~ContainerWidget() override;
 
   void setViewWidget(QWidget* widget);
   QWidget* viewWidget();

--- a/avogadro/qtgui/elementdetail_p.h
+++ b/avogadro/qtgui/elementdetail_p.h
@@ -44,19 +44,19 @@ public:
   /**
    * @return the bounding rectangle of the element item.
    */
-  QRectF boundingRect() const;
+  QRectF boundingRect() const override;
 
   /**
    * @return the painter path which is also a rectangle in this case.
    */
-  QPainterPath shape() const;
+  QPainterPath shape() const override;
 
   /**
    * This is where most of the action takes place. The element box is drawn
    * along with its symbol, proton number, mass and full name.
    */
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget);
+             QWidget* widget) override;
 
   /**
    * Change the element displayed in the detail object.

--- a/avogadro/qtgui/elementitem_p.h
+++ b/avogadro/qtgui/elementitem_p.h
@@ -42,24 +42,24 @@ public:
    * is then used by PeriodicTable to figure out which element was clicked on.
    */
   ElementItem(int elementNumber = 0);
-  ~ElementItem();
+  ~ElementItem() override;
 
   /**
    * @return the bounding rectangle of the element item.
    */
-  QRectF boundingRect() const;
+  QRectF boundingRect() const override;
 
   /**
    * @return the painter path which is also a rectangle in this case.
    */
-  QPainterPath shape() const;
+  QPainterPath shape() const override;
 
   /**
    * This is where most of the action takes place. The element box is drawn
    * along with its symbol.
    */
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget);
+             QWidget* widget) override;
 
 private:
   /** Indicates if element is well-formed (e.g., has non-empty symbol). */

--- a/avogadro/qtgui/extensionplugin.h
+++ b/avogadro/qtgui/extensionplugin.h
@@ -53,7 +53,7 @@ class AVOGADROQTGUI_EXPORT ExtensionPlugin : public QObject
 
 public:
   explicit ExtensionPlugin(QObject* parent = 0);
-  ~ExtensionPlugin();
+  ~ExtensionPlugin() override;
 
   /**
    * The name of the extension plugin, will be displayed in the user interface.
@@ -154,7 +154,7 @@ class AVOGADROQTGUI_EXPORT ExtensionPluginFactory
   : public QtPlugins::PluginFactory<ExtensionPlugin>
 {
 public:
-  virtual ~ExtensionPluginFactory();
+  ~ExtensionPluginFactory() override;
 };
 
 } // End QtGui namespace

--- a/avogadro/qtgui/filebrowsewidget.h
+++ b/avogadro/qtgui/filebrowsewidget.h
@@ -40,7 +40,7 @@ public:
   };
 
   explicit FileBrowseWidget(QWidget* theParent = 0);
-  ~FileBrowseWidget();
+  ~FileBrowseWidget() override;
 
   QString fileName() const;
 

--- a/avogadro/qtgui/fileformatdialog.h
+++ b/avogadro/qtgui/fileformatdialog.h
@@ -114,7 +114,7 @@ private:
    * complex use cases arise.
    */
   explicit FileFormatDialog(QWidget* parent = nullptr);
-  ~FileFormatDialog();
+  ~FileFormatDialog() override;
 
   /**
    * @return A filter string for use with a QFileDialog, containing entries

--- a/avogadro/qtgui/generichighlighter.h
+++ b/avogadro/qtgui/generichighlighter.h
@@ -99,7 +99,7 @@ public:
   }
 
 protected:
-  void highlightBlock(const QString& text);
+  void highlightBlock(const QString& text) override;
 
 private:
   QList<Rule> m_rules;

--- a/avogadro/qtgui/interfacescript.h
+++ b/avogadro/qtgui/interfacescript.h
@@ -465,7 +465,7 @@ public:
   explicit InterfaceScript(const QString& scriptFilePath_,
                            QObject* parent_ = nullptr);
   explicit InterfaceScript(QObject* parent_ = nullptr);
-  ~InterfaceScript();
+  ~InterfaceScript() override;
 
   /**
    * @return True if debugging is enabled.

--- a/avogadro/qtgui/interfacewidget.h
+++ b/avogadro/qtgui/interfacewidget.h
@@ -54,7 +54,7 @@ public:
    * script specified by scriptFilePath.
    */
   explicit InterfaceWidget(const QString& scriptFilePath, QWidget* parent_ = 0);
-  ~InterfaceWidget();
+  ~InterfaceWidget() override;
 
   /**
    * Use the script pointed to by scriptFilePath.

--- a/avogadro/qtgui/meshgenerator.h
+++ b/avogadro/qtgui/meshgenerator.h
@@ -73,7 +73,7 @@ public:
   /**
    * Destructor.
    */
-  ~MeshGenerator();
+  ~MeshGenerator() override;
 
   /**
    * Initialization function, set up the MeshGenerator ready to find an
@@ -89,7 +89,7 @@ public:
    * Use this function to begin Mesh generation. Uses an asynchronous thread,
    * and so avoids locking the user interface while the isosurface is found.
    */
-  void run();
+  void run() override;
 
   /**
    * @return The Cube being used by the class.

--- a/avogadro/qtgui/molecule.h
+++ b/avogadro/qtgui/molecule.h
@@ -56,7 +56,7 @@ public:
   typedef PersistentBond<Molecule> PersistentBondType;
 
   Molecule(QObject* parent_ = 0);
-  ~Molecule();
+  ~Molecule() override;
   /** copy constructor */
   Molecule(const Molecule& other);
 

--- a/avogadro/qtgui/molecule.h
+++ b/avogadro/qtgui/molecule.h
@@ -38,7 +38,9 @@ class RWMolecule;
  * @brief A QObject derived molecule object with signals/slots.
  */
 
-class AVOGADROQTGUI_EXPORT Molecule : public QObject, public Core::Molecule
+class AVOGADROQTGUI_EXPORT Molecule
+  : public QObject
+  , public Core::Molecule
 {
   Q_OBJECT
 

--- a/avogadro/qtgui/moleculemodel.h
+++ b/avogadro/qtgui/moleculemodel.h
@@ -29,7 +29,11 @@ class Molecule;
 
 struct MoleculeSystem
 {
-  MoleculeSystem() : m_molecule(nullptr), m_dirty(false), m_active(false) {}
+  MoleculeSystem()
+    : m_molecule(nullptr)
+    , m_dirty(false)
+    , m_active(false)
+  {}
 
   Molecule* m_molecule;
   Eigen::Affine3f m_modelView;
@@ -56,7 +60,8 @@ public:
 
   Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  bool setData(const QModelIndex& index, const QVariant& value,
+               int role) override;
   QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,

--- a/avogadro/qtgui/moleculemodel.h
+++ b/avogadro/qtgui/moleculemodel.h
@@ -50,17 +50,17 @@ class AVOGADROQTGUI_EXPORT MoleculeModel : public QAbstractItemModel
 public:
   explicit MoleculeModel(QObject* p = 0);
 
-  QModelIndex parent(const QModelIndex& child) const;
-  int rowCount(const QModelIndex& parent) const;
-  int columnCount(const QModelIndex& parent) const;
+  QModelIndex parent(const QModelIndex& child) const override;
+  int rowCount(const QModelIndex& parent) const override;
+  int columnCount(const QModelIndex& parent) const override;
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role);
-  QVariant data(const QModelIndex& index, int role) const;
+  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,
-                    const QModelIndex& parent = QModelIndex()) const;
+                    const QModelIndex& parent = QModelIndex()) const override;
 
   void clear();
 

--- a/avogadro/qtgui/multiviewwidget.cpp
+++ b/avogadro/qtgui/multiviewwidget.cpp
@@ -38,7 +38,7 @@ signals:
   void activeWidget(QWidget* widget);
 
 protected:
-  bool eventFilter(QObject* obj, QEvent* e)
+  bool eventFilter(QObject* obj, QEvent* e) override
   {
     Q_ASSERT(m_widget);
     if (e->type() == QEvent::MouseButtonPress) {

--- a/avogadro/qtgui/multiviewwidget.cpp
+++ b/avogadro/qtgui/multiviewwidget.cpp
@@ -32,7 +32,10 @@ class ActiveWidgetFilter : public QObject
   Q_OBJECT
 
 public:
-  ActiveWidgetFilter(MultiViewWidget* p = 0) : QObject(p), m_widget(p) {}
+  ActiveWidgetFilter(MultiViewWidget* p = 0)
+    : QObject(p)
+    , m_widget(p)
+  {}
 
 signals:
   void activeWidget(QWidget* widget);
@@ -54,14 +57,13 @@ protected:
 };
 
 MultiViewWidget::MultiViewWidget(QWidget* p, Qt::WindowFlags f)
-  : QWidget(p, f), m_factory(nullptr), m_activeWidget(nullptr),
-    m_activeFilter(new ActiveWidgetFilter(this))
-{
-}
+  : QWidget(p, f)
+  , m_factory(nullptr)
+  , m_activeWidget(nullptr)
+  , m_activeFilter(new ActiveWidgetFilter(this))
+{}
 
-MultiViewWidget::~MultiViewWidget()
-{
-}
+MultiViewWidget::~MultiViewWidget() {}
 
 void MultiViewWidget::addWidget(QWidget* widget)
 {

--- a/avogadro/qtgui/multiviewwidget.h
+++ b/avogadro/qtgui/multiviewwidget.h
@@ -42,7 +42,7 @@ class AVOGADROQTGUI_EXPORT MultiViewWidget : public QWidget
 
 public:
   explicit MultiViewWidget(QWidget* parent = 0, Qt::WindowFlags f = 0);
-  ~MultiViewWidget();
+  ~MultiViewWidget() override;
 
   void addWidget(QWidget* widget);
 

--- a/avogadro/qtgui/periodictablescene_p.h
+++ b/avogadro/qtgui/periodictablescene_p.h
@@ -58,7 +58,7 @@ protected:
   /**
    * Handles the mouse press events to change the active element.
    */
-  void mousePressEvent(QGraphicsSceneMouseEvent* event);
+  void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
 
 private:
   ElementDetail* m_detail;

--- a/avogadro/qtgui/periodictableview.h
+++ b/avogadro/qtgui/periodictableview.h
@@ -46,7 +46,7 @@ public:
    * of PeriodicTableScene.
    */
   explicit PeriodicTableView(QWidget* parent_ = 0);
-  ~PeriodicTableView();
+  ~PeriodicTableView() override;
 
   /**
    * @return The currently selected element.
@@ -80,17 +80,17 @@ protected:
   /**
    * Double click event - select an element and hide the PeriodicTableView.
    */
-  void mouseDoubleClickEvent(QMouseEvent* event);
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
 
   /**
    * Handles the keyboard events to change the active element.
    */
-  void keyPressEvent(QKeyEvent* event_);
+  void keyPressEvent(QKeyEvent* event_) override;
 
   /**
    * Handle resize events.
    */
-  void resizeEvent(QResizeEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
 
 private:
   /**

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -45,7 +45,10 @@ using Core::UnitCell;
 class RWMolecule::UndoCommand : public QUndoCommand
 {
 public:
-  UndoCommand(RWMolecule& m) : QUndoCommand(tr("Modify Molecule")), m_mol(m) {}
+  UndoCommand(RWMolecule& m)
+    : QUndoCommand(tr("Modify Molecule"))
+    , m_mol(m)
+  {}
 
 protected:
   Array<Index>& atomUniqueIds() { return m_mol.m_molecule.atomUniqueIds(); }
@@ -85,26 +88,28 @@ enum MergeIds
 // To add a new class, add a new entry to the MergeIds enum above and use that
 // symbolic value as the template parameter. Implement the mergeWith() method
 // to update the "after" state. See SetPositions3dCommand for an example.
-template <int Id>
+template<int Id>
 class MergeUndoCommand : public RWMolecule::UndoCommand
 {
   bool m_canMerge;
 
 public:
-  MergeUndoCommand(RWMolecule& m) : UndoCommand(m), m_canMerge(false) {}
+  MergeUndoCommand(RWMolecule& m)
+    : UndoCommand(m)
+    , m_canMerge(false)
+  {}
   void setCanMerge(bool merge) { m_canMerge = merge; }
   bool canMerge() const { return m_canMerge; }
   int id() const override { return m_canMerge ? Id : -1; }
 };
 } // end anon namespace
 
-RWMolecule::RWMolecule(Molecule& mol, QObject* p) : QObject(p), m_molecule(mol)
-{
-}
+RWMolecule::RWMolecule(Molecule& mol, QObject* p)
+  : QObject(p)
+  , m_molecule(mol)
+{}
 
-RWMolecule::~RWMolecule()
-{
-}
+RWMolecule::~RWMolecule() {}
 
 namespace {
 class AddAtomCommand : public RWMolecule::UndoCommand
@@ -117,10 +122,12 @@ class AddAtomCommand : public RWMolecule::UndoCommand
 public:
   AddAtomCommand(RWMolecule& m, unsigned char aN, bool usingPositions,
                  Index atomId, Index uid)
-    : UndoCommand(m), m_atomicNumber(aN), m_usingPositions(usingPositions),
-      m_atomId(atomId), m_uniqueId(uid)
-  {
-  }
+    : UndoCommand(m)
+    , m_atomicNumber(aN)
+    , m_usingPositions(usingPositions)
+    , m_atomId(atomId)
+    , m_uniqueId(uid)
+  {}
 
   void redo() override
   {
@@ -183,10 +190,12 @@ class RemoveAtomCommand : public RWMolecule::UndoCommand
 public:
   RemoveAtomCommand(RWMolecule& m, Index atomId, Index uid, unsigned char aN,
                     const Vector3& pos)
-    : UndoCommand(m), m_atomId(atomId), m_atomUid(uid), m_atomicNumber(aN),
-      m_position3d(pos)
-  {
-  }
+    : UndoCommand(m)
+    , m_atomId(atomId)
+    , m_atomUid(uid)
+    , m_atomicNumber(aN)
+    , m_position3d(pos)
+  {}
 
   void redo() override
   {
@@ -335,10 +344,10 @@ public:
   SetAtomicNumbersCommand(RWMolecule& m,
                           const Core::Array<unsigned char>& oldAtomicNumbers,
                           const Core::Array<unsigned char>& newAtomicNumbers)
-    : UndoCommand(m), m_oldAtomicNumbers(oldAtomicNumbers),
-      m_newAtomicNumbers(newAtomicNumbers)
-  {
-  }
+    : UndoCommand(m)
+    , m_oldAtomicNumbers(oldAtomicNumbers)
+    , m_newAtomicNumbers(newAtomicNumbers)
+  {}
 
   void redo() override { atomicNumbers() = m_newAtomicNumbers; }
 
@@ -369,10 +378,11 @@ public:
   SetAtomicNumberCommand(RWMolecule& m, Index atomId,
                          unsigned char oldAtomicNumber,
                          unsigned char newAtomicNumber)
-    : UndoCommand(m), m_atomId(atomId), m_oldAtomicNumber(oldAtomicNumber),
-      m_newAtomicNumber(newAtomicNumber)
-  {
-  }
+    : UndoCommand(m)
+    , m_atomId(atomId)
+    , m_oldAtomicNumber(oldAtomicNumber)
+    , m_newAtomicNumber(newAtomicNumber)
+  {}
 
   void redo() override { atomicNumbers()[m_atomId] = m_newAtomicNumber; }
 
@@ -402,10 +412,10 @@ public:
   SetPositions3dCommand(RWMolecule& m,
                         const Core::Array<Vector3>& oldPositions3d,
                         const Core::Array<Vector3>& newPositions3d)
-    : MergeUndoCommand<SetPositions3dMergeId>(m),
-      m_oldPositions3d(oldPositions3d), m_newPositions3d(newPositions3d)
-  {
-  }
+    : MergeUndoCommand<SetPositions3dMergeId>(m)
+    , m_oldPositions3d(oldPositions3d)
+    , m_newPositions3d(newPositions3d)
+  {}
 
   void redo() override { positions3d() = m_newPositions3d; }
 
@@ -449,10 +459,11 @@ public:
   SetPosition3dCommand(RWMolecule& m, Index atomId,
                        const Vector3& oldPosition3d,
                        const Vector3& newPosition3d)
-    : MergeUndoCommand<SetPosition3dMergeId>(m), m_atomIds(1, atomId),
-      m_oldPosition3ds(1, oldPosition3d), m_newPosition3ds(1, newPosition3d)
-  {
-  }
+    : MergeUndoCommand<SetPosition3dMergeId>(m)
+    , m_atomIds(1, atomId)
+    , m_oldPosition3ds(1, oldPosition3d)
+    , m_newPosition3ds(1, newPosition3d)
+  {}
 
   void redo() override
   {
@@ -546,10 +557,11 @@ public:
   SetAtomHybridizationCommand(RWMolecule& m, Index atomId,
                               Core::AtomHybridization oldHybridization,
                               Core::AtomHybridization newHybridization)
-    : UndoCommand(m), m_atomId(atomId), m_oldHybridization(oldHybridization),
-      m_newHybridization(newHybridization)
-  {
-  }
+    : UndoCommand(m)
+    , m_atomId(atomId)
+    , m_oldHybridization(oldHybridization)
+    , m_newHybridization(newHybridization)
+  {}
 
   void redo() override { hybridizations()[m_atomId] = m_newHybridization; }
 
@@ -579,10 +591,11 @@ class SetAtomFormalChargeCommand : public RWMolecule::UndoCommand
 public:
   SetAtomFormalChargeCommand(RWMolecule& m, Index atomId, signed char oldCharge,
                              signed char newCharge)
-    : UndoCommand(m), m_atomId(atomId), m_oldCharge(oldCharge),
-      m_newCharge(newCharge)
-  {
-  }
+    : UndoCommand(m)
+    , m_atomId(atomId)
+    , m_oldCharge(oldCharge)
+    , m_newCharge(newCharge)
+  {}
 
   void redo() override { formalCharges()[m_atomId] = m_newCharge; }
 
@@ -614,10 +627,12 @@ public:
   AddBondCommand(RWMolecule& m, unsigned char order,
                  const std::pair<Index, Index>& bondPair, Index bondId,
                  Index uid)
-    : UndoCommand(m), m_bondOrder(order), m_bondPair(bondPair),
-      m_bondId(bondId), m_uniqueId(uid)
-  {
-  }
+    : UndoCommand(m)
+    , m_bondOrder(order)
+    , m_bondPair(bondPair)
+    , m_bondId(bondId)
+    , m_uniqueId(uid)
+  {}
 
   void redo() override
   {
@@ -686,10 +701,12 @@ public:
   RemoveBondCommand(RWMolecule& m, Index bondId, Index bondUid,
                     const std::pair<Index, Index>& bondPair,
                     unsigned char bondOrder)
-    : UndoCommand(m), m_bondId(bondId), m_bondUid(bondUid),
-      m_bondPair(bondPair), m_bondOrder(bondOrder)
-  {
-  }
+    : UndoCommand(m)
+    , m_bondId(bondId)
+    , m_bondUid(bondUid)
+    , m_bondPair(bondPair)
+    , m_bondOrder(bondOrder)
+  {}
 
   void redo() override
   {
@@ -772,10 +789,10 @@ class SetBondOrdersCommand : public RWMolecule::UndoCommand
 public:
   SetBondOrdersCommand(RWMolecule& m, const Array<unsigned char>& oldBondOrders,
                        const Array<unsigned char>& newBondOrders)
-    : UndoCommand(m), m_oldBondOrders(oldBondOrders),
-      m_newBondOrders(newBondOrders)
-  {
-  }
+    : UndoCommand(m)
+    , m_oldBondOrders(oldBondOrders)
+    , m_newBondOrders(newBondOrders)
+  {}
 
   void redo() override { bondOrders() = m_newBondOrders; }
 
@@ -805,10 +822,11 @@ class SetBondOrderCommand : public MergeUndoCommand<SetBondOrderMergeId>
 public:
   SetBondOrderCommand(RWMolecule& m, Index bondId, unsigned char oldBondOrder,
                       unsigned char newBondOrder)
-    : MergeUndoCommand<SetBondOrderMergeId>(m), m_bondId(bondId),
-      m_oldBondOrder(oldBondOrder), m_newBondOrder(newBondOrder)
-  {
-  }
+    : MergeUndoCommand<SetBondOrderMergeId>(m)
+    , m_bondId(bondId)
+    , m_oldBondOrder(oldBondOrder)
+    , m_newBondOrder(newBondOrder)
+  {}
 
   void redo() override { bondOrders()[m_bondId] = m_newBondOrder; }
 
@@ -852,9 +870,10 @@ public:
   SetBondPairsCommand(RWMolecule& m,
                       const Array<std::pair<Index, Index>>& oldBondPairs,
                       const Array<std::pair<Index, Index>>& newBondPairs)
-    : UndoCommand(m), m_oldBondPairs(oldBondPairs), m_newBondPairs(newBondPairs)
-  {
-  }
+    : UndoCommand(m)
+    , m_oldBondPairs(oldBondPairs)
+    , m_newBondPairs(newBondPairs)
+  {}
 
   void redo() override { bondPairs() = m_newBondPairs; }
 
@@ -895,10 +914,11 @@ public:
   SetBondPairCommand(RWMolecule& m, Index bondId,
                      const std::pair<Index, Index>& oldBondPair,
                      const std::pair<Index, Index>& newBondPair)
-    : UndoCommand(m), m_bondId(bondId), m_oldBondPair(oldBondPair),
-      m_newBondPair(newBondPair)
-  {
-  }
+    : UndoCommand(m)
+    , m_bondId(bondId)
+    , m_oldBondPair(oldBondPair)
+    , m_newBondPair(newBondPair)
+  {}
 
   void redo() override { bondPairs()[m_bondId] = m_newBondPair; }
 
@@ -931,9 +951,9 @@ class AddUnitCellCommand : public RWMolecule::UndoCommand
 
 public:
   AddUnitCellCommand(RWMolecule& m, const UnitCell& newUnitCell)
-    : UndoCommand(m), m_newUnitCell(newUnitCell)
-  {
-  }
+    : UndoCommand(m)
+    , m_newUnitCell(newUnitCell)
+  {}
 
   void redo() override
   {
@@ -971,9 +991,9 @@ class RemoveUnitCellCommand : public RWMolecule::UndoCommand
 
 public:
   RemoveUnitCellCommand(RWMolecule& m, const UnitCell& oldUnitCell)
-    : UndoCommand(m), m_oldUnitCell(oldUnitCell)
-  {
-  }
+    : UndoCommand(m)
+    , m_oldUnitCell(oldUnitCell)
+  {}
 
   void redo() override { m_mol.molecule().setUnitCell(nullptr); }
 
@@ -1008,9 +1028,10 @@ class ModifyMoleculeCommand : public RWMolecule::UndoCommand
 public:
   ModifyMoleculeCommand(RWMolecule& m, const Molecule& oldMolecule,
                         const Molecule& newMolecule)
-    : UndoCommand(m), m_oldMolecule(oldMolecule), m_newMolecule(newMolecule)
-  {
-  }
+    : UndoCommand(m)
+    , m_oldMolecule(oldMolecule)
+    , m_newMolecule(newMolecule)
+  {}
 
   void redo() override { m_mol.molecule() = m_newMolecule; }
 

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -411,7 +411,7 @@ public:
 
   void undo() override { positions3d() = m_oldPositions3d; }
 
-  bool mergeWith(const QUndoCommand* other)
+  bool mergeWith(const QUndoCommand* other) override
   {
     const SetPositions3dCommand* o =
       dynamic_cast<const SetPositions3dCommand*>(other);
@@ -466,7 +466,7 @@ public:
       positions3d()[m_atomIds[i]] = m_oldPosition3ds[i];
   }
 
-  bool mergeWith(const QUndoCommand* o)
+  bool mergeWith(const QUndoCommand* o) override
   {
     const SetPosition3dCommand* other =
       dynamic_cast<const SetPosition3dCommand*>(o);
@@ -814,7 +814,7 @@ public:
 
   void undo() override { bondOrders()[m_bondId] = m_oldBondOrder; }
 
-  bool mergeWith(const QUndoCommand* other)
+  bool mergeWith(const QUndoCommand* other) override
   {
     const SetBondOrderCommand* o =
       dynamic_cast<const SetBondOrderCommand*>(other);

--- a/avogadro/qtgui/sceneplugin.h
+++ b/avogadro/qtgui/sceneplugin.h
@@ -49,7 +49,7 @@ class AVOGADROQTGUI_EXPORT ScenePlugin : public QObject
 
 public:
   explicit ScenePlugin(QObject* parent = 0);
-  ~ScenePlugin();
+  ~ScenePlugin() override;
 
   /**
    * Process the supplied atom, and add the necessary primitives to the scene.
@@ -95,7 +95,7 @@ class AVOGADROQTGUI_EXPORT ScenePluginFactory
   : public Avogadro::QtPlugins::PluginFactory<ScenePlugin>
 {
 public:
-  virtual ~ScenePluginFactory() {}
+  ~ScenePluginFactory() override {}
 };
 
 } // End QtGui namespace

--- a/avogadro/qtgui/scenepluginmodel.h
+++ b/avogadro/qtgui/scenepluginmodel.h
@@ -40,17 +40,17 @@ class AVOGADROQTGUI_EXPORT ScenePluginModel : public QAbstractItemModel
 public:
   explicit ScenePluginModel(QObject* parent = 0);
 
-  QModelIndex parent(const QModelIndex& child) const;
-  int rowCount(const QModelIndex& parent) const;
-  int columnCount(const QModelIndex& parent) const;
+  QModelIndex parent(const QModelIndex& child) const override;
+  int rowCount(const QModelIndex& parent) const override;
+  int columnCount(const QModelIndex& parent) const override;
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role);
-  QVariant data(const QModelIndex& index, int role) const;
+  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,
-                    const QModelIndex& parent = QModelIndex()) const;
+                    const QModelIndex& parent = QModelIndex()) const override;
 
   void clear();
 

--- a/avogadro/qtgui/scenepluginmodel.h
+++ b/avogadro/qtgui/scenepluginmodel.h
@@ -46,7 +46,8 @@ public:
 
   Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  bool setData(const QModelIndex& index, const QVariant& value,
+               int role) override;
   QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,

--- a/avogadro/qtgui/toolplugin.h
+++ b/avogadro/qtgui/toolplugin.h
@@ -53,7 +53,7 @@ class AVOGADROQTGUI_EXPORT ToolPlugin : public QObject
 
 public:
   explicit ToolPlugin(QObject* parent = 0);
-  ~ToolPlugin();
+  ~ToolPlugin() override;
 
   /**
    * The name of the tool, will be displayed in the user interface.

--- a/avogadro/qtopengl/glwidget.h
+++ b/avogadro/qtopengl/glwidget.h
@@ -58,7 +58,7 @@ class AVOGADROQTOPENGL_EXPORT GLWidget : public QOpenGLWidget
 
 public:
   explicit GLWidget(QWidget* parent = 0);
-  ~GLWidget();
+  ~GLWidget() override;
 
   /** Set the molecule the widget will render. */
   void setMolecule(QtGui::Molecule* molecule);
@@ -178,22 +178,22 @@ protected slots:
 
 protected:
   /** This is where the GL context is initialized. */
-  void initializeGL();
+  void initializeGL() override;
 
   /** Take care of resizing the context. */
-  void resizeGL(int width, int height);
+  void resizeGL(int width, int height) override;
 
   /** Main entry point for all GL rendering. */
-  void paintGL();
+  void paintGL() override;
 
   /** Reimplemented from QOpenGLWidget @{ */
-  void mouseDoubleClickEvent(QMouseEvent*);
-  void mousePressEvent(QMouseEvent*);
-  void mouseMoveEvent(QMouseEvent*);
-  void mouseReleaseEvent(QMouseEvent*);
-  void wheelEvent(QWheelEvent*);
-  void keyPressEvent(QKeyEvent*);
-  void keyReleaseEvent(QKeyEvent*);
+  void mouseDoubleClickEvent(QMouseEvent*) override;
+  void mousePressEvent(QMouseEvent*) override;
+  void mouseMoveEvent(QMouseEvent*) override;
+  void mouseReleaseEvent(QMouseEvent*) override;
+  void wheelEvent(QWheelEvent*) override;
+  void keyPressEvent(QKeyEvent*) override;
+  void keyReleaseEvent(QKeyEvent*) override;
   /** @} */
 
 private:

--- a/avogadro/qtplugins/3dmol/3dmol.h
+++ b/avogadro/qtplugins/3dmol/3dmol.h
@@ -37,15 +37,15 @@ class ThreeDMol : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit ThreeDMol(QObject* parent_ = 0);
-  ~ThreeDMol();
+  ~ThreeDMol() override;
 
-  QString name() const { return tr("ThreeDMol"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("ThreeDMol"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void showDialog();

--- a/avogadro/qtplugins/3dmol/3dmoldialog.h
+++ b/avogadro/qtplugins/3dmol/3dmoldialog.h
@@ -45,7 +45,7 @@ class ThreeDMolDialog : public QDialog
 
 public:
   explicit ThreeDMolDialog(QtGui::Molecule* mol, QWidget* parent_ = 0);
-  ~ThreeDMolDialog();
+  ~ThreeDMolDialog() override;
 
   QtGui::Molecule* molecule() { return m_molecule; }
 

--- a/avogadro/qtplugins/apbs/apbsdialog.h
+++ b/avogadro/qtplugins/apbs/apbsdialog.h
@@ -51,7 +51,7 @@ public:
   /**
    * Destructor for ApbsDialog.
    */
-  ~ApbsDialog();
+  ~ApbsDialog() override;
 
   void setMolecule(QtGui::Molecule* molecule);
 

--- a/avogadro/qtplugins/apbs/apbsoutputdialog.h
+++ b/avogadro/qtplugins/apbs/apbsoutputdialog.h
@@ -46,7 +46,7 @@ public:
   /**
    * Destructor for ApbsOutputDialog.
    */
-  ~ApbsOutputDialog();
+  ~ApbsOutputDialog() override;
 
   /**
    * Returns true if the user checked the 'Load Structure' check box.

--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
@@ -120,7 +120,7 @@ class Quad : public MeshGeometry
 {
 public:
   Quad() {}
-  ~Quad() {}
+  ~Quad() override {}
 
   /**
    * @brief setQuad Set the four corners of the quad.
@@ -161,7 +161,7 @@ class ArcSector : public MeshGeometry
 {
 public:
   ArcSector() {}
-  ~ArcSector() {}
+  ~ArcSector() override {}
 
   /**
    * Define the sector.
@@ -227,7 +227,7 @@ class QuadOutline : public LineStripGeometry
 {
 public:
   QuadOutline() {}
-  ~QuadOutline() {}
+  ~QuadOutline() override {}
 
   /**
    * @brief setQuad Set the four corners of the quad.
@@ -257,7 +257,7 @@ class ArcStrip : public LineStripGeometry
 {
 public:
   ArcStrip() {}
-  ~ArcStrip() {}
+  ~ArcStrip() override {}
 
   /**
    * Define the arc.

--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
@@ -56,11 +56,11 @@ namespace Avogadro {
 namespace QtPlugins {
 
 using Core::Array;
+using Core::Elements;
+using QtGui::Molecule;
 using QtGui::RWAtom;
 using QtGui::RWBond;
 using QtGui::RWMolecule;
-using QtGui::Molecule;
-using Core::Elements;
 using Rendering::GeometryNode;
 using Rendering::GroupNode;
 using Rendering::Identifier;
@@ -305,17 +305,19 @@ void ArcStrip::setArc(const Vector3f& origin, const Vector3f& start,
 } // end anon namespace
 
 BondCentricTool::BondCentricTool(QObject* parent_)
-  : QtGui::ToolPlugin(parent_), m_activateAction(new QAction(this)),
-    m_molecule(nullptr), m_renderer(nullptr), m_moveState(IgnoreMove),
-    m_planeSnapIncr(10.f), m_snapPlaneToBonds(true)
+  : QtGui::ToolPlugin(parent_)
+  , m_activateAction(new QAction(this))
+  , m_molecule(nullptr)
+  , m_renderer(nullptr)
+  , m_moveState(IgnoreMove)
+  , m_planeSnapIncr(10.f)
+  , m_snapPlaneToBonds(true)
 {
   m_activateAction->setText(tr("Bond-centric manipulation"));
   m_activateAction->setIcon(QIcon(":/icons/bondcentrictool.png"));
 }
 
-BondCentricTool::~BondCentricTool()
-{
-}
+BondCentricTool::~BondCentricTool() {}
 
 QWidget* BondCentricTool::toolWidget() const
 {
@@ -338,9 +340,7 @@ void BondCentricTool::setEditMolecule(QtGui::RWMolecule* mol)
   }
 }
 
-void BondCentricTool::setGLWidget(QtOpenGL::GLWidget*)
-{
-}
+void BondCentricTool::setGLWidget(QtOpenGL::GLWidget*) {}
 
 void BondCentricTool::setGLRenderer(Rendering::GLRenderer* ren)
 {

--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.h
@@ -60,7 +60,7 @@ class BondCentricTool : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit BondCentricTool(QObject* parent_ = nullptr);
-  ~BondCentricTool();
+  ~BondCentricTool() override;
 
   QString name() const override;
   QString description() const override;

--- a/avogadro/qtplugins/coordinateeditor/coordinateeditordialog.h
+++ b/avogadro/qtplugins/coordinateeditor/coordinateeditordialog.h
@@ -39,7 +39,7 @@ class CoordinateEditorDialog : public QDialog
   Q_OBJECT
 public:
   explicit CoordinateEditorDialog(QWidget* parent_ = 0);
-  ~CoordinateEditorDialog();
+  ~CoordinateEditorDialog() override;
 
   void setMolecule(QtGui::Molecule* mol);
 

--- a/avogadro/qtplugins/coordinateeditor/coordinatetextedit.h
+++ b/avogadro/qtplugins/coordinateeditor/coordinatetextedit.h
@@ -44,7 +44,7 @@ public slots:
   void markValid(QTextCursor& cur, const QString& tooltip);
 
 protected:
-  bool event(QEvent* e);
+  bool event(QEvent* e) override;
 
 private:
   void showToolTip(QHelpEvent* e) const;

--- a/avogadro/qtplugins/coordinateeditor/coordinatetextedit.h
+++ b/avogadro/qtplugins/coordinateeditor/coordinatetextedit.h
@@ -54,7 +54,11 @@ private:
     int start;
     int end;
     QString tooltip;
-    Mark(int s, int e, const QString& t) : start(s), end(e), tooltip(t) {}
+    Mark(int s, int e, const QString& t)
+      : start(s)
+      , end(e)
+      , tooltip(t)
+    {}
     bool contains(int i) const { return i >= start && i <= end; }
   };
   QList<Mark> m_marks;

--- a/avogadro/qtplugins/crystal/crystal.h
+++ b/avogadro/qtplugins/crystal/crystal.h
@@ -31,15 +31,15 @@ class Crystal : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit Crystal(QObject* parent_ = 0);
-  ~Crystal();
+  ~Crystal() override;
 
-  QString name() const { return tr("Crystal"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Crystal"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
   void moleculeChanged(unsigned int changes);
 

--- a/avogadro/qtplugins/crystal/crystalscene.h
+++ b/avogadro/qtplugins/crystal/crystalscene.h
@@ -38,7 +38,10 @@ public:
 
   QString name() const override { return tr("Crystal Lattice"); }
 
-  QString description() const override { return tr("Render the unit cell boundaries."); }
+  QString description() const override
+  {
+    return tr("Render the unit cell boundaries.");
+  }
 
   bool isEnabled() const override;
 

--- a/avogadro/qtplugins/crystal/crystalscene.h
+++ b/avogadro/qtplugins/crystal/crystalscene.h
@@ -31,18 +31,18 @@ class CrystalScene : public QtGui::ScenePlugin
 
 public:
   explicit CrystalScene(QObject* parent = 0);
-  ~CrystalScene();
+  ~CrystalScene() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Crystal Lattice"); }
+  QString name() const override { return tr("Crystal Lattice"); }
 
-  QString description() const { return tr("Render the unit cell boundaries."); }
+  QString description() const override { return tr("Render the unit cell boundaries."); }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/crystal/importcrystaldialog.h
+++ b/avogadro/qtplugins/crystal/importcrystaldialog.h
@@ -43,7 +43,7 @@ class ImportCrystalDialog : public QDialog
   Q_OBJECT
 public:
   ImportCrystalDialog(QWidget* p = 0);
-  ~ImportCrystalDialog();
+  ~ImportCrystalDialog() override;
 
   // Avogadro::Core::Molecule is required for the format function
   bool importCrystalClipboard(Avogadro::Core::Molecule& mol);

--- a/avogadro/qtplugins/crystal/supercelldialog.h
+++ b/avogadro/qtplugins/crystal/supercelldialog.h
@@ -43,7 +43,7 @@ class SupercellDialog : public QDialog
   Q_OBJECT
 public:
   SupercellDialog(QWidget* p = 0);
-  ~SupercellDialog();
+  ~SupercellDialog() override;
 
   bool buildSupercell(Avogadro::QtGui::Molecule& mol);
 

--- a/avogadro/qtplugins/crystal/volumescalingdialog.h
+++ b/avogadro/qtplugins/crystal/volumescalingdialog.h
@@ -36,7 +36,7 @@ class VolumeScalingDialog : public QDialog
 
 public:
   explicit VolumeScalingDialog(QWidget* parent = 0);
-  ~VolumeScalingDialog();
+  ~VolumeScalingDialog() override;
 
   void setCurrentVolume(double vol);
   double newVolume() const;

--- a/avogadro/qtplugins/customelements/customelements.h
+++ b/avogadro/qtplugins/customelements/customelements.h
@@ -30,15 +30,15 @@ class CustomElements : public QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit CustomElements(QObject* parent_ = 0);
-  ~CustomElements();
+  ~CustomElements() override;
 
-  QString name() const { return tr("Custom Elements"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Custom Elements"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void moleculeChanged(unsigned int changes);

--- a/avogadro/qtplugins/editor/editor.h
+++ b/avogadro/qtplugins/editor/editor.h
@@ -39,7 +39,7 @@ class Editor : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit Editor(QObject* parent_ = nullptr);
-  ~Editor();
+  ~Editor() override;
 
   QString name() const override { return tr("Editor tool"); }
   QString description() const override { return tr("Editor tool"); }

--- a/avogadro/qtplugins/editor/editortoolwidget.h
+++ b/avogadro/qtplugins/editor/editortoolwidget.h
@@ -36,7 +36,7 @@ class EditorToolWidget : public QWidget
 
 public:
   explicit EditorToolWidget(QWidget* parent_ = 0);
-  ~EditorToolWidget();
+  ~EditorToolWidget() override;
 
   void setAtomicNumber(unsigned char atomicNum);
   unsigned char atomicNumber() const;

--- a/avogadro/qtplugins/gamessinput/gamesshighlighter.h
+++ b/avogadro/qtplugins/gamessinput/gamesshighlighter.h
@@ -36,7 +36,7 @@ public:
   GamessHighlighter(QTextDocument* parent_ = 0);
 
 protected:
-  void highlightBlock(const QString& text);
+  void highlightBlock(const QString& text) override;
 
 private:
   struct HighlightingRule

--- a/avogadro/qtplugins/gamessinput/gamessinput.h
+++ b/avogadro/qtplugins/gamessinput/gamessinput.h
@@ -45,7 +45,10 @@ public:
 
   QString name() const override { return tr("GAMESS input"); }
 
-  QString description() const override { return tr("Generate input for GAMESS."); }
+  QString description() const override
+  {
+    return tr("Generate input for GAMESS.");
+  }
 
   QList<QAction*> actions() const override;
 

--- a/avogadro/qtplugins/gamessinput/gamessinput.h
+++ b/avogadro/qtplugins/gamessinput/gamessinput.h
@@ -41,17 +41,17 @@ class GamessInput : public QtGui::ExtensionPlugin
 
 public:
   explicit GamessInput(QObject* parent = 0);
-  ~GamessInput();
+  ~GamessInput() override;
 
-  QString name() const { return tr("GAMESS input"); }
+  QString name() const override { return tr("GAMESS input"); }
 
-  QString description() const { return tr("Generate input for GAMESS."); }
+  QString description() const override { return tr("Generate input for GAMESS."); }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 public slots:
   /**
@@ -59,7 +59,7 @@ public slots:
    */
   void openJobOutput(const MoleQueue::JobObject& job);
 
-  bool readMolecule(QtGui::Molecule& mol);
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void menuActivated();

--- a/avogadro/qtplugins/gamessinput/gamessinputdialog.h
+++ b/avogadro/qtplugins/gamessinput/gamessinputdialog.h
@@ -45,7 +45,7 @@ class GamessInputDialog : public QDialog
 
 public:
   explicit GamessInputDialog(QWidget* parent_ = 0, Qt::WindowFlags f = 0);
-  ~GamessInputDialog();
+  ~GamessInputDialog() override;
 
   void setMolecule(QtGui::Molecule* mol);
 
@@ -56,7 +56,7 @@ signals:
   void openJobOutput(const MoleQueue::JobObject& job);
 
 protected:
-  void showEvent(QShowEvent* e);
+  void showEvent(QShowEvent* e) override;
 
 private slots:
   void updatePreviewText();

--- a/avogadro/qtplugins/hydrogens/hydrogens.h
+++ b/avogadro/qtplugins/hydrogens/hydrogens.h
@@ -30,15 +30,15 @@ class Hydrogens : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit Hydrogens(QObject* parent_ = 0);
-  ~Hydrogens();
+  ~Hydrogens() override;
 
-  QString name() const { return tr("Hydrogens"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Hydrogens"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void adjustHydrogens();

--- a/avogadro/qtplugins/importpqr/importpqr.h
+++ b/avogadro/qtplugins/importpqr/importpqr.h
@@ -56,8 +56,8 @@ public:
   void setMoleculeData(QByteArray& molData, QString name);
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
-  bool readMolecule(QtGui::Molecule& mol);
+  void setMolecule(QtGui::Molecule* mol) override;
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void menuActivated();

--- a/avogadro/qtplugins/importpqr/pqrrequest.h
+++ b/avogadro/qtplugins/importpqr/pqrrequest.h
@@ -35,68 +35,68 @@ class PQRRequest : public QObject
 
 public:
   /**
-  * @brief Constuctor to initialize the NetworkAcessManager and set pointers to
-  * the widget's ui elements.
-  * @param tw Pointer to ui's table widget
-  * @param gv Pointer to ui's graphics view for SVG preview
-  * @param nd Pointer to the name display
-  * @param fd Pointer to the formula display
-  */
+   * @brief Constuctor to initialize the NetworkAcessManager and set pointers to
+   * the widget's ui elements.
+   * @param tw Pointer to ui's table widget
+   * @param gv Pointer to ui's graphics view for SVG preview
+   * @param nd Pointer to the name display
+   * @param fd Pointer to the formula display
+   */
   PQRRequest(QTableWidget*, QLabel*, QLineEdit*, QLabel*, PQRWidget*);
 
   /**
-  * @brief Free the ui pointers
-  */
+   * @brief Free the ui pointers
+   */
   ~PQRRequest() override;
 
   /**
-  * @brief Sends a network request to search for molecules from PQR;
-  * @param url The url to query
-  */
+   * @brief Sends a network request to search for molecules from PQR;
+   * @param url The url to query
+   */
   void sendRequest(QString);
 
   /**
-  * @brief Sends a network request to download a file from PQR
-  * @param url The url to send the request to
-  * @param mol2 The mol2 representation of the molecule to download
-  */
+   * @brief Sends a network request to download a file from PQR
+   * @param url The url to send the request to
+   * @param mol2 The mol2 representation of the molecule to download
+   */
   void sendRequest(QString, QString);
 
   /**
-  * @brief Sends a network request to download a png form PQR
-  * @param url The url to send the request to
-  */
+   * @brief Sends a network request to download a png form PQR
+   * @param url The url to send the request to
+   */
   void sendPNGRequest(QString url);
 
   /**
-  * @brief Called when a molecule is selected to display information about the
-  * molecule and start grabbing the SVG preview.
-  * @param num The row number of the table result selected
-  * @returns The mol2 of the result for the widget to reference
-  */
+   * @brief Called when a molecule is selected to display information about the
+   * molecule and start grabbing the SVG preview.
+   * @param num The row number of the table result selected
+   * @returns The mol2 of the result for the widget to reference
+   */
   QString molSelected(int);
 
 private slots:
   /**
-  * @brief Parses the JSON response from querying PQR
-  */
+   * @brief Parses the JSON response from querying PQR
+   */
   void parseJson();
 
   /**
-  * @brief Creates a file after requesting a file from PQR
-  */
+   * @brief Creates a file after requesting a file from PQR
+   */
   void getFile();
 
   /**
-  * @brief Loads PNG data after sending a request
-  */
+   * @brief Loads PNG data after sending a request
+   */
   void SetPNG();
 
 private:
   /**
-  * @brief The result struct holds all data received in each result from
-  * querying PQR
-  */
+   * @brief The result struct holds all data received in each result from
+   * querying PQR
+   */
   struct result
   {
     QString inchikey;
@@ -132,15 +132,16 @@ private:
   QString currentMolName;
 
   /**
-  * @brief Takes a formula string and returns a QString with subscript tags
-  * @param formula The formula string
-  */
+   * @brief Takes a formula string and returns a QString with subscript tags
+   * @param formula The formula string
+   */
   QString parseSubscripts(QString);
 
   /**
-  * @brief Takes a formula string and returns the molecular mass of the molecule
-  * @param formula The formula string
-  */
+   * @brief Takes a formula string and returns the molecular mass of the
+   * molecule
+   * @param formula The formula string
+   */
   float getMolMass(QString);
 };
 }

--- a/avogadro/qtplugins/importpqr/pqrrequest.h
+++ b/avogadro/qtplugins/importpqr/pqrrequest.h
@@ -47,7 +47,7 @@ public:
   /**
   * @brief Free the ui pointers
   */
-  ~PQRRequest();
+  ~PQRRequest() override;
 
   /**
   * @brief Sends a network request to search for molecules from PQR;

--- a/avogadro/qtplugins/importpqr/pqrwidget.h
+++ b/avogadro/qtplugins/importpqr/pqrwidget.h
@@ -17,10 +17,10 @@
 #include <QtCore/QSortFilterProxyModel>
 
 /**
-* PQRWidget is a class extending QDialog to provide the ui for
-* importing/downloading
-* molecules from PQR.
-*/
+ * PQRWidget is a class extending QDialog to provide the ui for
+ * importing/downloading
+ * molecules from PQR.
+ */
 
 namespace Ui {
 class PQRWidget;
@@ -49,24 +49,24 @@ public:
 private slots:
 
   /**
-  * @brief Called when the search button is clicked to send a query to PQR
-  */
+   * @brief Called when the search button is clicked to send a query to PQR
+   */
   void searchAction();
 
   /**
-  * @brief Called when a table result is double clicked to display preview
-  * information
-  * about the result before downloading.
-  * @param row The row of the result selected.
-  * @param col The column of the result selected.
-  */
+   * @brief Called when a table result is double clicked to display preview
+   * information
+   * about the result before downloading.
+   * @param row The row of the result selected.
+   * @param col The column of the result selected.
+   */
   void molSelected(int, int);
 
   /**
-  * @brief Called when the download button is clicked to send a request to
-  * download
-  * molecule information from PQR.
-  */
+   * @brief Called when the download button is clicked to send a request to
+   * download
+   * molecule information from PQR.
+   */
   void downloadMol();
 
 private:

--- a/avogadro/qtplugins/importpqr/pqrwidget.h
+++ b/avogadro/qtplugins/importpqr/pqrwidget.h
@@ -42,7 +42,7 @@ class PQRWidget : public QDialog
 
 public:
   PQRWidget(QWidget* parent = 0, ImportPQR* p = nullptr);
-  ~PQRWidget();
+  ~PQRWidget() override;
   void loadMolecule(QByteArray&, QString);
   void loadPNG(QByteArray&);
 

--- a/avogadro/qtplugins/licorice/licorice.h
+++ b/avogadro/qtplugins/licorice/licorice.h
@@ -32,18 +32,18 @@ class Licorice : public QtGui::ScenePlugin
 
 public:
   explicit Licorice(QObject* parent = 0);
-  ~Licorice();
+  ~Licorice() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Licorice"); }
+  QString name() const override { return tr("Licorice"); }
 
-  QString description() const { return tr("Render atoms as licorice."); }
+  QString description() const override { return tr("Render atoms as licorice."); }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/licorice/licorice.h
+++ b/avogadro/qtplugins/licorice/licorice.h
@@ -39,7 +39,10 @@ public:
 
   QString name() const override { return tr("Licorice"); }
 
-  QString description() const override { return tr("Render atoms as licorice."); }
+  QString description() const override
+  {
+    return tr("Render atoms as licorice.");
+  }
 
   bool isEnabled() const override;
 

--- a/avogadro/qtplugins/lineformatinput/lineformatinput.h
+++ b/avogadro/qtplugins/lineformatinput/lineformatinput.h
@@ -37,15 +37,15 @@ class LineFormatInput : public QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit LineFormatInput(QObject* parent_ = 0);
-  ~LineFormatInput();
+  ~LineFormatInput() override;
 
-  QString name() const { return tr("LineFormatInput"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("LineFormatInput"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule*);
+  void setMolecule(QtGui::Molecule*) override;
 
 private slots:
   void showDialog();

--- a/avogadro/qtplugins/lineformatinput/lineformatinputdialog.h
+++ b/avogadro/qtplugins/lineformatinput/lineformatinputdialog.h
@@ -35,7 +35,7 @@ class LineFormatInputDialog : public QDialog
 
 public:
   explicit LineFormatInputDialog(QWidget* parent = 0);
-  ~LineFormatInputDialog();
+  ~LineFormatInputDialog() override;
 
   void setFormats(const QStringList& indents);
   QString format() const;
@@ -45,7 +45,7 @@ public:
   QString descriptor() const;
 
 protected slots:
-  void accept();
+  void accept() override;
 
 private:
   Ui::LineFormatInputDialog* m_ui;

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -39,7 +39,7 @@ class Manipulator : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit Manipulator(QObject* parent_ = nullptr);
-  ~Manipulator();
+  ~Manipulator() override;
 
   QString name() const override { return tr("Manipulate tool"); }
   QString description() const override { return tr("Manipulate tool"); }

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -43,7 +43,7 @@ class MeasureTool : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit MeasureTool(QObject* parent_ = nullptr);
-  ~MeasureTool();
+  ~MeasureTool() override;
 
   QString name() const override { return tr("Measure tool"); }
   QString description() const override { return tr("Measure tool"); }

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -67,7 +67,7 @@ private:
   float dihedralAngle(const Vector3& b1, const Vector3& b2,
                       const Vector3& b3) const;
   bool toggleAtom(const Rendering::Identifier& atom);
-  template <typename T>
+  template<typename T>
   void createLabels(T* mol, Rendering::GeometryNode* geo,
                     QVector<Vector3>& positions);
 

--- a/avogadro/qtplugins/meshes/meshes.h
+++ b/avogadro/qtplugins/meshes/meshes.h
@@ -32,18 +32,18 @@ class Meshes : public QtGui::ScenePlugin
 
 public:
   explicit Meshes(QObject* parent = 0);
-  ~Meshes();
+  ~Meshes() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Meshes"); }
+  QString name() const override { return tr("Meshes"); }
 
-  QString description() const { return tr("Render triangle meshes."); }
+  QString description() const override { return tr("Render triangle meshes."); }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/molecularproperties/molecularproperties.h
+++ b/avogadro/qtplugins/molecularproperties/molecularproperties.h
@@ -37,15 +37,15 @@ class MolecularProperties : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit MolecularProperties(QObject* parent_ = 0);
-  ~MolecularProperties();
+  ~MolecularProperties() override;
 
-  QString name() const { return tr("Molecular Properties"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Molecular Properties"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void showDialog();

--- a/avogadro/qtplugins/molecularproperties/molecularpropertiesdialog.h
+++ b/avogadro/qtplugins/molecularproperties/molecularpropertiesdialog.h
@@ -47,7 +47,7 @@ class MolecularPropertiesDialog : public QDialog
 public:
   explicit MolecularPropertiesDialog(QtGui::Molecule* mol,
                                      QWidget* parent_ = 0);
-  ~MolecularPropertiesDialog();
+  ~MolecularPropertiesDialog() override;
 
   QtGui::Molecule* molecule() { return m_molecule; }
 

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -37,7 +37,7 @@ class Navigator : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit Navigator(QObject* parent_ = nullptr);
-  ~Navigator();
+  ~Navigator() override;
 
   QString name() const override { return tr("Navigate tool"); }
   QString description() const override { return tr("Navigate tool"); }

--- a/avogadro/qtplugins/networkdatabases/networkdatabases.h
+++ b/avogadro/qtplugins/networkdatabases/networkdatabases.h
@@ -56,8 +56,8 @@ public:
   QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
-  bool readMolecule(QtGui::Molecule& mol);
+  void setMolecule(QtGui::Molecule* mol) override;
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void showDialog();

--- a/avogadro/qtplugins/openbabel/obfileformat.h
+++ b/avogadro/qtplugins/openbabel/obfileformat.h
@@ -35,19 +35,19 @@ public:
                const std::vector<std::string> fileExtensions_,
                const std::vector<std::string> mimeTypes_,
                bool fileOnly_ = false);
-  ~OBFileFormat();
+  ~OBFileFormat() override;
 
   Operations supportedOperations() const override
   {
     return m_rwFlags | File | (m_fileOnly ? None : Stream | String);
   }
 
-  bool read(std::istream& in, Core::Molecule& molecule);
-  bool write(std::ostream& out, const Core::Molecule& molecule);
+  bool read(std::istream& in, Core::Molecule& molecule) override;
+  bool write(std::ostream& out, const Core::Molecule& molecule) override;
 
-  void clear();
+  void clear() override;
 
-  FileFormat* newInstance() const;
+  FileFormat* newInstance() const override;
 
   std::string description() const override { return m_description; }
   std::string identifier() const override { return m_identifier; }

--- a/avogadro/qtplugins/openbabel/obforcefielddialog.h
+++ b/avogadro/qtplugins/openbabel/obforcefielddialog.h
@@ -40,7 +40,7 @@ public:
    */
   explicit OBForceFieldDialog(const QStringList& forceFields,
                               QWidget* parent_ = 0);
-  ~OBForceFieldDialog();
+  ~OBForceFieldDialog() override;
 
   /**
    * Construct a new dialog using the forcefields in @a forceFields and

--- a/avogadro/qtplugins/openbabel/openbabel.h
+++ b/avogadro/qtplugins/openbabel/openbabel.h
@@ -42,27 +42,27 @@ class OpenBabel : public QtGui::ExtensionPlugin
 
 public:
   explicit OpenBabel(QObject* parent = 0);
-  ~OpenBabel();
+  ~OpenBabel() override;
 
-  QString name() const { return tr("OpenBabel"); }
+  QString name() const override { return tr("OpenBabel"); }
 
-  QString description() const
+  QString description() const override
   {
     return tr("Interact with OpenBabel utilities.");
   }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  QList<Io::FileFormat*> fileFormats() const;
+  QList<Io::FileFormat*> fileFormats() const override;
 
   QString openBabelInfo() const;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
-  bool readMolecule(QtGui::Molecule& mol);
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void refreshReadFormats();

--- a/avogadro/qtplugins/overlayaxes/overlayaxes.h
+++ b/avogadro/qtplugins/overlayaxes/overlayaxes.h
@@ -30,7 +30,7 @@ class OverlayAxes : public QtGui::ScenePlugin
   Q_OBJECT
 public:
   explicit OverlayAxes(QObject* parent = 0);
-  ~OverlayAxes();
+  ~OverlayAxes() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
@@ -38,16 +38,16 @@ public:
   void processEditable(const QtGui::RWMolecule& molecule,
                        Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Reference Axes Overlay"); }
+  QString name() const override { return tr("Reference Axes Overlay"); }
 
-  QString description() const
+  QString description() const override
   {
     return tr("Render reference axes in the corner of the display.");
   }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/playertool/playertool.h
+++ b/avogadro/qtplugins/playertool/playertool.h
@@ -41,7 +41,7 @@ class PlayerTool : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit PlayerTool(QObject* p = nullptr);
-  ~PlayerTool();
+  ~PlayerTool() override;
 
   QString name() const override { return tr("Player tool"); }
   QString description() const override { return tr("Play back trajectories"); }

--- a/avogadro/qtplugins/plugindownloader/downloaderwidget.h
+++ b/avogadro/qtplugins/plugindownloader/downloaderwidget.h
@@ -42,7 +42,7 @@ class DownloaderWidget : public QDialog
 
 public:
   DownloaderWidget(QWidget* parent = 0);
-  ~DownloaderWidget();
+  ~DownloaderWidget() override;
 
 public slots:
   void showREADME();

--- a/avogadro/qtplugins/plugindownloader/plugindownloader.h
+++ b/avogadro/qtplugins/plugindownloader/plugindownloader.h
@@ -55,8 +55,8 @@ public:
   QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
-  bool readMolecule(QtGui::Molecule& mol);
+  void setMolecule(QtGui::Molecule* mol) override;
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void showDialog();

--- a/avogadro/qtplugins/pluginmanager.h
+++ b/avogadro/qtplugins/pluginmanager.h
@@ -95,7 +95,7 @@ public:
 private:
   // Hide the constructor, destructor, copy and assignment operator.
   PluginManager(QObject* parent = 0);
-  ~PluginManager();
+  ~PluginManager() override;
   PluginManager(const PluginManager&);            // Not implemented.
   PluginManager& operator=(const PluginManager&); // Not implemented.
 

--- a/avogadro/qtplugins/pluginmanager.h
+++ b/avogadro/qtplugins/pluginmanager.h
@@ -74,7 +74,7 @@ public:
    * pluginManager->pluginFactories<Avogadro::QtGui::ScenePluginFactory>();
    * @endcode
    */
-  template <typename T>
+  template<typename T>
   QList<T*> pluginFactories() const;
 
   /**
@@ -89,7 +89,7 @@ public:
    * @param name The identifier of the plugin factory.
    * @return The plugin factory if the plugin was found, nullptr otherwise.
    */
-  template <typename T>
+  template<typename T>
   T* pluginFactory(const QString& id) const;
 
 private:
@@ -108,7 +108,7 @@ private:
   QList<QObject*> m_plugins;
 };
 
-template <typename T>
+template<typename T>
 QList<T*> PluginManager::pluginFactories() const
 {
   QList<T*> factories;
@@ -120,7 +120,7 @@ QList<T*> PluginManager::pluginFactories() const
   return factories;
 }
 
-template <typename T>
+template<typename T>
 T* PluginManager::pluginFactory(const QString& id) const
 {
   T* factory;

--- a/avogadro/qtplugins/quantuminput/quantuminput.h
+++ b/avogadro/qtplugins/quantuminput/quantuminput.h
@@ -51,20 +51,20 @@ class QuantumInput : public QtGui::ExtensionPlugin
 
 public:
   explicit QuantumInput(QObject* parent = 0);
-  ~QuantumInput();
+  ~QuantumInput() override;
 
-  QString name() const { return tr("Quantum input"); }
+  QString name() const override { return tr("Quantum input"); }
 
-  QString description() const
+  QString description() const override
   {
     return tr("Generate input for quantum codes.");
   }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 public slots:
   /**
@@ -77,7 +77,7 @@ public slots:
    */
   void openJobOutput(const ::MoleQueue::JobObject& job);
 
-  bool readMolecule(QtGui::Molecule& mol);
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void menuActivated();

--- a/avogadro/qtplugins/quantumoutput/gaussiansetconcurrent.h
+++ b/avogadro/qtplugins/quantumoutput/gaussiansetconcurrent.h
@@ -46,7 +46,7 @@ class GaussianSetConcurrent : public QObject
 
 public:
   explicit GaussianSetConcurrent(QObject* p = 0);
-  ~GaussianSetConcurrent();
+  ~GaussianSetConcurrent() override;
 
   void setMolecule(Core::Molecule* mol);
 

--- a/avogadro/qtplugins/quantumoutput/quantumoutput.h
+++ b/avogadro/qtplugins/quantumoutput/quantumoutput.h
@@ -56,7 +56,10 @@ public:
 
   QString name() const override { return tr("Quantum output"); }
 
-  QString description() const override { return tr("Read output from quantum codes."); }
+  QString description() const override
+  {
+    return tr("Read output from quantum codes.");
+  }
 
   QList<QAction*> actions() const override;
 

--- a/avogadro/qtplugins/quantumoutput/quantumoutput.h
+++ b/avogadro/qtplugins/quantumoutput/quantumoutput.h
@@ -52,17 +52,17 @@ class QuantumOutput : public QtGui::ExtensionPlugin
 
 public:
   explicit QuantumOutput(QObject* parent = 0);
-  ~QuantumOutput();
+  ~QuantumOutput() override;
 
-  QString name() const { return tr("Quantum output"); }
+  QString name() const override { return tr("Quantum output"); }
 
-  QString description() const { return tr("Read output from quantum codes."); }
+  QString description() const override { return tr("Read output from quantum codes."); }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void surfacesActivated();

--- a/avogadro/qtplugins/quantumoutput/slatersetconcurrent.h
+++ b/avogadro/qtplugins/quantumoutput/slatersetconcurrent.h
@@ -46,7 +46,7 @@ class SlaterSetConcurrent : public QObject
 
 public:
   explicit SlaterSetConcurrent(QObject* p = 0);
-  ~SlaterSetConcurrent();
+  ~SlaterSetConcurrent() override;
 
   void setMolecule(Core::Molecule* mol);
 

--- a/avogadro/qtplugins/quantumoutput/surfacedialog.h
+++ b/avogadro/qtplugins/quantumoutput/surfacedialog.h
@@ -37,7 +37,7 @@ class SurfaceDialog : public QDialog
 
 public:
   SurfaceDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
-  ~SurfaceDialog();
+  ~SurfaceDialog() override;
 
   void setupBasis(int numElectrons, int numMOs);
   void setupCube(int numCubes);

--- a/avogadro/qtplugins/select/select.h
+++ b/avogadro/qtplugins/select/select.h
@@ -30,15 +30,15 @@ class Select : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit Select(QObject* parent_ = 0);
-  ~Select();
+  ~Select() override;
 
-  QString name() const { return tr("Select"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Select"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 private slots:
   void selectAll();

--- a/avogadro/qtplugins/selectiontool/selectiontool.h
+++ b/avogadro/qtplugins/selectiontool/selectiontool.h
@@ -40,7 +40,7 @@ class SelectionTool : public QtGui::ToolPlugin
   Q_OBJECT
 public:
   explicit SelectionTool(QObject* parent_ = nullptr);
-  ~SelectionTool();
+  ~SelectionTool() override;
 
   QString name() const override { return tr("Selection tool"); }
   QString description() const override { return tr("Selection tool"); }

--- a/avogadro/qtplugins/spectra/spectra.h
+++ b/avogadro/qtplugins/spectra/spectra.h
@@ -38,20 +38,20 @@ class Spectra : public QtGui::ExtensionPlugin
 
 public:
   explicit Spectra(QObject* parent = 0);
-  ~Spectra();
+  ~Spectra() override;
 
-  QString name() const { return tr("Spectra and Vibrations"); }
+  QString name() const override { return tr("Spectra and Vibrations"); }
 
-  QString description() const
+  QString description() const override
   {
     return tr("Display spectra and vibrational modes.");
   }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 public slots:
   void setMode(int mode);

--- a/avogadro/qtplugins/spectra/vibrationdialog.h
+++ b/avogadro/qtplugins/spectra/vibrationdialog.h
@@ -40,7 +40,7 @@ class VibrationDialog : public QDialog
 
 public:
   VibrationDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
-  ~VibrationDialog();
+  ~VibrationDialog() override;
 
   void setMolecule(QtGui::Molecule* molecule);
   int currentMode() const;

--- a/avogadro/qtplugins/spectra/vibrationmodel.h
+++ b/avogadro/qtplugins/spectra/vibrationmodel.h
@@ -30,19 +30,19 @@ class VibrationModel : public QAbstractItemModel
 public:
   explicit VibrationModel(QObject* p = 0);
 
-  QModelIndex parent(const QModelIndex& child) const;
-  int rowCount(const QModelIndex& parent) const;
-  int columnCount(const QModelIndex& parent) const;
+  QModelIndex parent(const QModelIndex& child) const override;
+  int rowCount(const QModelIndex& parent) const override;
+  int columnCount(const QModelIndex& parent) const override;
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role);
-  QVariant data(const QModelIndex& index, int role) const;
+  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,
-                    const QModelIndex& parent = QModelIndex()) const;
+                    const QModelIndex& parent = QModelIndex()) const override;
 
   void clear();
 

--- a/avogadro/qtplugins/spectra/vibrationmodel.h
+++ b/avogadro/qtplugins/spectra/vibrationmodel.h
@@ -36,9 +36,11 @@ public:
 
   Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role) const override;
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+  bool setData(const QModelIndex& index, const QVariant& value,
+               int role) override;
   QVariant data(const QModelIndex& index, int role) const override;
 
   QModelIndex index(int row, int column,

--- a/avogadro/qtplugins/symmetry/operationstablemodel.h
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.h
@@ -18,7 +18,8 @@
 #define AVOGADRO_QTPLUGINS_OPERATIONSTABLEMODEL_H
 
 namespace msym {
-extern "C" {
+extern "C"
+{
 #include <libmsym/msym.h>
 }
 }
@@ -53,8 +54,10 @@ public:
     return OPERATIONSTABLEMODEL_COLUMN_COUNT;
   };
 
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+  QVariant data(const QModelIndex& index,
+                int role = Qt::DisplayRole) const override;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role) const override;
 
   void setOperations(int operations_size,
                      const msym::msym_symmetry_operation_t* operations);

--- a/avogadro/qtplugins/symmetry/operationstablemodel.h
+++ b/avogadro/qtplugins/symmetry/operationstablemodel.h
@@ -45,16 +45,16 @@ public:
   };
 
   explicit OperationsTableModel(QObject* parent = 0);
-  virtual ~OperationsTableModel();
+  ~OperationsTableModel() override;
 
-  int rowCount(const QModelIndex&) const { return m_operations_size; };
-  int columnCount(const QModelIndex&) const
+  int rowCount(const QModelIndex&) const override { return m_operations_size; };
+  int columnCount(const QModelIndex&) const override
   {
     return OPERATIONSTABLEMODEL_COLUMN_COUNT;
   };
 
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-  QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+  QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
   void setOperations(int operations_size,
                      const msym::msym_symmetry_operation_t* operations);

--- a/avogadro/qtplugins/symmetry/richtextdelegate.h
+++ b/avogadro/qtplugins/symmetry/richtextdelegate.h
@@ -30,9 +30,9 @@ class RichTextDelegate : public QStyledItemDelegate
 
 public:
   RichTextDelegate(QObject* parent = 0) : QStyledItemDelegate(parent){};
-  QSize sizeHint(const QStyleOptionViewItem& o, const QModelIndex& index) const;
+  QSize sizeHint(const QStyleOptionViewItem& o, const QModelIndex& index) const override;
   void paint(QPainter* p, const QStyleOptionViewItem& o,
-             const QModelIndex& index) const;
+             const QModelIndex& index) const override;
 };
 }
 }

--- a/avogadro/qtplugins/symmetry/richtextdelegate.h
+++ b/avogadro/qtplugins/symmetry/richtextdelegate.h
@@ -29,8 +29,10 @@ class RichTextDelegate : public QStyledItemDelegate
   Q_OBJECT
 
 public:
-  RichTextDelegate(QObject* parent = 0) : QStyledItemDelegate(parent){};
-  QSize sizeHint(const QStyleOptionViewItem& o, const QModelIndex& index) const override;
+  RichTextDelegate(QObject* parent = 0)
+    : QStyledItemDelegate(parent){};
+  QSize sizeHint(const QStyleOptionViewItem& o,
+                 const QModelIndex& index) const override;
   void paint(QPainter* p, const QStyleOptionViewItem& o,
              const QModelIndex& index) const override;
 };

--- a/avogadro/qtplugins/symmetry/symmetry.h
+++ b/avogadro/qtplugins/symmetry/symmetry.h
@@ -22,7 +22,8 @@
 #include "symmetrywidget.h"
 
 namespace msym {
-extern "C" {
+extern "C"
+{
 #include <libmsym/msym.h>
 }
 }

--- a/avogadro/qtplugins/symmetry/symmetry.h
+++ b/avogadro/qtplugins/symmetry/symmetry.h
@@ -39,15 +39,15 @@ class Symmetry : public Avogadro::QtGui::ExtensionPlugin
   Q_OBJECT
 public:
   explicit Symmetry(QObject* parent_ = 0);
-  ~Symmetry();
+  ~Symmetry() override;
 
-  QString name() const { return tr("Symmetry"); }
-  QString description() const;
-  QList<QAction*> actions() const;
-  QStringList menuPath(QAction*) const;
+  QString name() const override { return tr("Symmetry"); }
+  QString description() const override;
+  QList<QAction*> actions() const override;
+  QStringList menuPath(QAction*) const override;
 
 public slots:
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
   void moleculeChanged(unsigned int changes);
 

--- a/avogadro/qtplugins/symmetry/symmetryscene.h
+++ b/avogadro/qtplugins/symmetry/symmetryscene.h
@@ -43,7 +43,10 @@ public:
 
   QString name() const override { return tr("Symmetry Elements"); }
 
-  QString description() const override { return tr("Render symmetry elements."); }
+  QString description() const override
+  {
+    return tr("Render symmetry elements.");
+  }
 
   bool isEnabled() const override;
 

--- a/avogadro/qtplugins/symmetry/symmetryscene.h
+++ b/avogadro/qtplugins/symmetry/symmetryscene.h
@@ -41,13 +41,13 @@ public:
   void processEditable(const QtGui::RWMolecule& molecule,
                        Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Symmetry Elements"); }
+  QString name() const override { return tr("Symmetry Elements"); }
 
-  QString description() const { return tr("Render symmetry elements."); }
+  QString description() const override { return tr("Render symmetry elements."); }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.h
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.h
@@ -32,18 +32,18 @@ class VanDerWaals : public QtGui::ScenePlugin
 
 public:
   explicit VanDerWaals(QObject* parent = 0);
-  ~VanDerWaals();
+  ~VanDerWaals() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Van der Waals"); }
+  QString name() const override { return tr("Van der Waals"); }
 
-  QString description() const { return tr("Simple display of VdW spheres."); }
+  QString description() const override { return tr("Simple display of VdW spheres."); }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.h
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.h
@@ -39,7 +39,10 @@ public:
 
   QString name() const override { return tr("Van der Waals"); }
 
-  QString description() const override { return tr("Simple display of VdW spheres."); }
+  QString description() const override
+  {
+    return tr("Simple display of VdW spheres.");
+  }
 
   bool isEnabled() const override;
 

--- a/avogadro/qtplugins/vanderwaalsao/vanderwaalsao.h
+++ b/avogadro/qtplugins/vanderwaalsao/vanderwaalsao.h
@@ -33,21 +33,21 @@ class VanDerWaalsAO : public QtGui::ScenePlugin
 
 public:
   explicit VanDerWaalsAO(QObject* parent = 0);
-  ~VanDerWaalsAO();
+  ~VanDerWaalsAO() override;
 
   void process(const Core::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const { return tr("Van der Waals (AO)"); }
+  QString name() const override { return tr("Van der Waals (AO)"); }
 
-  QString description() const
+  QString description() const override
   {
     return tr("Simple display of VdW spheres with ambient occlusion.");
   }
 
-  bool isEnabled() const;
+  bool isEnabled() const override;
 
-  void setEnabled(bool enable);
+  void setEnabled(bool enable) override;
 
 private:
   bool m_enabled;

--- a/avogadro/qtplugins/workflows/workflow.h
+++ b/avogadro/qtplugins/workflows/workflow.h
@@ -52,7 +52,10 @@ public:
 
   QString name() const override { return tr("Workflow scripts"); }
 
-  QString description() const override { return tr("Run external workflow commands"); }
+  QString description() const override
+  {
+    return tr("Run external workflow commands");
+  }
 
   QList<QAction*> actions() const override;
 

--- a/avogadro/qtplugins/workflows/workflow.h
+++ b/avogadro/qtplugins/workflows/workflow.h
@@ -48,17 +48,17 @@ class Workflow : public QtGui::ExtensionPlugin
 
 public:
   explicit Workflow(QObject* parent = 0);
-  ~Workflow();
+  ~Workflow() override;
 
-  QString name() const { return tr("Workflow scripts"); }
+  QString name() const override { return tr("Workflow scripts"); }
 
-  QString description() const { return tr("Run external workflow commands"); }
+  QString description() const override { return tr("Run external workflow commands"); }
 
-  QList<QAction*> actions() const;
+  QList<QAction*> actions() const override;
 
-  QStringList menuPath(QAction*) const;
+  QStringList menuPath(QAction*) const override;
 
-  void setMolecule(QtGui::Molecule* mol);
+  void setMolecule(QtGui::Molecule* mol) override;
 
 public slots:
   /**
@@ -68,7 +68,7 @@ public slots:
 
   void run();
 
-  bool readMolecule(QtGui::Molecule& mol);
+  bool readMolecule(QtGui::Molecule& mol) override;
 
 private slots:
   void menuActivated();

--- a/avogadro/rendering/ambientocclusionspheregeometry.cpp
+++ b/avogadro/rendering/ambientocclusionspheregeometry.cpp
@@ -886,7 +886,7 @@ public:
   }
 
   void renderDepth(const Eigen::Matrix4f& modelView,
-                   const Eigen::Matrix4f& projection)
+                   const Eigen::Matrix4f& projection) override
   {
     // bind buffer objects
     m_vbo.bind();
@@ -936,7 +936,7 @@ public:
 
   void renderAO(const Eigen::Matrix4f& modelView,
                 const Eigen::Matrix4f& projection, GLint textureSize,
-                float numDirections)
+                float numDirections) override
   {
     // bind buffer objects
     m_vbo.bind();

--- a/avogadro/rendering/ambientocclusionspheregeometry.cpp
+++ b/avogadro/rendering/ambientocclusionspheregeometry.cpp
@@ -552,8 +552,12 @@ class AmbientOcclusionBaker
 {
 public:
   AmbientOcclusionBaker(AmbientOcclusionRenderer* renderer, GLint textureSize_)
-    : m_renderer(renderer), m_textureSize(textureSize_), m_depthTexture(0),
-      m_depthFBO(0), m_aoTexture(0), m_aoFBO(0)
+    : m_renderer(renderer)
+    , m_textureSize(textureSize_)
+    , m_depthTexture(0)
+    , m_depthFBO(0)
+    , m_aoTexture(0)
+    , m_aoFBO(0)
   {
     initialize();
   }
@@ -879,8 +883,11 @@ public:
   SphereAmbientOcclusionRenderer(BufferObject& vbo, BufferObject& ibo,
                                  int numSpheres, int numVertices,
                                  int numIndices)
-    : m_vbo(vbo), m_ibo(ibo), m_numSpheres(numSpheres),
-      m_numVertices(numVertices), m_numIndices(numIndices)
+    : m_vbo(vbo)
+    , m_ibo(ibo)
+    , m_numSpheres(numSpheres)
+    , m_numVertices(numVertices)
+    , m_numIndices(numIndices)
   {
     initialize();
   }
@@ -1075,7 +1082,9 @@ private:
 class AmbientOcclusionSphereGeometry::Private
 {
 public:
-  Private() : aoTextureSize(1024) {}
+  Private()
+    : aoTextureSize(1024)
+  {}
 
   BufferObject vbo;
   BufferObject ibo;
@@ -1093,16 +1102,18 @@ public:
 };
 
 AmbientOcclusionSphereGeometry::AmbientOcclusionSphereGeometry()
-  : m_dirty(false), d(new Private)
-{
-}
+  : m_dirty(false)
+  , d(new Private)
+{}
 
 AmbientOcclusionSphereGeometry::AmbientOcclusionSphereGeometry(
   const AmbientOcclusionSphereGeometry& other)
-  : Drawable(other), m_spheres(other.m_spheres), m_indices(other.m_indices),
-    m_dirty(true), d(new Private)
-{
-}
+  : Drawable(other)
+  , m_spheres(other.m_spheres)
+  , m_indices(other.m_indices)
+  , m_dirty(true)
+  , d(new Private)
+{}
 
 AmbientOcclusionSphereGeometry::~AmbientOcclusionSphereGeometry()
 {

--- a/avogadro/rendering/ambientocclusionspheregeometry.h
+++ b/avogadro/rendering/ambientocclusionspheregeometry.h
@@ -76,9 +76,9 @@ public:
    * @param rayDirection Normalized direction of the ray.
    * @return Sorted collection of primitives that were hit.
    */
-  std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
-                                        const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const override;
+  std::multimap<float, Identifier> hits(
+    const Vector3f& rayOrigin, const Vector3f& rayEnd,
+    const Vector3f& rayDirection) const override;
 
   /**
    * Add a sphere to the geometry object.

--- a/avogadro/rendering/ambientocclusionspheregeometry.h
+++ b/avogadro/rendering/ambientocclusionspheregeometry.h
@@ -47,7 +47,7 @@ class AVOGADRORENDERING_EXPORT AmbientOcclusionSphereGeometry : public Drawable
 public:
   AmbientOcclusionSphereGeometry();
   AmbientOcclusionSphereGeometry(const AmbientOcclusionSphereGeometry& other);
-  ~AmbientOcclusionSphereGeometry();
+  ~AmbientOcclusionSphereGeometry() override;
 
   AmbientOcclusionSphereGeometry& operator=(AmbientOcclusionSphereGeometry);
   friend void swap(AmbientOcclusionSphereGeometry& lhs,
@@ -67,7 +67,7 @@ public:
    * @brief Render the sphere geometry.
    * @param camera The current camera to be used for rendering.
    */
-  void render(const Camera& camera);
+  void render(const Camera& camera) override;
 
   /**
    * Return the primitives that are hit by the ray.
@@ -78,7 +78,7 @@ public:
    */
   std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
                                         const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const;
+                                        const Vector3f& rayDirection) const override;
 
   /**
    * Add a sphere to the geometry object.
@@ -95,7 +95,7 @@ public:
   /**
    * Clear the contents of the node.
    */
-  void clear();
+  void clear() override;
 
   /**
    * Get the number of spheres in the node object.

--- a/avogadro/rendering/cylindergeometry.h
+++ b/avogadro/rendering/cylindergeometry.h
@@ -28,9 +28,12 @@ struct CylinderColor
 {
   CylinderColor(const Vector3f& pos1, const Vector3f& pos2, float r,
                 const Vector3ub& c, const Vector3ub& c2 = Vector3ub::Zero())
-    : end1(pos1), end2(pos2), radius(r), color(c), color2(c2)
-  {
-  }
+    : end1(pos1)
+    , end2(pos2)
+    , radius(r)
+    , color(c)
+    , color2(c2)
+  {}
 
   Vector3f end1;
   Vector3f end2;
@@ -79,9 +82,9 @@ public:
    * @param rayDirection Normalized direction of the ray.
    * @return Sorted collection of primitives that were hit.
    */
-  std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
-                                        const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const override;
+  std::multimap<float, Identifier> hits(
+    const Vector3f& rayOrigin, const Vector3f& rayEnd,
+    const Vector3f& rayDirection) const override;
 
   /**
    * @brief Add a cylinder to the geometry object.

--- a/avogadro/rendering/cylindergeometry.h
+++ b/avogadro/rendering/cylindergeometry.h
@@ -51,7 +51,7 @@ class AVOGADRORENDERING_EXPORT CylinderGeometry : public Drawable
 public:
   CylinderGeometry();
   CylinderGeometry(const CylinderGeometry& other);
-  ~CylinderGeometry();
+  ~CylinderGeometry() override;
 
   CylinderGeometry& operator=(CylinderGeometry);
   friend void swap(CylinderGeometry& lhs, CylinderGeometry& rhs);
@@ -70,7 +70,7 @@ public:
    * @brief Render the cylinder geometry.
    * @param camera The current camera to be used for rendering.
    */
-  void render(const Camera& camera);
+  void render(const Camera& camera) override;
 
   /**
    * Return the primitives that are hit by the ray.
@@ -81,7 +81,7 @@ public:
    */
   std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
                                         const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const;
+                                        const Vector3f& rayDirection) const override;
 
   /**
    * @brief Add a cylinder to the geometry object.
@@ -141,7 +141,7 @@ public:
   /**
    * Clear the contents of the node.
    */
-  void clear();
+  void clear() override;
 
   /**
    * Get the number of cylinders in the node object.

--- a/avogadro/rendering/geometrynode.h
+++ b/avogadro/rendering/geometrynode.h
@@ -44,7 +44,7 @@ class AVOGADRORENDERING_EXPORT GeometryNode : public Node
 {
 public:
   GeometryNode();
-  ~GeometryNode();
+  ~GeometryNode() override;
 
   /**
    * Accept a visit from our friendly visitor.

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -35,8 +35,10 @@ namespace Avogadro {
 namespace Rendering {
 
 GLRenderer::GLRenderer()
-  : m_valid(false), m_textRenderStrategy(nullptr), m_center(Vector3f::Zero()),
-    m_radius(20.0)
+  : m_valid(false)
+  , m_textRenderStrategy(nullptr)
+  , m_center(Vector3f::Zero())
+  , m_radius(20.0)
 {
   m_overlayCamera.setIdentity();
 }

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -129,18 +129,18 @@ void GLRenderer::setTextRenderStrategy(TextRenderStrategy* tren)
     class ResetTextLabelVisitor : public Visitor
     {
     public:
-      void visit(Node&) { return; }
-      void visit(GroupNode&) { return; }
-      void visit(GeometryNode&) { return; }
-      void visit(Drawable&) { return; }
-      void visit(SphereGeometry&) { return; }
-      void visit(AmbientOcclusionSphereGeometry&) { return; }
-      void visit(CylinderGeometry&) { return; }
-      void visit(MeshGeometry&) { return; }
+      void visit(Node&) override { return; }
+      void visit(GroupNode&) override { return; }
+      void visit(GeometryNode&) override { return; }
+      void visit(Drawable&) override { return; }
+      void visit(SphereGeometry&) override { return; }
+      void visit(AmbientOcclusionSphereGeometry&) override { return; }
+      void visit(CylinderGeometry&) override { return; }
+      void visit(MeshGeometry&) override { return; }
       void visit(Texture2D&) { return; }
-      void visit(TextLabel2D& l) { l.resetTexture(); }
-      void visit(TextLabel3D& l) { l.resetTexture(); }
-      void visit(LineStripGeometry&) { return; }
+      void visit(TextLabel2D& l) override { l.resetTexture(); }
+      void visit(TextLabel3D& l) override { l.resetTexture(); }
+      void visit(LineStripGeometry&) override { return; }
     } labelResetter;
 
     m_scene.rootNode().accept(labelResetter);

--- a/avogadro/rendering/linestripgeometry.h
+++ b/avogadro/rendering/linestripgeometry.h
@@ -47,7 +47,7 @@ public:
 
   LineStripGeometry();
   LineStripGeometry(const LineStripGeometry& other);
-  ~LineStripGeometry();
+  ~LineStripGeometry() override;
 
   LineStripGeometry& operator=(LineStripGeometry);
   friend void swap(LineStripGeometry& lhs, LineStripGeometry& rhs);
@@ -61,12 +61,12 @@ public:
    * @brief Render the line strips.
    * @param camera The current camera to be used for rendering.
    */
-  void render(const Camera& camera);
+  void render(const Camera& camera) override;
 
   /**
    * Clear the contents of the node.
    */
-  void clear();
+  void clear() override;
 
   /**
    * Add a complete line strip to the object.

--- a/avogadro/rendering/linestripgeometry.h
+++ b/avogadro/rendering/linestripgeometry.h
@@ -38,7 +38,10 @@ public:
     Vector3f vertex; // 12 bytes
     Vector4ub color; //  4 bytes
 
-    PackedVertex(const Vector3f& v, const Vector4ub& c) : vertex(v), color(c) {}
+    PackedVertex(const Vector3f& v, const Vector4ub& c)
+      : vertex(v)
+      , color(c)
+    {}
     static int vertexOffset() { return 0; }
     static int colorOffset() { return static_cast<int>(sizeof(Vector3f)); }
   };

--- a/avogadro/rendering/meshgeometry.h
+++ b/avogadro/rendering/meshgeometry.h
@@ -41,9 +41,10 @@ public:
     unsigned char padding[4]; //  4 bytes
 
     PackedVertex(const Vector4ub& c, const Vector3f& n, const Vector3f& v)
-      : color(c), normal(n), vertex(v)
-    {
-    }
+      : color(c)
+      , normal(n)
+      , vertex(v)
+    {}
 
     static int colorOffset() { return 0; }
     static int normalOffset() { return static_cast<int>(sizeof(Vector4ub)); }

--- a/avogadro/rendering/meshgeometry.h
+++ b/avogadro/rendering/meshgeometry.h
@@ -57,7 +57,7 @@ public:
 
   MeshGeometry();
   MeshGeometry(const MeshGeometry& other);
-  ~MeshGeometry();
+  ~MeshGeometry() override;
 
   MeshGeometry& operator=(MeshGeometry);
   friend void swap(MeshGeometry& lhs, MeshGeometry& rhs);
@@ -71,7 +71,7 @@ public:
    * @brief Render the mesh geometry.
    * @param camera The current camera to be used for rendering.
    */
-  void render(const Camera& camera);
+  void render(const Camera& camera) override;
 
   /**
    * Add vertices to the object. Note that this just adds vertices to the
@@ -110,7 +110,7 @@ public:
   /**
    * Clear the contents of the node.
    */
-  void clear();
+  void clear() override;
 
   /**
    * Get the number of vertices.

--- a/avogadro/rendering/spheregeometry.h
+++ b/avogadro/rendering/spheregeometry.h
@@ -53,7 +53,7 @@ class AVOGADRORENDERING_EXPORT SphereGeometry : public Drawable
 public:
   SphereGeometry();
   SphereGeometry(const SphereGeometry& other);
-  ~SphereGeometry();
+  ~SphereGeometry() override;
 
   SphereGeometry& operator=(SphereGeometry);
   friend void swap(SphereGeometry& lhs, SphereGeometry& rhs);
@@ -72,7 +72,7 @@ public:
    * @brief Render the sphere geometry.
    * @param camera The current camera to be used for rendering.
    */
-  void render(const Camera& camera);
+  void render(const Camera& camera) override;
 
   /**
    * Return the primitives that are hit by the ray.
@@ -83,7 +83,7 @@ public:
    */
   std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
                                         const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const;
+                                        const Vector3f& rayDirection) const override;
 
   /**
    * Add a sphere to the geometry object.
@@ -100,7 +100,7 @@ public:
   /**
    * Clear the contents of the node.
    */
-  void clear();
+  void clear() override;
 
   /**
    * Get the number of spheres in the node object.

--- a/avogadro/rendering/spheregeometry.h
+++ b/avogadro/rendering/spheregeometry.h
@@ -28,9 +28,10 @@ namespace Rendering {
 struct SphereColor
 {
   SphereColor(Vector3f centre, float r, Vector3ub c)
-    : center(centre), radius(r), color(c)
-  {
-  }
+    : center(centre)
+    , radius(r)
+    , color(c)
+  {}
   Vector3f center;
   float radius;
   Vector3ub color;
@@ -81,9 +82,9 @@ public:
    * @param rayDirection Normalized direction of the ray.
    * @return Sorted collection of primitives that were hit.
    */
-  std::multimap<float, Identifier> hits(const Vector3f& rayOrigin,
-                                        const Vector3f& rayEnd,
-                                        const Vector3f& rayDirection) const override;
+  std::multimap<float, Identifier> hits(
+    const Vector3f& rayOrigin, const Vector3f& rayEnd,
+    const Vector3f& rayDirection) const override;
 
   /**
    * Add a sphere to the geometry object.

--- a/avogadro/rendering/textlabelbase.h
+++ b/avogadro/rendering/textlabelbase.h
@@ -40,7 +40,7 @@ class AVOGADRORENDERING_EXPORT TextLabelBase : public Drawable
 public:
   TextLabelBase();
   TextLabelBase(const TextLabelBase& other);
-  ~TextLabelBase();
+  ~TextLabelBase() override;
 
   TextLabelBase& operator=(TextLabelBase other);
   friend void swap(TextLabelBase& lhs, TextLabelBase& rhs);

--- a/avogadro/rendering/transformnode.h
+++ b/avogadro/rendering/transformnode.h
@@ -34,7 +34,7 @@ class AVOGADRORENDERING_EXPORT TransformNode : public GroupNode
 {
 public:
   explicit TransformNode(GroupNode* parent = 0);
-  ~TransformNode();
+  ~TransformNode() override;
 };
 
 } // End namespace Rendering

--- a/avogadro/rendering/volumegeometry.h
+++ b/avogadro/rendering/volumegeometry.h
@@ -35,7 +35,7 @@ class AVOGADRORENDERING_EXPORT VolumeGeometry : public Drawable
 {
 public:
   VolumeGeometry();
-  ~VolumeGeometry();
+  ~VolumeGeometry() override;
 };
 
 } // End namespace Rendering


### PR DESCRIPTION
Minimizes warnings from compilation with C++11 compilers.

Change-Id: If051516da3a1760b70c79e21be795ea5f7f3328b