### PR TITLE
ImportPQR: move to nlohmann json

### DIFF
--- a/avogadro/qtplugins/importpqr/CMakeLists.txt
+++ b/avogadro/qtplugins/importpqr/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(SYSTEM "${AvogadroLibs_SOURCE_DIR}/thirdparty/jsoncpp")
+include_directories(SYSTEM "${AvogadroLibs_SOURCE_DIR}/thirdparty")
 
 # Extension
 set(importpqr_srcs
@@ -17,4 +17,4 @@ avogadro_plugin(ImportPQR
   ""
 )
 
-target_link_libraries(ImportPQR LINK_PRIVATE ${Qt5Network_LIBRARIES} jsoncpp)
+target_link_libraries(ImportPQR LINK_PRIVATE ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/importpqr/pqrrequest.h
+++ b/avogadro/qtplugins/importpqr/pqrrequest.h
@@ -19,8 +19,6 @@
 
 #include <cctype>
 
-#include <json/json.h>
-
 /**
  * @brief The PQRRequest class sends and receives network requests to PQR and
  * updates ui elements from the widget.
@@ -104,16 +102,18 @@ private:
     QString mol2url;
     QString formula;
     float mass;
+
+    // Default constructor
+    result()
+      : inchikey("Error"), name("Error"), mol2url("Error"), formula("Error"),
+        mass(-1.0)
+    {}
   };
   /** An array to hold all results from a query */
-  result* results;
+  std::vector<result> results;
 
   /** Holds a reply from a network request */
   QNetworkReply* reply;
-  /** Jsoncpp reader to read JSON results */
-  Json::Reader* read;
-  /** Holds a node of JSON results */
-  Json::Value root;
   /** Used to send/receive network request */
   QNetworkAccessManager* oNetworkAccessManager;
   /** Used to parse JSON results */
@@ -144,6 +144,6 @@ private:
    */
   float getMolMass(QString);
 };
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro
 #endif // PQRRequest_H


### PR DESCRIPTION
Part of the transfer to use nlohmann json instead of cpp json, this
eliminates the cpp json usage in the import pqr plugin to use nlohmann
json instead.

I also fixed a few memory leaks that were present.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
