### PR TITLE
Moving backgroundfileformat from app to qtgui

### DIFF
--- a/avogadro/qtgui/CMakeLists.txt
+++ b/avogadro/qtgui/CMakeLists.txt
@@ -32,6 +32,7 @@ configure_file("${CMAKE_CURRENT_BINARY_DIR}/avogadropython.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/avogadropython.h")
 
 set(HEADERS
+  backgroundfileformat.h
   containerwidget.h
   customelementdialog.h
   elementtranslator.h
@@ -60,6 +61,7 @@ set(HEADERS
 )
 
 set(SOURCES
+  backgroundfileformat.cpp
   containerwidget.cpp
   customelementdialog.cpp
   elementdetail_p.cpp

--- a/avogadro/qtgui/backgroundfileformat.cpp
+++ b/avogadro/qtgui/backgroundfileformat.cpp
@@ -1,0 +1,86 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "backgroundfileformat.h"
+
+#include <avogadro/io/fileformat.h>
+
+namespace Avogadro {
+
+namespace QtGui {
+
+BackgroundFileFormat::BackgroundFileFormat(Io::FileFormat* format,
+                                           QObject* aparent)
+  : QObject(aparent), m_format(format), m_molecule(nullptr), m_success(false)
+{}
+
+BackgroundFileFormat::~BackgroundFileFormat()
+{
+  delete m_format;
+}
+
+void BackgroundFileFormat::read()
+{
+  m_success = false;
+  m_error.clear();
+
+  if (!m_molecule)
+    m_error = tr("No molecule set in BackgroundFileFormat!");
+
+  if (!m_format)
+    m_error = tr("No Io::FileFormat set in BackgroundFileFormat!");
+
+  if (m_fileName.isEmpty())
+    m_error = tr("No file name set in BackgroundFileFormat!");
+
+  if (m_error.isEmpty()) {
+    m_success =
+      m_format->readFile(m_fileName.toLocal8Bit().data(), *m_molecule);
+
+    if (!m_success)
+      m_error = QString::fromStdString(m_format->error());
+  }
+
+  emit finished();
+}
+
+void BackgroundFileFormat::write()
+{
+  m_success = false;
+  m_error.clear();
+
+  if (!m_molecule)
+    m_error = tr("No molecule set in BackgroundFileFormat!");
+
+  if (!m_format)
+    m_error = tr("No Io::FileFormat set in BackgroundFileFormat!");
+
+  if (m_fileName.isEmpty())
+    m_error = tr("No file name set in BackgroundFileFormat!");
+
+  if (m_error.isEmpty()) {
+    m_success =
+      m_format->writeFile(m_fileName.toLocal8Bit().data(), *m_molecule);
+
+    if (!m_success)
+      m_error = QString::fromStdString(m_format->error());
+  }
+
+  emit finished();
+}
+
+} // namespace QtGui
+} // namespace Avogadro

--- a/avogadro/qtgui/backgroundfileformat.h
+++ b/avogadro/qtgui/backgroundfileformat.h
@@ -1,0 +1,112 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2013 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_QTGUI_BACKGROUNDFILEFORMAT_H
+#define AVOGADRO_QTGUI_BACKGROUNDFILEFORMAT_H
+
+#include "avogadroqtguiexport.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+
+namespace Avogadro {
+
+namespace Core {
+class Molecule;
+}
+
+namespace Io {
+class FileFormat;
+}
+
+namespace QtGui {
+
+/**
+ * @brief The BackgroundFileFormat class provides a thin QObject wrapper around
+ * an instance of Io::FileFormat.
+ */
+class AVOGADROQTGUI_EXPORT BackgroundFileFormat : public QObject
+{
+  Q_OBJECT
+public:
+  /**
+   * This class takes ownership of @a format and will delete it when destructed.
+   */
+  explicit BackgroundFileFormat(Io::FileFormat* format, QObject* aparent = 0);
+  ~BackgroundFileFormat();
+
+  /**
+   * The molecule instance to read/write.
+   * @{
+   */
+  void setMolecule(Core::Molecule* mol) { m_molecule = mol; }
+  Core::Molecule* molecule() const { return m_molecule; }
+  /**@}*/
+
+  /**
+   * The name of the file to read/write.
+   * @{
+   */
+  void setFileName(const QString& filename) { m_fileName = filename; }
+  QString fileName() const { return m_fileName; }
+  /**@}*/
+
+  /**
+   * The Io::FileFormat to use.
+   */
+  Io::FileFormat* fileFormat() const { return m_format; }
+
+  /**
+   * @return True if the operation was successful.
+   */
+  bool success() const { return m_success; }
+
+  /**
+   * @return An error string, set if success() is false.
+   */
+  QString error() const { return m_error; }
+
+signals:
+
+  /**
+   * Emitted when a call to read or write is called.
+   */
+  void finished();
+
+public slots:
+
+  /**
+   * Use the fileFormat() to read fileName() into molecule().
+   */
+  void read();
+
+  /**
+   * Use the fileFormat() to write fileName() from molecule().
+   */
+  void write();
+
+private:
+  Io::FileFormat* m_format;
+  Core::Molecule* m_molecule;
+  QString m_fileName;
+  QString m_error;
+  bool m_success;
+};
+
+} // namespace QtGui
+} // namespace Avogadro
+
+#endif // AVOGADRO_BACKGROUNDFILEFORMAT_H


### PR DESCRIPTION
This PR creates a copy of backgroundfileformat from the app. Once this is merged, the original files in the app will be removed and these will be used instead.

Intent for doing this is to make the backgroundfileformat usable from the libraries as well, atleast for now for sake of the topology import library.

-------
Signed-off-by: Adarsh Balasubramanian <badarsh2@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
