### PR TITLE
Custom atom color support

### DIFF
--- a/avogadro/core/atom.h
+++ b/avogadro/core/atom.h
@@ -156,6 +156,14 @@ public:
   /** @} */
 
   /**
+   * The color of this atom
+   * @{
+   */
+  void setColor(Vector3ub color);
+  Vector3ub color() const;
+  /** @} */
+
+  /**
    * Is the atom selected.
    * {@
    */
@@ -309,6 +317,18 @@ template <class Molecule_T>
 signed char AtomTemplate<Molecule_T>::formalCharge() const
 {
   return m_molecule->formalCharge(m_index);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setColor(Vector3ub color)
+{
+  m_molecule->setColor(m_index, std::move(color));
+}
+
+template <class Molecule_T>
+Vector3ub AtomTemplate<Molecule_T>::color() const
+{
+  return m_molecule->color(m_index);
 }
 
 template <class Molecule_T>

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -40,7 +40,7 @@ Molecule::Molecule(const Molecule& other)
     m_atomicNumbers(other.atomicNumbers()), m_positions2d(other.m_positions2d),
     m_positions3d(other.m_positions3d), m_coordinates3d(other.m_coordinates3d),
     m_timesteps(other.m_timesteps), m_hybridizations(other.m_hybridizations),
-    m_formalCharges(other.m_formalCharges),
+    m_formalCharges(other.m_formalCharges), m_colors(other.m_colors),
     m_vibrationFrequencies(other.m_vibrationFrequencies),
     m_vibrationIntensities(other.m_vibrationIntensities),
     m_vibrationLx(other.m_vibrationLx), m_bondPairs(other.m_bondPairs),
@@ -75,6 +75,7 @@ Molecule::Molecule(Molecule&& other) noexcept
     m_timesteps(std::move(other.m_timesteps)),
     m_hybridizations(std::move(other.m_hybridizations)),
     m_formalCharges(std::move(other.m_formalCharges)),
+    m_colors(std::move(other.m_colors)),
     m_vibrationFrequencies(std::move(other.m_vibrationFrequencies)),
     m_vibrationIntensities(std::move(other.m_vibrationIntensities)),
     m_vibrationLx(std::move(other.m_vibrationLx)),
@@ -105,6 +106,7 @@ Molecule& Molecule::operator=(const Molecule& other)
     m_timesteps = other.m_timesteps;
     m_hybridizations = other.m_hybridizations;
     m_formalCharges = other.m_formalCharges;
+    m_colors = other.m_colors,
     m_vibrationFrequencies = other.m_vibrationFrequencies;
     m_vibrationIntensities = other.m_vibrationIntensities;
     m_vibrationLx = other.m_vibrationLx;
@@ -152,6 +154,7 @@ Molecule& Molecule::operator=(Molecule&& other) noexcept
     m_timesteps = std::move(other.m_timesteps);
     m_hybridizations = std::move(other.m_hybridizations);
     m_formalCharges = std::move(other.m_formalCharges);
+    m_colors = std::move(other.m_colors);
     m_vibrationFrequencies = std::move(other.m_vibrationFrequencies);
     m_vibrationIntensities = std::move(other.m_vibrationIntensities);
     m_vibrationLx = std::move(other.m_vibrationLx);
@@ -244,6 +247,16 @@ Array<signed char>& Molecule::formalCharges()
 const Array<signed char>& Molecule::formalCharges() const
 {
   return m_formalCharges;
+}
+
+Array<Vector3ub>& Molecule::colors()
+{
+  return m_colors;
+}
+
+const Array<Vector3ub>& Molecule::colors() const
+{
+  return m_colors;
 }
 
 Array<Vector2>& Molecule::atomPositions2d()
@@ -354,6 +367,8 @@ bool Molecule::removeAtom(Index index)
       m_hybridizations[index] = m_hybridizations.back();
     if (m_formalCharges.size() == m_atomicNumbers.size())
       m_formalCharges[index] = m_formalCharges.back();
+    if (m_colors.size() == m_atomicNumbers.size())
+      m_colors[index] = m_colors.back();
 
     // Find any bonds to the moved atom and update their index.
     atomBonds = bonds(atom(newSize));
@@ -377,6 +392,8 @@ bool Molecule::removeAtom(Index index)
     m_hybridizations.pop_back();
   if (m_formalCharges.size() == m_atomicNumbers.size())
     m_formalCharges.pop_back();
+  if (m_colors.size() == m_atomicNumbers.size())
+    m_colors.pop_back();
   m_atomicNumbers.pop_back();
 
   return true;

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -24,6 +24,7 @@
 
 #include "array.h"
 #include "bond.h"
+#include "elements.h"
 #include "graph.h"
 #include "variantmap.h"
 #include "vector.h"
@@ -181,6 +182,37 @@ public:
    * @return True on success, false otherwise.
    */
   bool setFormalCharge(Index atomId, signed char charge);
+
+  /** Returns a vector of colors for the atoms in the moleucle. */
+  Array<Vector3ub>& colors();
+
+  /** \overload */
+  const Array<Vector3ub>& colors() const;
+
+  /**
+   * Get the color for the requested atom.
+   * @param atomId The index of the atom.
+   * @return The color of the atom indexed at @a atomId, or
+   * (0,0,0) if @a atomId is invalid. If no color is set for the
+   * given atomId, the default color for the atomic number of
+   * the atomId is returned.
+   */
+  Vector3ub color(Index atomId) const;
+
+  /**
+   * Replace the current array of colors.
+   * @param colors The new color array. Must be of length atomCount().
+   * @return True on success, false otherwise.
+   */
+  bool setColors(const Core::Array<Vector3ub>& colors);
+
+  /**
+   * Set the color of a single atom.
+   * @param atomId The index of the atom to modify.
+   * @param color The new color.
+   * @return True on success, false otherwise.
+   */
+  bool setColor(Index atomId, Vector3ub color);
 
   /** Returns a vector of 2d atom positions for the atoms in the molecule. */
   const Array<Vector2>& atomPositions2d() const;
@@ -594,6 +626,7 @@ protected:
   Array<AtomHybridization> m_hybridizations;
   Array<signed char> m_formalCharges;
   Array<Vector3> m_forceVectors;
+  Array<Vector3ub> m_colors;
 
   // Vibration data if available.
   Array<double> m_vibrationFrequencies;
@@ -705,6 +738,40 @@ inline bool Molecule::setFormalCharge(Index atomId, signed char charge)
     if (atomId >= m_formalCharges.size())
       m_formalCharges.resize(atomCount(), 0);
     m_formalCharges[atomId] = charge;
+    return true;
+  }
+  return false;
+}
+
+inline Vector3ub Molecule::color(Index atomId) const
+{
+  if (atomId >= atomCount())
+    return Vector3ub(0, 0, 0);
+
+  if (atomId < m_colors.size())
+    return m_colors[atomId];
+
+  return Vector3ub(Elements::color(atomicNumber(atomId)));
+}
+
+inline bool Molecule::setColors(const Core::Array<Vector3ub>& colors)
+{
+  if (colors.size() == atomCount()) {
+    m_colors = colors;
+    return true;
+  }
+  return false;
+}
+
+inline bool Molecule::setColor(Index atomId, Vector3ub color)
+{
+  if (atomId < atomCount()) {
+    if (atomId >= m_colors.size()) {
+      for (Index i = m_colors.size(); i < atomCount(); ++i) {
+        m_colors.push_back(Vector3ub(Elements::color(atomicNumber(i))));
+      }
+    }
+    m_colors[atomId] = color;
     return true;
   }
   return false;

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -63,6 +63,7 @@ protected:
   {
     return m_mol.m_molecule.formalCharges();
   }
+  Array<Vector3ub>& colors() { return m_mol.m_molecule.colors(); }
   Array<std::pair<Index, Index>>& bondPairs()
   {
     return m_mol.m_molecule.bondPairs();
@@ -589,6 +590,38 @@ bool RWMolecule::setFormalCharge(Index atomId, signed char charge)
   SetAtomFormalChargeCommand* comm = new SetAtomFormalChargeCommand(
     *this, atomId, m_molecule.formalCharge(atomId), charge);
   comm->setText(tr("Change Atom Formal Charge"));
+  m_undoStack.push(comm);
+  return true;
+}
+
+namespace {
+class SetAtomColorCommand : public RWMolecule::UndoCommand
+{
+  Index m_atomId;
+  Vector3ub m_oldColor;
+  Vector3ub m_newColor;
+
+public:
+  SetAtomColorCommand(RWMolecule& m, Index atomId, Vector3ub oldColor,
+                      Vector3ub newColor)
+    : UndoCommand(m), m_atomId(atomId), m_oldColor(oldColor),
+      m_newColor(newColor)
+  {}
+
+  void redo() override { colors()[m_atomId] = m_newColor; }
+
+  void undo() override { colors()[m_atomId] = m_oldColor; }
+};
+} // end namespace
+
+bool RWMolecule::setColor(Index atomId, Vector3ub color)
+{
+  if (atomId >= atomCount())
+    return false;
+
+  SetAtomColorCommand* comm =
+    new SetAtomColorCommand(*this, atomId, m_molecule.color(atomId), color);
+  comm->setText(tr("Change Atom Color"));
   m_undoStack.push(comm);
   return true;
 }

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -285,6 +285,24 @@ public:
   bool setFormalCharge(Index atomId, signed char charge);
 
   /**
+   * Get the color for the requested atom.
+   * @param atomId The index of the atom.
+   * @return The color of the atom indexed at @a atomId, or
+   * (0, 0, 0) if @a atomId is invalid. If no color is set for the
+   * given atomId, the default color for the atomic number of
+   * the atomId is returned.
+   */
+  Vector3ub color(Index atomId) const;
+
+  /**
+   * Set the color of a single atom.
+   * @param atomId The index of the atom to modify.
+   * @param color The new color.
+   * @return True on success, false otherwise.
+   */
+  bool setColor(Index atomId, Vector3ub color);
+
+  /**
    * Create a new bond in the molecule.
    * @param atom1 The first atom in the bond.
    * @param atom2 The second order in the bond.
@@ -729,6 +747,11 @@ inline Core::AtomHybridization RWMolecule::hybridization(Index atomId) const
 inline signed char RWMolecule::formalCharge(Index atomId) const
 {
   return m_molecule.formalCharge(atomId);
+}
+
+inline Vector3ub RWMolecule::color(Index atomId) const
+{
+  return m_molecule.color(atomId);
 }
 
 inline RWMolecule::BondType RWMolecule::addBond(const AtomType& atom1,

--- a/avogadro/qtplugins/ballandstick/ballandstick.cpp
+++ b/avogadro/qtplugins/ballandstick/ballandstick.cpp
@@ -69,8 +69,7 @@ void BallAndStick::process(const Molecule& molecule, Rendering::GroupNode& node)
     unsigned char atomicNumber = atom.atomicNumber();
     if (atomicNumber == 1 && !m_showHydrogens)
       continue;
-    const unsigned char* c = Elements::color(atomicNumber);
-    Vector3ub color(c[0], c[1], c[2]);
+    Vector3ub color = atom.color();
     float radius = static_cast<float>(Elements::radiusVDW(atomicNumber));
     if (atom.selected()) {
       color = Vector3ub(0, 0, 255);
@@ -92,8 +91,8 @@ void BallAndStick::process(const Molecule& molecule, Rendering::GroupNode& node)
     }
     Vector3f pos1 = bond.atom1().position3d().cast<float>();
     Vector3f pos2 = bond.atom2().position3d().cast<float>();
-    Vector3ub color1(Elements::color(bond.atom1().atomicNumber()));
-    Vector3ub color2(Elements::color(bond.atom2().atomicNumber()));
+    Vector3ub color1 = bond.atom1().color();
+    Vector3ub color2 = bond.atom2().color();
     Vector3f bondVector = pos2 - pos1;
     float bondLength = bondVector.norm();
     bondVector /= bondLength;
@@ -137,8 +136,8 @@ void BallAndStick::processEditable(const QtGui::RWMolecule& molecule,
     unsigned char atomicNumber = atom.atomicNumber();
     if (atomicNumber == 1 && !m_showHydrogens)
       continue;
-    const unsigned char* c = Elements::color(atomicNumber);
-    Vector3ub color(c[0], c[1], c[2]);
+
+    Vector3ub color = atom.color();
     spheres->addSphere(atom.position3d().cast<float>(), color,
                        static_cast<float>(Elements::radiusVDW(atomicNumber)) *
                          0.3f);
@@ -157,8 +156,8 @@ void BallAndStick::processEditable(const QtGui::RWMolecule& molecule,
     }
     Vector3f pos1 = bond.atom1().position3d().cast<float>();
     Vector3f pos2 = bond.atom2().position3d().cast<float>();
-    Vector3ub color1(Elements::color(bond.atom1().atomicNumber()));
-    Vector3ub color2(Elements::color(bond.atom2().atomicNumber()));
+    Vector3ub color1 = bond.atom1().color();
+    Vector3ub color2 = bond.atom2().color();
     Vector3f bondVector = pos2 - pos1;
     float bondLength = bondVector.norm();
     bondVector /= bondLength;

--- a/avogadro/qtplugins/licorice/licorice.cpp
+++ b/avogadro/qtplugins/licorice/licorice.cpp
@@ -55,7 +55,7 @@ void Licorice::process(const Molecule& molecule, Rendering::GroupNode& node)
   geometry->addDrawable(spheres);
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     Core::Atom atom = molecule.atom(i);
-    Vector3ub color(Elements::color(atom.atomicNumber()));
+    Vector3ub color = atom.color();
     spheres->addSphere(atom.position3d().cast<float>(), color, radius);
   }
 
@@ -67,8 +67,8 @@ void Licorice::process(const Molecule& molecule, Rendering::GroupNode& node)
     Core::Bond bond = molecule.bond(i);
     Vector3f pos1 = bond.atom1().position3d().cast<float>();
     Vector3f pos2 = bond.atom2().position3d().cast<float>();
-    Vector3ub color1(Elements::color(bond.atom1().atomicNumber()));
-    Vector3ub color2(Elements::color(bond.atom2().atomicNumber()));
+    Vector3ub color1 = bond.atom1().color();
+    Vector3ub color2 = bond.atom2().color();
     Vector3f bondVector = pos2 - pos1;
     float bondLength = bondVector.norm();
     bondVector /= bondLength;

--- a/avogadro/qtplugins/selectiontool/CMakeLists.txt
+++ b/avogadro/qtplugins/selectiontool/CMakeLists.txt
@@ -1,6 +1,11 @@
-set(tool_srcs selectiontool.cpp)
+set(tool_srcs
+  selectiontool.cpp
+  selectiontoolwidget.cpp
+)
 
-set(tool_uis)
+set(tool_uis
+  selectiontoolwidget.ui
+)
 
 set(tool_rcs selectiontool.qrc)
 

--- a/avogadro/qtplugins/selectiontool/selectiontool.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontool.cpp
@@ -198,8 +198,10 @@ void SelectionTool::draw(Rendering::GroupNode& node)
 
 void SelectionTool::applyColor(Vector3ub color)
 {
-  for (Rendering::Identifier& atom : m_atoms) {
-    m_molecule->atom(atom.index).setColor(color);
+  for (Index i = 0; i < m_molecule->atomCount(); ++i) {
+    auto a = m_molecule->atom(i);
+    if (a.selected())
+      a.setColor(color);
   }
   m_molecule->emitChanged(Molecule::Atoms);
 }

--- a/avogadro/qtplugins/selectiontool/selectiontool.h
+++ b/avogadro/qtplugins/selectiontool/selectiontool.h
@@ -31,6 +31,7 @@
 
 namespace Avogadro {
 namespace QtPlugins {
+class SelectionToolWidget;
 
 /**
  * @brief SelectionTool selects atoms and bonds from the screen.
@@ -59,12 +60,16 @@ public:
 
   void draw(Rendering::GroupNode& node) override;
 
+private slots:
+  void applyColor(Vector3ub color);
+
 private:
   bool addAtom(const Rendering::Identifier& atom);
 
   QAction* m_activateAction;
   QtGui::Molecule* m_molecule;
   Rendering::GLRenderer* m_renderer;
+  SelectionToolWidget* m_toolWidget;
   QVector<Rendering::Identifier> m_atoms;
   bool m_drawSelectionBox;
   Vector2 m_start;

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
@@ -1,0 +1,70 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "selectiontoolwidget.h"
+#include "ui_selectiontoolwidget.h"
+
+#include <QtWidgets/QColorDialog>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+SelectionToolWidget::SelectionToolWidget(QWidget* parent)
+  : QWidget(parent), m_ui(new Ui::SelectionToolWidget)
+{
+  m_ui->setupUi(this);
+  connect(m_ui->applyColorButton, SIGNAL(clicked()), this,
+          SLOT(userClickedColor()));
+}
+
+SelectionToolWidget::~SelectionToolWidget()
+{
+  delete m_ui;
+}
+
+void SelectionToolWidget::setColor(Vector3ub color)
+{
+  QColor new_color(color[0], color[1], color[2]);
+  QPalette pal = m_ui->applyColorButton->palette();
+  pal.setColor(QPalette::Button, new_color);
+  m_ui->applyColorButton->setPalette(pal);
+  m_ui->applyColorButton->update();
+}
+
+void SelectionToolWidget::userClickedColor()
+{
+  QColorDialog dlg(this);
+
+  QPalette pal = m_ui->applyColorButton->palette();
+  dlg.setCurrentColor(pal.color(QPalette::Button));
+
+  if (dlg.exec()) {
+    QColor new_color = dlg.currentColor();
+    pal.setColor(QPalette::Button, new_color);
+    m_ui->applyColorButton->setPalette(pal);
+    m_ui->applyColorButton->update();
+
+    Vector3ub color;
+    color[0] = static_cast<unsigned char>(new_color.red());
+    color[1] = static_cast<unsigned char>(new_color.green());
+    color[2] = static_cast<unsigned char>(new_color.blue());
+
+    emit colorApplied(color);
+  }
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
@@ -1,0 +1,55 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_SELECTIONTOOLWIDGET_H
+#define AVOGADRO_QTPLUGINS_SELECTIONTOOLWIDGET_H
+
+#include <QtWidgets/QWidget>
+
+#include <avogadro/core/vector.h>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+namespace Ui {
+class SelectionToolWidget;
+}
+
+class SelectionToolWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit SelectionToolWidget(QWidget* parent = 0);
+  ~SelectionToolWidget();
+
+  void setColor(Vector3ub color);
+
+signals:
+  void colorApplied(Vector3ub color);
+
+private slots:
+  void userClickedColor();
+
+private:
+  Ui::SelectionToolWidget* m_ui;
+  Vector3ub m_currentColor;
+};
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_SELECTIONTOOLWIDGET_H

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.ui
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Avogadro::QtPlugins::SelectionToolWidget</class>
+ <widget class="QWidget" name="Avogadro::QtPlugins::SelectionToolWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Apply Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="applyColorButton">
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
@@ -52,8 +52,8 @@ void VanDerWaals::process(const Core::Molecule& molecule,
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     Core::Atom atom = molecule.atom(i);
     unsigned char atomicNumber = atom.atomicNumber();
-    const unsigned char* c = Elements::color(atomicNumber);
-    Vector3ub color(c[0], c[1], c[2]);
+
+    Vector3ub color = atom.color();
     spheres->addSphere(atom.position3d().cast<float>(), color,
                        static_cast<float>(Elements::radiusVDW(atomicNumber)));
   }


### PR DESCRIPTION
This is a WIP.

The purpose of this PR is to add specialized coloring options for atoms in Avogadro. Currently, this can only be done when the atom is added through the Editor plugin, but before this is merged I plan on adding support for changing the atom color with the Select plugin.

I have a quick question about how Colors are supported in Avogadro. `Elements::Color` returns an `unsigned char*`. Should this be changed to a `Vector3ub` or even an `unsigned int` as is done with `QRgb`?

Signed-off-by: Jonathan Fine <finej@purdue.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
