### PR TITLE
Fix resdataparse to read the final residue (HEM)

### DIFF
--- a/avogadro/core/residuedata.h
+++ b/avogadro/core/residuedata.h
@@ -750,6 +750,29 @@ ResidueData HEDData("HED",
                     // Double Bonds
                     { { "C1", "O1" }, { "C6", "O6" } });
 
+ResidueData HEMData(
+  "HEM",
+  // Atoms
+  { "FE",  "NA",  "NB",  "NC",  "ND",  "CHA", "C1A", "C4D", "CHB", "C4A", "C1B",
+    "CHC", "C4B", "C1C", "CHD", "C4C", "C1D", "C2A", "C3A", "CAA", "CMA", "CBA",
+    "CGA", "O1A", "O2A", "C2B", "C3B", "CMB", "CAB", "CBB", "C2C", "C3C", "CMC",
+    "CAC", "CBC", "C2D", "C3D", "CMD", "CAD", "CBD", "CGD", "O1D", "O2D" },
+  // Single Bonds
+  { { "FE", "NA" },   { "FE", "NB" },   { "FE", "NC" },   { "FE", "ND" },
+    { "CHA", "C1A" }, { "CHA", "C4D" }, { "CHB", "C4A" }, { "CHB", "C1B" },
+    { "CHC", "C4B" }, { "CHC", "C1C" }, { "CHD", "C4C" }, { "CHD", "C1D" },
+    { "NA", "C1A" },  { "NA", "C4A" },  { "C1A", "C2A" }, { "C2A", "C3A" },
+    { "C2A", "CAA" }, { "C3A", "C4A" }, { "C3A", "CMA" }, { "CAA", "CBA" },
+    { "CBA", "CGA" }, { "CGA", "O2A" }, { "NB", "C1B" },  { "NB", "C4B" },
+    { "C1B", "C2B" }, { "C2B", "C3B" }, { "C2B", "CMB" }, { "C3B", "C4B" },
+    { "C3B", "CAB" }, { "CAB", "CBB" }, { "NC", "C1C" },  { "NC", "C4C" },
+    { "C1C", "C2C" }, { "C2C", "C3C" }, { "C2C", "CMC" }, { "C3C", "C4C" },
+    { "C3C", "CAC" }, { "CAC", "CBC" }, { "ND", "C1D" },  { "ND", "C4D" },
+    { "C1D", "C2D" }, { "C2D", "C3D" }, { "C2D", "CMD" }, { "C3D", "C4D" },
+    { "C3D", "CAD" }, { "CAD", "CBD" }, { "CBD", "CGD" }, { "CGD", "O2D" } },
+  // Double Bonds
+  { { "CGA", "O1A" }, { "CGD", "O1D" } });
+
 std::map<std::string, ResidueData> residueDict = {
   { "ALA", ALAData }, { "ARG", ARGData }, { "ARZ", ARZData },
   { "ASN", ASNData }, { "ASP", ASPData }, { "ASH", ASHData },
@@ -763,9 +786,10 @@ std::map<std::string, ResidueData> residueDict = {
   { "SER", SERData }, { "THR", THRData }, { "TRP", TRPData },
   { "TYR", TYRData }, { "VAL", VALData }, { "TIP", TIPData },
   { "HOH", HOHData }, { "WAT", WATData }, { "INH", INHData },
-  { "UMP", UMPData }, { "HED", HEDData }
+  { "UMP", UMPData }, { "HED", HEDData }, { "HEM", HEMData }
 };
-}
-}
+
+} // namespace Core
+} // namespace Avogadro
 
 #endif

--- a/utilities/resdata/resdataparse.cxx
+++ b/utilities/resdata/resdataparse.cxx
@@ -121,6 +121,29 @@ int main(int argc, char* argv[])
 
     } else {
       if (params[0] == "RES") {
+        currResidue = params[1];
+        atoms.clear();
+        singleBonds.clear();
+        doubleBonds.clear();
+      } else if (params[0] == "ATOM") {
+        if (params[1][0] >= '0' && params[1][0] <= '9')
+          std::rotate(params[1].begin(), params[1].begin() + 1,
+                      params[1].end());
+        atoms.push_back(params[1]);
+      } else if (params[0] == "BOND") {
+        if (params[1][0] >= '0' && params[1][0] <= '9')
+          std::rotate(params[1].begin(), params[1].begin() + 1,
+                      params[1].end());
+        if (params[2][0] >= '0' && params[2][0] <= '9')
+          std::rotate(params[2].begin(), params[2].begin() + 1,
+                      params[2].end());
+
+        if (params[3] == "1") {
+          singleBonds.push_back(make_pair(params[1], params[2]));
+        } else if (params[3] == "2") {
+          doubleBonds.push_back(make_pair(params[1], params[2]));
+        }
+      } else if (params[0] == "END") {
         if (currResidue != "") {
           output << "ResidueData " << currResidue << "Data(\"" << currResidue
                  << "\",\n"
@@ -149,29 +172,6 @@ int main(int argc, char* argv[])
           }
           output << "});\n\n";
           residueClassNames.push_back(currResidue);
-        }
-
-        currResidue = params[1];
-        atoms.clear();
-        singleBonds.clear();
-        doubleBonds.clear();
-      } else if (params[0] == "ATOM") {
-        if (params[1][0] >= '0' && params[1][0] <= '9')
-          std::rotate(params[1].begin(), params[1].begin() + 1,
-                      params[1].end());
-        atoms.push_back(params[1]);
-      } else if (params[0] == "BOND") {
-        if (params[1][0] >= '0' && params[1][0] <= '9')
-          std::rotate(params[1].begin(), params[1].begin() + 1,
-                      params[1].end());
-        if (params[2][0] >= '0' && params[2][0] <= '9')
-          std::rotate(params[2].begin(), params[2].begin() + 1,
-                      params[2].end());
-
-        if (params[3] == "1") {
-          singleBonds.push_back(make_pair(params[1], params[2]));
-        } else if (params[3] == "2") {
-          doubleBonds.push_back(make_pair(params[1], params[2]));
         }
       }
     }


### PR DESCRIPTION
Add the resulting single/double for HEM residues

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
