### PR TITLE
QtGui::Molecule: Append m_bondUniqueIds only once

### DIFF
--- a/avogadro/qtgui/molecule.cpp
+++ b/avogadro/qtgui/molecule.cpp
@@ -185,7 +185,10 @@ Molecule::BondType Molecule::addBond(const AtomType& a, const AtomType& b,
                                      unsigned char order)
 {
   m_bondUniqueIds.push_back(bondCount());
-  BondType bond_ = Core::Molecule::addBond(a, b, order);
+  assert(a.isValid() && a.molecule() == this);
+  assert(b.isValid() && b.molecule() == this);
+
+  BondType bond_ = Core::Molecule::addBond(a.index(), b.index(), order);
   return bond_;
 }
 


### PR DESCRIPTION
This prevents a complex call sequence of:

QtGui::Molecule::addBond() // atom types
Core::Molecule::addBond() // atom types
QtGui::Molecule::addBond() // atom indices

In this complex call sequence, two different
QtGui::Molecule::addBond() functions get called, and this
results in m_bondUniqueIds being appended to twice.

This fix explicitly calls Core::Molecule::addBond() for atom indices
and ensures that only one QtGui::Molecule::addBond() gets called,
so that m_bondUniqueIds is only appended once.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
