### PR TITLE
Plugin Downloader: move to nlohmann json

### DIFF
--- a/avogadro/qtplugins/plugindownloader/CMakeLists.txt
+++ b/avogadro/qtplugins/plugindownloader/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(SYSTEM "${AvogadroLibs_SOURCE_DIR}/thirdparty/jsoncpp")
+include_directories(SYSTEM "${AvogadroLibs_SOURCE_DIR}/thirdparty")
 
 find_package(LibArchive REQUIRED)
 include_directories(SYSTEM ${LIBARCHIVE_INCLUDE_DIRS})
@@ -20,4 +20,4 @@ avogadro_plugin(PluginDownloader
 )
 
 target_link_libraries(PluginDownloader LINK_PRIVATE ${Qt5Network_LIBRARIES}
-  ${LIBARCHIVE_LIBRARIES} jsoncpp)
+  ${LIBARCHIVE_LIBRARIES})

--- a/avogadro/qtplugins/plugindownloader/downloaderwidget.h
+++ b/avogadro/qtplugins/plugindownloader/downloaderwidget.h
@@ -23,7 +23,7 @@
 
 #include <QtWidgets/QDialog>
 
-#include <json/json.h>
+#include <nlohmann/json.hpp>
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -63,6 +63,13 @@ private:
     QString zipballUrl;
     QString readmeUrl;
     bool hasRelease;
+
+    // Default constructor
+    repo()
+      : name("Error"), description("Error"), releaseVersion("Error"),
+        type("other"), updatedAt("Error"), zipballUrl("Error"),
+        readmeUrl("Error"), hasRelease(false)
+    {}
   };
 
   struct downloadEntry
@@ -77,22 +84,19 @@ private:
   void downloadNext();
   bool checkSHA1(QByteArray);
 
-  struct repo* m_repoList;
+  std::vector<repo> m_repoList;
   Ui::DownloaderWidget* m_ui;
   QNetworkAccessManager* m_NetworkAccessManager;
   QNetworkReply* m_reply;
-  /** Jsoncpp reader to read JSON results */
-  Json::Reader* m_read;
   /** Holds a node of JSON results */
-  Json::Value m_root;
+  nlohmann::json m_root;
   /** Used to parse JSON results */
   QVariantMap m_jsonResult;
 
   QString m_filePath;
 
   QList<downloadEntry> m_downloadList;
-  int m_numRepos;
 };
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro
 #endif // AVOGADRO_DOWNLOADERWIDGET_H


### PR DESCRIPTION
Part of the transfer to use nlohmann json instead of cpp json, this
eliminates the cpp json usage in the plugin downloader to use nlohmann
json instead.

I also fixed a few memory leaks that were present.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
