### PR TITLE
Fix compile error on FreeBSD (NULL -> nullptr)

### DIFF
--- a/avogadro/rendering/cylindergeometry.cpp
+++ b/avogadro/rendering/cylindergeometry.cpp
@@ -223,7 +223,7 @@ void CylinderGeometry::render(const Camera& camera)
   // Render the loaded spheres using the shader and bound VBO.
   glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(d->numberOfVertices),
                       static_cast<GLsizei>(d->numberOfIndices), GL_UNSIGNED_INT,
-                      reinterpret_cast<const GLvoid*>(NULL));
+                      reinterpret_cast<const GLvoid*>(0));
 
   d->vbo.release();
   d->ibo.release();

--- a/avogadro/rendering/meshgeometry.cpp
+++ b/avogadro/rendering/meshgeometry.cpp
@@ -171,7 +171,7 @@ void MeshGeometry::render(const Camera& camera)
   glDrawRangeElements(GL_TRIANGLES, 0,
                       static_cast<GLuint>(d->numberOfVertices - 1),
                       static_cast<GLsizei>(d->numberOfIndices), GL_UNSIGNED_INT,
-                      reinterpret_cast<const GLvoid*>(NULL));
+                      reinterpret_cast<const GLvoid*>(0));
 
   d->vbo.release();
   d->ibo.release();


### PR DESCRIPTION
This fixes #400 reported in GitHub where the NULL macro is defined to
nullptr on FreeBSD.