### PR TITLE
Increase FPS cap to 1000 FPS

### DIFF
--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -38,7 +38,6 @@
 #include <QtWidgets/QSlider>
 #include <QtWidgets/QSpinBox>
 #include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QMessageBox>
 
 #include <QDebug>
 

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -93,7 +93,7 @@ QWidget* PlayerTool::toolWidget() const
     m_animationFPS = new QSpinBox;
     m_animationFPS->setValue(5);
     m_animationFPS->setMinimum(0);
-    m_animationFPS->setMaximum(100);
+    m_animationFPS->setMaximum(1000);
     m_animationFPS->setSuffix(tr(" FPS", "frames per second"));
     frames->addWidget(m_animationFPS);
     layout->addLayout(frames);
@@ -257,8 +257,11 @@ void PlayerTool::recordMovie()
 
   if (selfFilter == tr("GIF (*.gif)")) {
     GifWriter writer;
+    //GIF only supports up to 100 FPS, this minimizes breakage when FPS>100
+    QMessageBox::warning(this, "GIF FPS support warning",
+                         QString("The GIF file format does not support frame rates over 100 FPS."));
     GifBegin(&writer, (baseName + ".gif").toLatin1().data(), EXPORT_WIDTH,
-             EXPORT_HEIGHT, 100 / m_animationFPS->value());
+             EXPORT_HEIGHT, 100 / std::min(m_animationFPS->value(), 100) );
     for (int i = 0; i < m_molecule->coordinate3dCount(); ++i) {
       m_molecule->setCoordinate3d(i);
       if (bonding) {
@@ -294,7 +297,7 @@ void PlayerTool::recordMovie()
         }
       }
       GifWriteFrame(&writer, imageData, EXPORT_WIDTH, EXPORT_HEIGHT,
-                    100 / m_animationFPS->value());
+                    100 / std::min(m_animationFPS->value(), 100) );
       delete[] imageData;
     }
     GifEnd(&writer);

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -260,9 +260,8 @@ void PlayerTool::recordMovie()
     GifWriter writer;
     // GIF only supports up to 100 FPS, this minimizes breakage when FPS>100
     QMessageBox::warning(
-      this, "GIF FPS support warning",
-      QString(
-        "The GIF file format does not support frame rates over 100 FPS."));
+      qobject_cast<QWidget*>(parent()), tr("GIF FPS support warning"),
+      tr("The GIF file format does not support frame rates over 100 FPS."));
     GifBegin(&writer, (baseName + ".gif").toLatin1().data(), EXPORT_WIDTH,
              EXPORT_HEIGHT, 100 / std::min(m_animationFPS->value(), 100));
     for (int i = 0; i < m_molecule->coordinate3dCount(); ++i) {

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -257,9 +257,11 @@ void PlayerTool::recordMovie()
 
   if (selfFilter == tr("GIF (*.gif)")) {
     GifWriter writer;
-    //GIF only supports up to 100 FPS, this minimizes breakage when FPS>100
-    QMessageBox::warning(this, "GIF FPS support warning",
-                         QString("The GIF file format does not support frame rates over 100 FPS."));
+    // GIF only supports up to 100 FPS, this minimizes breakage when FPS>100
+    QMessageBox::warning(
+      this, "GIF FPS support warning",
+      QString(
+        "The GIF file format does not support frame rates over 100 FPS."));
     GifBegin(&writer, (baseName + ".gif").toLatin1().data(), EXPORT_WIDTH,
              EXPORT_HEIGHT, 100 / std::min(m_animationFPS->value(), 100));
     for (int i = 0; i < m_molecule->coordinate3dCount(); ++i) {

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -38,6 +38,7 @@
 #include <QtWidgets/QSlider>
 #include <QtWidgets/QSpinBox>
 #include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QMessageBox>
 
 #include <QDebug>
 

--- a/avogadro/qtplugins/playertool/playertool.cpp
+++ b/avogadro/qtplugins/playertool/playertool.cpp
@@ -261,7 +261,7 @@ void PlayerTool::recordMovie()
     QMessageBox::warning(this, "GIF FPS support warning",
                          QString("The GIF file format does not support frame rates over 100 FPS."));
     GifBegin(&writer, (baseName + ".gif").toLatin1().data(), EXPORT_WIDTH,
-             EXPORT_HEIGHT, 100 / std::min(m_animationFPS->value(), 100) );
+             EXPORT_HEIGHT, 100 / std::min(m_animationFPS->value(), 100));
     for (int i = 0; i < m_molecule->coordinate3dCount(); ++i) {
       m_molecule->setCoordinate3d(i);
       if (bonding) {
@@ -297,7 +297,7 @@ void PlayerTool::recordMovie()
         }
       }
       GifWriteFrame(&writer, imageData, EXPORT_WIDTH, EXPORT_HEIGHT,
-                    100 / std::min(m_animationFPS->value(), 100) );
+                    100 / std::min(m_animationFPS->value(), 100));
       delete[] imageData;
     }
     GifEnd(&writer);


### PR DESCRIPTION
This increases the FPS cap from 100 FPS to 1000 FPS. Useful for playing trajectories with extremely small timesteps.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
