### PR TITLE
Io: Add an option to not perceive bonds in xyz

### DIFF
--- a/avogadro/io/xyzformat.cpp
+++ b/avogadro/io/xyzformat.cpp
@@ -21,11 +21,15 @@
 #include <avogadro/core/utilities.h>
 #include <avogadro/core/vector.h>
 
+#include <nlohmann/json.hpp>
+
 #include <iomanip>
 #include <istream>
 #include <ostream>
 #include <sstream>
 #include <string>
+
+using json = nlohmann::json;
 
 using std::string;
 using std::endl;
@@ -58,6 +62,12 @@ XyzFormat::~XyzFormat()
 
 bool XyzFormat::read(std::istream& inStream, Core::Molecule& mol)
 {
+  json opts;
+  if (!options().empty())
+    opts = json::parse(options(), nullptr, false);
+  else
+    opts = json::object();
+
   size_t numAtoms = 0;
   if (!(inStream >> numAtoms)) {
     appendError("Error parsing number of atoms.");
@@ -141,7 +151,8 @@ bool XyzFormat::read(std::istream& inStream, Core::Molecule& mol)
   }
 
   // This format has no connectivity information, so perceive basics at least.
-  mol.perceiveBondsSimple();
+  if (opts.value("perceiveBonds", true))
+    mol.perceiveBondsSimple();
 
   return true;
 }

--- a/python/io.cpp
+++ b/python/io.cpp
@@ -59,7 +59,7 @@ public:
 private:
   FileFormatManager& m_ffm;
 };
-}
+} // namespace
 
 void exportIo(py::module& m)
 {
@@ -76,11 +76,18 @@ void exportIo(py::module& m)
   py::class_<ffm>(m, "FileFormatManager")
     .def(py::init<>())
     .def("readFile", &ffm::readFile,
-         "Read in a molecule from the supplied file path")
+         "Read in a molecule from the supplied file path", py::arg("molecule"),
+         py::arg("fileName"), py::arg("fileExtension") = std::string(),
+         py::arg("options") = std::string())
     .def("writeFile", &ffm::writeFile,
-         "Write the molecule to the supplied file path")
+         "Write the molecule to the supplied file path", py::arg("molecule"),
+         py::arg("fileName"), py::arg("fileExtension") = std::string(),
+         py::arg("options") = std::string())
     .def("readString", &ffm::readString,
-         "Read in a molecule from the supplied string")
+         "Read in a molecule from the supplied string", py::arg("molecule"),
+         py::arg("string"), py::arg("fileExtension"),
+         py::arg("options") = std::string())
     .def("writeString", &ffm::writeString,
-         "Write a molecule to the supplied string");
+         "Write a molecule to the supplied string", py::arg("mol"),
+         py::arg("ext"), py::arg("options") = std::string());
 }

--- a/python/io.cpp
+++ b/python/io.cpp
@@ -26,27 +26,31 @@ public:
   ffm() : m_ffm(FileFormatManager::instance()) {}
 
   bool readFile(Core::Molecule& molecule, const std::string& fileName,
-                const std::string& fileExtension = std::string()) const
+                const std::string& fileExtension = std::string(),
+                const std::string& options = std::string()) const
   {
-    return m_ffm.readFile(molecule, fileName, fileExtension);
+    return m_ffm.readFile(molecule, fileName, fileExtension, options);
   }
 
   bool writeFile(const Core::Molecule& molecule, const std::string& fileName,
-                 const std::string& fileExtension = std::string()) const
+                 const std::string& fileExtension = std::string(),
+                 const std::string& options = std::string()) const
   {
-    return m_ffm.writeFile(molecule, fileName, fileExtension);
+    return m_ffm.writeFile(molecule, fileName, fileExtension, options);
   }
 
   bool readString(Core::Molecule& molecule, const std::string& string,
-                  const std::string& fileExtension) const
+                  const std::string& fileExtension,
+                  const std::string& options = std::string()) const
   {
-    return m_ffm.readString(molecule, string, fileExtension);
+    return m_ffm.readString(molecule, string, fileExtension, options);
   }
 
-  std::string writeString(const Molecule& mol, const std::string& ext)
+  std::string writeString(const Molecule& mol, const std::string& ext,
+                          const std::string& options = std::string())
   {
     std::string fileStr;
-    bool ok = m_ffm.writeString(mol, fileStr, ext);
+    bool ok = m_ffm.writeString(mol, fileStr, ext, options);
     if (!ok)
       fileStr = "Error: " + FileFormatManager::instance().error();
     return fileStr;

--- a/tests/io/xyztest.cpp
+++ b/tests/io/xyztest.cpp
@@ -58,6 +58,31 @@ TEST(XyzTest, readAtomicSymbols)
   EXPECT_EQ(molecule.atom(4).position3d().z(), -0.36300);
 }
 
+// Turn off the option to perceive bonds
+TEST(XyzTest, readAtomicSymbolsNoBonds)
+{
+  XyzFormat xyz;
+  xyz.setOptions("{ \"perceiveBonds\": false }");
+  Molecule molecule;
+  EXPECT_TRUE(xyz.readFile(AVOGADRO_DATA "/data/methane.xyz", molecule));
+  ASSERT_EQ(xyz.error(), std::string());
+
+  EXPECT_EQ(molecule.atomCount(), 5);
+
+  // We turned off bond perception, so there should be zero bonds
+  EXPECT_EQ(molecule.bondCount(), 0);
+
+  EXPECT_EQ(molecule.atom(0).atomicNumber(), 6);
+  EXPECT_EQ(molecule.atom(1).atomicNumber(), 1);
+  EXPECT_EQ(molecule.atom(2).atomicNumber(), 1);
+  EXPECT_EQ(molecule.atom(3).atomicNumber(), 1);
+  EXPECT_EQ(molecule.atom(4).atomicNumber(), 1);
+
+  EXPECT_EQ(molecule.atom(4).position3d().x(), -0.51336);
+  EXPECT_EQ(molecule.atom(4).position3d().y(), 0.88916);
+  EXPECT_EQ(molecule.atom(4).position3d().z(), -0.36300);
+}
+
 // methane-num.xyz uses atomic numbers to identify atoms
 TEST(XyzTest, readAtomicNumbers)
 {


### PR DESCRIPTION
Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
