### PR TITLE
Travis-CI: Bump minimum gcc version to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,13 @@ matrix:
           - clang-format-6.0
 
     - compiler: gcc
-      env: TASKS="ctest gcc-4.8"
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: g++-4.9
+      env:
+        - TASKS="ctest gcc-4.9"
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
     - compiler: gcc
       addons:


### PR DESCRIPTION
nlohmann-json and pybind11 (which will be added sometime)
require a minimum gcc of 4.9.

This bumps our minimum gcc version in Travis-CI to gcc 4.9, which
will soon probably also be the minimum required version for building
Avogadro2.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
