### PR TITLE
Proposed shorter source file preamble for project

### DIFF
--- a/avogadro/core/array.h
+++ b/avogadro/core/array.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2011-2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_CORE_ARRAY_H


### PR DESCRIPTION
After some research into best practices, copyright law, and tradition
versus requirements I am proposing this much shorter source file
preamble. The LICENSE file is the only full license, and should be
kept with source files moved into other projects, git keeps far better
track of who owns the copyright of any given source code, the developer
certificate of origin offers assurance that those developers have the
right to contribute code under the license.

The lines help where files are copied, and it is possible to see what
project they came from, and the unambiguous license the code is released
under. When snippets of code are copied this change won't make things any
better or worse.

Signed-off-by: Marcus D. Hanwell <marcus.hanwell@kitware.com>