### PR TITLE
AppVeyor: Use ninja for the build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ init:
 environment:
   PATH: '%PATH%;%QTDIR%\bin'
   matrix:
-  - CMAKE_GENERATOR: '"Visual Studio 15 2017 Win64"'
+  - CMAKE_GENERATOR: '"Ninja"'
     QTDIR: C:\Qt\5.6\msvc2015_64
     platform: x64
 build_script:
@@ -29,6 +29,10 @@ build_script:
 
     cd openchemistry-build
 
+    choco install ninja
+
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
+
     cmake -G %CMAKE_GENERATOR% ../openchemistry
 
-    cmake --build . --target avogadrolibs --config Release -- /verbosity:detailed
+    cmake --build . --target avogadrolibs --config Release


### PR DESCRIPTION
Ninja seems to be much faster for the build than the
previous build system, partially because it uses all
of the cores on AppVeyor.

Ninja is installed with chocolatey, and the Visual Studio 2017
environment variables are set with the `vcvarsall.bat` script.

Verbosity detail was also turned off. This may have caused a
significant speed increase as well.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
