### PR TITLE
Bring VTK volume rendering and surfaces to Avogadro

### DIFF
--- a/avogadro/qtopengl/activeobjects.cpp
+++ b/avogadro/qtopengl/activeobjects.cpp
@@ -1,11 +1,11 @@
-/******************************************************************************
-  This source file is part of the Avogadro project.
-  This source code is released under the 3-Clause BSD License, (see "LICENSE").
-******************************************************************************/
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
 
 #include "activeobjects.h"
 
 #include "glwidget.h"
+
+#include <avogadro/qtgui/molecule.h>
 
 namespace Avogadro {
 namespace QtOpenGL {
@@ -24,9 +24,39 @@ GLWidget* ActiveObjects::activeGLWidget() const
   return m_glWidget;
 }
 
+QWidget* ActiveObjects::activeWidget() const
+{
+  return m_widget;
+}
+
+QtGui::Molecule* ActiveObjects::activeMolecule() const
+{
+  return m_molecule;
+}
+
 void ActiveObjects::setActiveGLWidget(GLWidget* glWidget)
 {
-  m_glWidget = glWidget;
+  if (m_glWidget != glWidget) {
+    m_glWidget = glWidget;
+    emit activeGLWidgetChanged(m_glWidget);
+    setActiveWidget(glWidget);
+  }
+}
+
+void ActiveObjects::setActiveWidget(QWidget* widget)
+{
+  if (m_widget != widget) {
+    m_widget = widget;
+    emit activeWidgetChanged(widget);
+  }
+}
+
+void ActiveObjects::setActiveMolecule(QtGui::Molecule* molecule)
+{
+  if (m_molecule != molecule) {
+    m_molecule = molecule;
+    emit activeMoleculeChanged(molecule);
+  }
 }
 
 } // namespace QtOpenGL

--- a/avogadro/qtopengl/activeobjects.cpp
+++ b/avogadro/qtopengl/activeobjects.cpp
@@ -37,6 +37,7 @@ QtGui::Molecule* ActiveObjects::activeMolecule() const
 void ActiveObjects::setActiveGLWidget(GLWidget* glWidget)
 {
   if (m_glWidget != glWidget) {
+    m_widget = nullptr;
     m_glWidget = glWidget;
     emit activeGLWidgetChanged(m_glWidget);
     setActiveWidget(glWidget);
@@ -46,6 +47,7 @@ void ActiveObjects::setActiveGLWidget(GLWidget* glWidget)
 void ActiveObjects::setActiveWidget(QWidget* widget)
 {
   if (m_widget != widget) {
+    m_glWidget = nullptr;
     m_widget = widget;
     emit activeWidgetChanged(widget);
   }

--- a/avogadro/qtopengl/activeobjects.h
+++ b/avogadro/qtopengl/activeobjects.h
@@ -1,7 +1,5 @@
-/******************************************************************************
-  This source file is part of the Avogadro project.
-  This source code is released under the 3-Clause BSD License, (see "LICENSE").
-******************************************************************************/
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
 
 #ifndef AVOGADRO_QTOPENGL_ACTIVEOBJECTS_H
 #define AVOGADRO_QTOPENGL_ACTIVEOBJECTS_H
@@ -10,13 +8,17 @@
 
 #include <QtCore/QObject>
 
+// #include "glwidget.h"
+
 #include <QtCore/QPointer>
 
+class QWidget;
 namespace Avogadro {
+namespace QtGui {
+class Molecule;
+}
 namespace QtOpenGL {
-
 class GLWidget;
-
 /**
  * @class ActiveObjects activeobjects.h <avogadro/qtopengl/activeobjects.h>
  * @brief Singleton to provide access to active objects.
@@ -40,16 +42,44 @@ public:
   /** Get the active GLWidget. **/
   GLWidget* activeGLWidget() const;
 
+  /** 
+   * Get the active widget (more general, could be GLWidget, vtkGLWidget, etc).
+   */
+  QWidget* activeWidget() const;
+
+  /**
+   * Get the active molecule.
+   */
+  QtGui::Molecule* activeMolecule() const;
+
 public slots:
-  /** Set the active GLWidget. **/
+  /** Set the active GLWidget. */
   void setActiveGLWidget(GLWidget* glWidget);
+
+  /** Set the active widget (GLWidget, vtkGLWidget, etc). */
+  void setActiveWidget(QWidget* widget);
+
+  /** Set the active widget (GLWidget, vtkGLWidget, etc). */
+  void setActiveMolecule(QtGui::Molecule* molecule);
+
+signals:
+  /** The active GL widget changed. */
+  void activeGLWidgetChanged(GLWidget* glWidget);
+
+  /** The active widget changed (GLWidget, vtkGLWidget, etc). */
+  void activeWidgetChanged(QWidget* widget);
+
+  /** The active molecule changed. */
+  void activeMoleculeChanged(QtGui::Molecule* molecule);
 
 private:
   ActiveObjects();
   ~ActiveObjects() override;
   Q_DISABLE_COPY(ActiveObjects)
 
-  QPointer<GLWidget> m_glWidget = nullptr;
+  GLWidget* m_glWidget = nullptr;
+  QWidget* m_widget = nullptr;
+  QtGui::Molecule* m_molecule = nullptr;
 };
 
 } // namespace QtOpenGL

--- a/avogadro/qtopengl/activeobjects.h
+++ b/avogadro/qtopengl/activeobjects.h
@@ -42,7 +42,7 @@ public:
   /** Get the active GLWidget. **/
   GLWidget* activeGLWidget() const;
 
-  /** 
+  /**
    * Get the active widget (more general, could be GLWidget, vtkGLWidget, etc).
    */
   QWidget* activeWidget() const;

--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -125,6 +125,7 @@ if(USE_VTK)
   add_subdirectory(plotpdf)
   add_subdirectory(plotrmsd)
   add_subdirectory(plotxrd)
+  add_subdirectory(coloropacitymap)
 endif()
 
 if(USE_MOLEQUEUE)

--- a/avogadro/qtplugins/coloropacitymap/CMakeLists.txt
+++ b/avogadro/qtplugins/coloropacitymap/CMakeLists.txt
@@ -1,0 +1,26 @@
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+
+set(_srcs
+  coloropacitymap.cpp
+  histogramwidget.cpp
+  qvtkwidget.cpp
+  vtkChartHistogram.cpp
+  vtkChartHistogramColorOpacityEditor.cpp
+  vtkCustomPiecewiseControlPointsItem.cpp
+  comdialog.cpp
+)
+
+set(_uis
+  comdialog.ui
+)
+
+avogadro_plugin(ColorOpacityMap
+  "Edit the color opacity map."
+  ExtensionPlugin
+  coloropacitymap.h
+  ColorOpacityMap
+  "${_srcs}"
+  "${_uis}"
+)
+
+target_link_libraries(ColorOpacityMap LINK_PRIVATE AvogadroVtk)

--- a/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
+++ b/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
@@ -1,0 +1,187 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "coloropacitymap.h"
+
+#include "comdialog.h"
+#include "computehistogram.h"
+#include "histogramwidget.h"
+
+#include <QAction>
+#include <QDialog>
+#include <QMessageBox>
+#include <QString>
+
+#include <avogadro/core/crystaltools.h>
+#include <avogadro/core/unitcell.h>
+#include <avogadro/core/cube.h>
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtopengl/activeobjects.h>
+#include <avogadro/qtopengl/glwidget.h>
+#include <avogadro/vtk/vtkplot.h>
+#include <avogadro/vtk/vtkglwidget.h>
+
+#include <vtkColorTransferFunction.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkTable.h>
+#include <vtkRenderWindow.h>
+
+using Avogadro::QtGui::Molecule;
+using Avogadro::QtOpenGL::ActiveObjects;
+
+using std::map;
+
+namespace Avogadro {
+namespace QtPlugins {
+
+using Core::Array;
+
+vtkImageData* cubeImageData(Core::Cube* cube)
+{
+  auto data = vtkImageData::New();
+  // data->SetNumberOfScalarComponents(1, nullptr);
+  Eigen::Vector3i dim = cube->dimensions();
+  data->SetExtent(0, dim.x() - 1, 0, dim.y() - 1, 0, dim.z() - 1);
+
+  // Translate origin, spacing, and types from Avogadro to VTK.
+  data->SetOrigin(cube->min().x(), cube->min().y(), cube->min().z());
+  data->SetSpacing(cube->spacing().data());
+  data->AllocateScalars(VTK_DOUBLE, 1);
+
+  double* dataPtr = static_cast<double*>(data->GetScalarPointer());
+  std::vector<double>* cubePtr = cube->data();
+
+  // Reorder our cube for VTK's Fortran ordering in vtkImageData.
+  for (int i = 0; i < dim.x(); ++i) {
+    for (int j = 0; j < dim.y(); ++j) {
+      for (int k = 0; k < dim.z(); ++k) {
+        dataPtr[(k * dim.y() + j) * dim.x() + i] =
+          (*cubePtr)[(i * dim.y() + j) * dim.z() + k];
+      }
+    }
+  }
+
+  return data;
+}
+
+ColorOpacityMap::ColorOpacityMap(QObject* p)
+  : Avogadro::QtGui::ExtensionPlugin(p)
+  , m_actions(QList<QAction*>())
+  , m_displayDialogAction(new QAction(this))
+{
+  m_displayDialogAction->setText(tr("Edit Color Opacity Map..."));
+  connect(m_displayDialogAction.data(), &QAction::triggered, this,
+          &ColorOpacityMap::displayDialog);
+  m_actions.push_back(m_displayDialogAction.data());
+  m_displayDialogAction->setProperty("menu priority", 70);
+
+  updateActions();
+}
+
+ColorOpacityMap::~ColorOpacityMap() = default;
+
+QList<QAction*> ColorOpacityMap::actions() const
+{
+  return m_actions;
+}
+
+QStringList ColorOpacityMap::menuPath(QAction*) const
+{
+  return QStringList() << tr("&Extensions");
+}
+
+void ColorOpacityMap::setMolecule(QtGui::Molecule* mol)
+{
+  if (m_molecule == mol)
+    return;
+
+  if (m_molecule)
+    m_molecule->disconnect(this);
+
+  m_molecule = mol;
+
+  if (m_molecule)
+    connect(m_molecule, SIGNAL(changed(uint)), SLOT(moleculeChanged(uint)));
+
+  updateActions();
+}
+
+void ColorOpacityMap::moleculeChanged(unsigned int c)
+{
+  Q_ASSERT(m_molecule == qobject_cast<Molecule*>(sender()));
+
+  // I think we need to look at adding cubes to changes, flaky right now.
+  auto changes = static_cast<Molecule::MoleculeChanges>(c);
+  if (changes & Molecule::Added || changes & Molecule::Removed) {
+    updateActions();
+    updateHistogram();
+  }
+}
+
+void ColorOpacityMap::updateActions()
+{
+  // Disable everything for nullptr molecules.
+  if (!m_molecule) {
+    foreach (QAction* action, m_actions)
+      action->setEnabled(false);
+    return;
+  }
+  foreach (QAction* action, m_actions)
+    action->setEnabled(true);
+}
+
+void ColorOpacityMap::updateHistogram()
+{
+  auto widget = ActiveObjects::instance().activeWidget();
+  auto vtkWidget = qobject_cast<VTK::vtkGLWidget*>(widget);
+
+  if (widget && vtkWidget && widget != m_activeWidget) {
+    if (m_activeWidget)
+      disconnect(widget, 0, this, 0);
+    connect(widget, SIGNAL(imageDataUpdated()), SLOT(updateHistogram()));
+    m_activeWidget = widget;
+  }
+
+  if (vtkWidget && m_molecule && m_molecule->cubeCount()) {
+    vtkNew<vtkTable> table;
+    auto imageData = vtkWidget->imageData();
+    auto lut = vtkWidget->lut();
+    auto opacity = vtkWidget->opacityFunction();
+
+    m_histogramWidget->setLUT(lut);
+    m_histogramWidget->setOpacityFunction(opacity);
+    if (imageData) {
+      PopulateHistogram(imageData, table);
+      m_histogramWidget->setInputData(table, "image_extents", "image_pops");
+    }
+  }
+}
+
+void ColorOpacityMap::displayDialog()
+{
+  if (!m_comDialog) {
+    auto p = qobject_cast<QWidget*>(parent());
+    m_comDialog = new ComDialog(p);
+    m_comDialog->setMolecule(m_molecule);
+    m_histogramWidget = m_comDialog->histogramWidget();
+    //m_c->resize(800, 600);
+    connect(m_histogramWidget, SIGNAL(colorMapUpdated()), SLOT(render()));
+    connect(m_histogramWidget, SIGNAL(opacityChanged()), SLOT(render()));
+    connect(m_comDialog, SIGNAL(renderNeeded()), SLOT(render()));
+  }
+  updateHistogram();
+  m_comDialog->show();
+}
+
+void ColorOpacityMap::render()
+{
+  auto widget = ActiveObjects::instance().activeWidget();
+  auto vtkWidget = qobject_cast<VTK::vtkGLWidget*>(widget);
+  if (vtkWidget) {
+    vtkWidget->GetRenderWindow()->Render();
+    vtkWidget->update();
+  }
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
+++ b/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
@@ -13,18 +13,18 @@
 #include <QString>
 
 #include <avogadro/core/crystaltools.h>
-#include <avogadro/core/unitcell.h>
 #include <avogadro/core/cube.h>
+#include <avogadro/core/unitcell.h>
 #include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtopengl/activeobjects.h>
 #include <avogadro/qtopengl/glwidget.h>
-#include <avogadro/vtk/vtkplot.h>
 #include <avogadro/vtk/vtkglwidget.h>
+#include <avogadro/vtk/vtkplot.h>
 
 #include <vtkColorTransferFunction.h>
 #include <vtkPiecewiseFunction.h>
-#include <vtkTable.h>
 #include <vtkRenderWindow.h>
+#include <vtkTable.h>
 
 using Avogadro::QtGui::Molecule;
 using Avogadro::QtOpenGL::ActiveObjects;
@@ -65,9 +65,8 @@ vtkImageData* cubeImageData(Core::Cube* cube)
 }
 
 ColorOpacityMap::ColorOpacityMap(QObject* p)
-  : Avogadro::QtGui::ExtensionPlugin(p)
-  , m_actions(QList<QAction*>())
-  , m_displayDialogAction(new QAction(this))
+  : Avogadro::QtGui::ExtensionPlugin(p), m_actions(QList<QAction*>()),
+    m_displayDialogAction(new QAction(this))
 {
   m_displayDialogAction->setText(tr("Edit Color Opacity Map..."));
   connect(m_displayDialogAction.data(), &QAction::triggered, this,
@@ -167,7 +166,7 @@ void ColorOpacityMap::displayDialog()
     m_comDialog = new ComDialog(p);
     m_comDialog->setMolecule(m_molecule);
     m_histogramWidget = m_comDialog->histogramWidget();
-    //m_c->resize(800, 600);
+    // m_c->resize(800, 600);
     connect(m_histogramWidget, SIGNAL(colorMapUpdated()), SLOT(render()));
     connect(m_histogramWidget, SIGNAL(opacityChanged()), SLOT(render()));
     connect(m_comDialog, SIGNAL(renderNeeded()), SLOT(render()));

--- a/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
+++ b/avogadro/qtplugins/coloropacitymap/coloropacitymap.cpp
@@ -109,6 +109,9 @@ void ColorOpacityMap::setMolecule(QtGui::Molecule* mol)
 void ColorOpacityMap::moleculeChanged(unsigned int c)
 {
   Q_ASSERT(m_molecule == qobject_cast<Molecule*>(sender()));
+  // Don't attempt to update anything if there is no dialog to update!
+  if (!m_comDialog)
+    return;
 
   // I think we need to look at adding cubes to changes, flaky right now.
   auto changes = static_cast<Molecule::MoleculeChanges>(c);

--- a/avogadro/qtplugins/coloropacitymap/coloropacitymap.h
+++ b/avogadro/qtplugins/coloropacitymap/coloropacitymap.h
@@ -1,0 +1,63 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef AVOGADRO_QTPLUGINS_COLOROPACITYMAP_H
+#define AVOGADRO_QTPLUGINS_COLOROPACITYMAP_H
+
+#include <avogadro/qtgui/extensionplugin.h>
+
+class QStringList;
+
+namespace Avogadro {
+class HistogramWidget;
+namespace QtPlugins {
+class ComDialog;
+/**
+ * @brief An interactive color opacity map editor with a value population histogram.
+ */
+class ColorOpacityMap : public Avogadro::QtGui::ExtensionPlugin
+{
+  Q_OBJECT
+public:
+  explicit ColorOpacityMap(QObject* parent_ = 0);
+  ~ColorOpacityMap();
+
+  QString name() const { return tr("ColorOpacityMap"); }
+  QString description() const;
+  QList<QAction*> actions() const;
+  QStringList menuPath(QAction*) const;
+
+public slots:
+  void setMolecule(QtGui::Molecule* mol);
+
+  void moleculeChanged(unsigned int changes);
+
+private slots:
+  void updateActions();
+
+  void updateHistogram();
+
+  void displayDialog();
+
+  void render();
+
+private:
+  QList<QAction*> m_actions;
+  QtGui::Molecule* m_molecule = nullptr;
+
+  ComDialog* m_comDialog = nullptr;
+  HistogramWidget* m_histogramWidget = nullptr;
+  QScopedPointer<QAction> m_displayDialogAction;
+
+  QWidget* m_activeWidget = nullptr;
+};
+
+inline QString ColorOpacityMap::description() const
+{
+  return tr("Edit color opacity maps, primarily for volume rendering.");
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_COLOROPACITYMAP_H

--- a/avogadro/qtplugins/coloropacitymap/coloropacitymap.h
+++ b/avogadro/qtplugins/coloropacitymap/coloropacitymap.h
@@ -13,7 +13,8 @@ class HistogramWidget;
 namespace QtPlugins {
 class ComDialog;
 /**
- * @brief An interactive color opacity map editor with a value population histogram.
+ * @brief An interactive color opacity map editor with a value population
+ * histogram.
  */
 class ColorOpacityMap : public Avogadro::QtGui::ExtensionPlugin
 {

--- a/avogadro/qtplugins/coloropacitymap/comdialog.cpp
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.cpp
@@ -1,0 +1,96 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "comdialog.h"
+
+#include "ui_comdialog.h"
+
+#include <avogadro/core/cube.h>
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtopengl/activeobjects.h>
+#include <avogadro/vtk/vtkglwidget.h>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+using QtOpenGL::ActiveObjects;
+using VTK::vtkGLWidget;
+
+ComDialog::ComDialog(QWidget* p, Qt::WindowFlags f)
+  : QDialog(p, f), m_ui(new Ui::ComDialog)
+{
+  m_ui->setupUi(this);
+  connect(m_ui->enableVolumeRendering, SIGNAL(stateChanged(int)),
+          SLOT(enableVolume(int)));
+  connect(m_ui->enableIsosurface, SIGNAL(stateChanged(int)),
+          SLOT(enableIsosurface(int)));
+  connect(m_ui->isoValue, SIGNAL(valueChanged(double)),
+          SLOT(setIsoValue(double)));
+  connect(m_ui->opacity, SIGNAL(valueChanged(double)),
+          SLOT(setOpacity(double)));
+}
+
+ComDialog::~ComDialog()
+{
+  delete m_ui;
+}
+
+HistogramWidget* ComDialog::histogramWidget()
+{
+  return m_ui->histogramWidget;
+}
+
+void ComDialog::setMolecule(QtGui::Molecule* mol)
+{
+  if (m_molecule == mol || !mol)
+    return;
+  m_molecule = mol;
+  // Figure out which cubes are available.
+  m_ui->cubesComboBox->clear();
+  for(Index i = 0; i < mol->cubeCount(); ++i) {
+    m_ui->cubesComboBox->addItem(QString(mol->cube(i)->name().c_str()));
+  }
+}
+
+void ComDialog::enableVolume(int enable)
+{
+  auto w = ActiveObjects::instance().activeWidget();
+  auto vtkgl = qobject_cast<vtkGLWidget*>(w);
+  if (vtkgl) {
+    vtkgl->renderVolume(enable == 0 ? false : true);
+    emit renderNeeded();
+  }
+}
+
+void ComDialog::enableIsosurface(int enable)
+{
+  auto w = ActiveObjects::instance().activeWidget();
+  auto vtkgl = qobject_cast<vtkGLWidget*>(w);
+  if (vtkgl) {
+    vtkgl->renderIsosurface(enable == 0 ? false : true);
+    emit renderNeeded();
+  }
+}
+
+void ComDialog::setIsoValue(double value)
+{
+  auto w = ActiveObjects::instance().activeWidget();
+  auto vtkgl = qobject_cast<vtkGLWidget*>(w);
+  if (vtkgl) {
+    vtkgl->setIsoValue(value);
+    emit renderNeeded();
+  }
+}
+
+void ComDialog::setOpacity(double value)
+{
+  auto w = ActiveObjects::instance().activeWidget();
+  auto vtkgl = qobject_cast<vtkGLWidget*>(w);
+  if (vtkgl) {
+    vtkgl->setOpacity(value);
+    emit renderNeeded();
+  }
+}
+
+}
+}

--- a/avogadro/qtplugins/coloropacitymap/comdialog.cpp
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.cpp
@@ -47,7 +47,7 @@ void ComDialog::setMolecule(QtGui::Molecule* mol)
   m_molecule = mol;
   // Figure out which cubes are available.
   m_ui->cubesComboBox->clear();
-  for(Index i = 0; i < mol->cubeCount(); ++i) {
+  for (Index i = 0; i < mol->cubeCount(); ++i) {
     m_ui->cubesComboBox->addItem(QString(mol->cube(i)->name().c_str()));
   }
 }
@@ -92,5 +92,5 @@ void ComDialog::setOpacity(double value)
   }
 }
 
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/coloropacitymap/comdialog.h
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.h
@@ -1,0 +1,50 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef AVOGADRO_QTPLUGINS_COMDIALOG_H
+#define AVOGADRO_QTPLUGINS_COMDIALOG_H
+
+#include <QtWidgets/QDialog>
+
+namespace Ui {
+class ComDialog;
+}
+
+namespace Avogadro {
+class HistogramWidget;
+namespace QtGui {
+class Molecule;
+}
+namespace QtPlugins {
+
+class ComDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  ComDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+  ~ComDialog() override;
+
+  HistogramWidget* histogramWidget();
+
+  void setMolecule(QtGui::Molecule* mol);
+
+protected slots:
+  void enableVolume(int enable);
+  void enableIsosurface(int enable);
+  void setIsoValue(double value);
+  void setOpacity(double value);
+
+signals:
+  void renderNeeded();
+
+private:
+  Ui::ComDialog* m_ui = nullptr;
+
+  QtGui::Molecule* m_molecule = nullptr;
+};
+
+} // End namespace QtPlugins
+} // End namespace Avogadro
+
+#endif

--- a/avogadro/qtplugins/coloropacitymap/comdialog.ui
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.ui
@@ -76,6 +76,9 @@
      </item>
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="isoValue">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="decimals">
         <number>3</number>
        </property>
@@ -96,6 +99,9 @@
      </item>
      <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="opacity">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="maximum">
         <double>1.000000000000000</double>
        </property>
@@ -120,5 +126,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>enableIsosurface</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>isoValue</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>472</x>
+     <y>465</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>472</x>
+     <y>493</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enableIsosurface</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opacity</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>472</x>
+     <y>465</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>472</x>
+     <y>525</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/avogadro/qtplugins/coloropacitymap/comdialog.ui
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ComDialog</class>
+ <widget class="QDialog" name="ComDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>776</width>
+    <height>549</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Volume Rendering</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="Avogadro::HistogramWidget" name="histogramWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>1</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Cube</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cubesComboBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Enable volume rendering</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="enableVolumeRendering">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Enable surface rendering</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="enableIsosurface">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Isovalue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QDoubleSpinBox" name="isoValue">
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="singleStep">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.050000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Opacity</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="opacity">
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.500000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Avogadro::HistogramWidget</class>
+   <extends>QWidget</extends>
+   <header>histogramwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/avogadro/qtplugins/coloropacitymap/computehistogram.h
+++ b/avogadro/qtplugins/coloropacitymap/computehistogram.h
@@ -1,0 +1,184 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef AVOGADRO_COMPUTE_HISTOGRAM_H
+#define AVOGADRO_COMPUTE_HISTOGRAM_H
+
+#include <vtkDoubleArray.h>
+#include <vtkImageData.h>
+#include <vtkMath.h>
+#include <vtkTable.h>
+#include <vtkPointData.h>
+#include <vtkFloatArray.h>
+#include <vtkIntArray.h>
+
+#include <cmath>
+
+namespace Avogadro {
+
+/** Single component integral type specialization. */
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+void calcHistogram(T* values, const vtkIdType numTuples, const float min,
+                   const float inv, int* pops, int&)
+{
+  for (vtkIdType j = 0; j < numTuples; ++j) {
+    ++pops[static_cast<int>((*values++ - min) * inv)];
+  }
+}
+
+/** Needs to be present, should never be compiled. */
+template <typename T>
+void calcHistogram(T*, const vtkIdType, int*)
+{
+  static_assert(!std::is_same<unsigned char, T>::value, "Invalid type");
+}
+
+/** Single component unsigned char covering 0 -> 255 range. */
+void calcHistogram(unsigned char* values, const vtkIdType numTuples, int* pops)
+{
+  for (vtkIdType j = 0; j < numTuples; ++j) {
+    ++pops[*values++];
+  }
+}
+
+/** Single component floating point type specialization. */
+template <typename T,
+          typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr>
+void calcHistogram(T* values, const vtkIdType numTuples, const float min,
+                   const float inv, int* pops, int& invalid)
+{
+  for (vtkIdType j = 0; j < numTuples; ++j) {
+    T value = *(values++);
+    if (std::isfinite(value)) {
+      ++pops[static_cast<int>((value - min) * inv)];
+    } else {
+      ++invalid;
+    }
+  }
+}
+
+/**
+ * Computes a histogram from an array of values.
+ * \param values The array from which to compute the histogram.
+ * \param numTuples Number of tuples in the array.
+ * \param numComponents Number of components in each tuple.
+ * \param min Minimum value in range
+ * \param max Maximum value in range
+ * \param inv Inverse of bin size, numBins is the number of bins
+ * in the histogram (or length of the pops array), and invalid is a return
+ * parameter indicating how many values in the array had a non-finite value.
+ */
+template <typename T>
+void CalculateHistogram(T* values, const vtkIdType numTuples,
+                        const vtkIdType numComponents, const float min,
+                        const float max, int* pops, const float inv,
+                        int& invalid)
+{
+  // Single component is a simpler/faster path, let's dispatch separately.
+  if (numComponents == 1) {
+    // Very fast path for unsigned char in 0 -> 255 range, or fast path.
+    if (std::is_same<T, unsigned char>::value && min == 0.f && max == 255.f) {
+      calcHistogram(values, numTuples, pops);
+    } else {
+      calcHistogram(values, numTuples, min, inv, pops, invalid);
+    }
+  } else {
+    // Multicomponent magnitude
+    for (vtkIdType j = 0; j < numTuples; ++j) {
+      // Check that all components are valid.
+      bool valid = true;
+      double squaredSum = 0.0;
+      for (vtkIdType c = 0; c < numComponents; ++c) {
+        T value = *(values + c);
+        if (!vtkMath::IsFinite(value)) {
+          valid = false;
+          break;
+        }
+        squaredSum += (value * value);
+      }
+      if (valid) {
+        int index = static_cast<int>((sqrt(squaredSum) - min) * inv);
+        ++pops[index];
+      } else {
+        ++invalid;
+      }
+      values += numComponents;
+    }
+  }
+}
+
+void PopulateHistogram(vtkImageData* input, vtkTable* output)
+{
+  // The output table will have the twice the number of columns, they will be
+  // the x and y for input column. This is the bin centers, and the population.
+  double minmax[2] = { 0.0, 0.0 };
+
+  // This number of bins in the 2D histogram will also be used as the number of
+  // bins in the 2D transfer function for X (scalar value) and Y (gradient mag.)
+  const int numberOfBins = 256;
+
+  // Keep the array we are working on around even if the user shallow copies
+  // over the input image data by incrementing the reference count here.
+  vtkSmartPointer<vtkDataArray> arrayPtr = input->GetPointData()->GetScalars();
+  if (!arrayPtr) {
+    return;
+  }
+
+  // The bin values are the centers, extending +/- half an inc either side
+  arrayPtr->GetFiniteRange(minmax, -1);
+  if (minmax[0] == minmax[1]) {
+    minmax[1] = minmax[0] + 1.0;
+  }
+
+  double inc = (minmax[1] - minmax[0]) / (numberOfBins - 1);
+  double halfInc = inc / 2.0;
+  vtkSmartPointer<vtkFloatArray> extents =
+    vtkFloatArray::SafeDownCast(output->GetColumnByName("image_extents"));
+  if (!extents) {
+    extents = vtkSmartPointer<vtkFloatArray>::New();
+    extents->SetName("image_extents");
+  }
+  extents->SetNumberOfTuples(numberOfBins);
+  double min = minmax[0] + halfInc;
+  for (int j = 0; j < numberOfBins; ++j) {
+    extents->SetValue(j, min + j * inc);
+  }
+  vtkSmartPointer<vtkIntArray> populations =
+    vtkIntArray::SafeDownCast(output->GetColumnByName("image_pops"));
+  if (!populations) {
+    populations = vtkSmartPointer<vtkIntArray>::New();
+    populations->SetName("image_pops");
+  }
+  populations->SetNumberOfTuples(numberOfBins);
+  auto pops = static_cast<int*>(populations->GetVoidPointer(0));
+  for (int k = 0; k < numberOfBins; ++k) {
+    pops[k] = 0;
+  }
+  int invalid = 0;
+
+  switch (arrayPtr->GetDataType()) {
+    vtkTemplateMacro(CalculateHistogram(
+      reinterpret_cast<VTK_TT*>(arrayPtr->GetVoidPointer(0)),
+      arrayPtr->GetNumberOfTuples(), arrayPtr->GetNumberOfComponents(),
+      minmax[0], minmax[1], pops, 1.0 / inc, invalid));
+    default:
+      cout << "UpdateFromFile: Unknown data type" << endl;
+  }
+
+#ifndef NDEBUG
+  vtkIdType total = invalid;
+  for (int i = 0; i < numberOfBins; ++i)
+    total += pops[i];
+  assert(total == arrayPtr->GetNumberOfTuples());
+#endif
+  if (invalid) {
+    cout << "Warning: NaN or infinite value in dataset" << endl;
+  }
+
+  output->AddColumn(extents);
+  output->AddColumn(populations);
+}
+
+} // End Avogadro namespace
+#endif // AVOGADRO_COMPUTE_HISTOGRAM_H

--- a/avogadro/qtplugins/coloropacitymap/computehistogram.h
+++ b/avogadro/qtplugins/coloropacitymap/computehistogram.h
@@ -5,12 +5,12 @@
 #define AVOGADRO_COMPUTE_HISTOGRAM_H
 
 #include <vtkDoubleArray.h>
-#include <vtkImageData.h>
-#include <vtkMath.h>
-#include <vtkTable.h>
-#include <vtkPointData.h>
 #include <vtkFloatArray.h>
+#include <vtkImageData.h>
 #include <vtkIntArray.h>
+#include <vtkMath.h>
+#include <vtkPointData.h>
+#include <vtkTable.h>
 
 #include <cmath>
 
@@ -180,5 +180,5 @@ void PopulateHistogram(vtkImageData* input, vtkTable* output)
   output->AddColumn(populations);
 }
 
-} // End Avogadro namespace
+} // namespace Avogadro
 #endif // AVOGADRO_COMPUTE_HISTOGRAM_H

--- a/avogadro/qtplugins/coloropacitymap/histogramwidget.cpp
+++ b/avogadro/qtplugins/coloropacitymap/histogramwidget.cpp
@@ -1,0 +1,162 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "histogramwidget.h"
+
+#include "qvtkwidget.h"
+
+#include <avogadro/qtopengl/activeobjects.h>
+#include <avogadro/qtopengl/glwidget.h>
+#include <avogadro/vtk/vtkglwidget.h>
+
+#include "vtkChartHistogramColorOpacityEditor.h"
+
+#include <vtkContextScene.h>
+#include <vtkContextView.h>
+#include <vtkControlPointsItem.h>
+#include <vtkDataArray.h>
+#include <vtkEventQtSlotConnect.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkRenderWindow.h>
+#include <vtkTable.h>
+#include <vtkVector.h>
+
+#include <vtkColorTransferFunction.h>
+
+#include <QCheckBox>
+#include <QColorDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#include <QDebug>
+
+namespace Avogadro {
+
+using QtOpenGL::ActiveObjects;
+
+HistogramWidget::HistogramWidget(QWidget* parent)
+  : QWidget(parent), m_qvtk(new QVTKGLWidget(this))
+{
+  // Set up our little chart.
+  m_histogramView->SetRenderWindow(m_qvtk->GetRenderWindow());
+  m_histogramView->SetInteractor(m_qvtk->GetInteractor());
+  m_histogramView->GetScene()->AddItem(m_histogramColorOpacityEditor);
+
+  // Connect events from the histogram color/opacity editor.
+  m_eventLink->Connect(m_histogramColorOpacityEditor,
+                       vtkCommand::CursorChangedEvent, this,
+                       SLOT(histogramClicked(vtkObject*)));
+  m_eventLink->Connect(m_histogramColorOpacityEditor,
+                       vtkCommand::EndEvent, this,
+                       SLOT(onScalarOpacityFunctionChanged()));
+  m_eventLink->Connect(m_histogramColorOpacityEditor,
+                       vtkControlPointsItem::CurrentPointEditEvent, this,
+                       SLOT(onCurrentPointEditEvent()));
+
+  auto hLayout = new QHBoxLayout(this);
+  hLayout->addWidget(m_qvtk);
+  setLayout(hLayout);
+}
+
+HistogramWidget::~HistogramWidget() = default;
+
+void HistogramWidget::setLUT(vtkColorTransferFunction* lut)
+{
+  if (m_LUT != lut) {
+    m_LUT = lut;
+    m_histogramColorOpacityEditor->SetColorTransferFunction(lut);
+    
+    emit colorMapUpdated();
+  }
+}
+
+void HistogramWidget::setOpacityFunction(vtkPiecewiseFunction* opacity)
+{
+  if (m_opacityFunction) {
+    m_eventLink->Disconnect(m_opacityFunction,
+                            vtkCommand::ModifiedEvent, this,
+                            SLOT(onScalarOpacityFunctionChanged()));
+  }
+  m_opacityFunction = opacity;
+  m_histogramColorOpacityEditor->SetOpacityFunction(opacity);
+  m_eventLink->Connect(m_opacityFunction, vtkCommand::ModifiedEvent,
+                       this, SLOT(onScalarOpacityFunctionChanged()));
+}
+
+vtkColorTransferFunction* HistogramWidget::LUT()
+{
+  return m_LUT;
+}
+
+vtkPiecewiseFunction* HistogramWidget::opacityFunction()
+{
+  return m_opacityFunction;
+}
+
+void HistogramWidget::setInputData(vtkTable* table, const char* x,
+                                   const char* y)
+{
+  m_inputData = table;
+  m_histogramColorOpacityEditor->SetHistogramInputData(table, x, y);
+  m_histogramColorOpacityEditor->SetOpacityFunction(m_opacityFunction);
+  if (m_LUT && table) {
+    m_histogramColorOpacityEditor->SetScalarVisibility(true);
+    m_histogramColorOpacityEditor->SetColorTransferFunction(m_LUT);
+    m_histogramColorOpacityEditor->SelectColorArray("image_extents");
+  }
+  m_histogramView->Render();
+}
+
+void HistogramWidget::onScalarOpacityFunctionChanged()
+{
+  // Update the histogram
+  m_histogramView->GetRenderWindow()->Render();
+
+  emit opacityChanged();
+}
+
+void HistogramWidget::onCurrentPointEditEvent()
+{
+  double rgb[3];
+  if (m_histogramColorOpacityEditor->GetCurrentControlPointColor(rgb)) {
+    QColor color =
+      QColorDialog::getColor(QColor::fromRgbF(rgb[0], rgb[1], rgb[2]), this,
+                             "Select Color for Control Point");
+    if (color.isValid()) {
+      rgb[0] = color.redF();
+      rgb[1] = color.greenF();
+      rgb[2] = color.blueF();
+      m_histogramColorOpacityEditor->SetCurrentControlPointColor(rgb);
+      onScalarOpacityFunctionChanged();
+    }
+  }
+}
+
+void HistogramWidget::histogramClicked(vtkObject*)
+{
+}
+
+void HistogramWidget::updateUI()
+{
+}
+
+void HistogramWidget::renderViews()
+{
+  
+//  pqView* view =
+//    tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
+//  if (view) {
+//    view->render();
+//  }
+}
+
+void HistogramWidget::showEvent(QShowEvent* event)
+{
+  QWidget::showEvent(event);
+  renderViews();
+}
+} // namespace Avogadro

--- a/avogadro/qtplugins/coloropacitymap/histogramwidget.cpp
+++ b/avogadro/qtplugins/coloropacitymap/histogramwidget.cpp
@@ -50,9 +50,8 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   m_eventLink->Connect(m_histogramColorOpacityEditor,
                        vtkCommand::CursorChangedEvent, this,
                        SLOT(histogramClicked(vtkObject*)));
-  m_eventLink->Connect(m_histogramColorOpacityEditor,
-                       vtkCommand::EndEvent, this,
-                       SLOT(onScalarOpacityFunctionChanged()));
+  m_eventLink->Connect(m_histogramColorOpacityEditor, vtkCommand::EndEvent,
+                       this, SLOT(onScalarOpacityFunctionChanged()));
   m_eventLink->Connect(m_histogramColorOpacityEditor,
                        vtkControlPointsItem::CurrentPointEditEvent, this,
                        SLOT(onCurrentPointEditEvent()));
@@ -69,7 +68,7 @@ void HistogramWidget::setLUT(vtkColorTransferFunction* lut)
   if (m_LUT != lut) {
     m_LUT = lut;
     m_histogramColorOpacityEditor->SetColorTransferFunction(lut);
-    
+
     emit colorMapUpdated();
   }
 }
@@ -77,14 +76,13 @@ void HistogramWidget::setLUT(vtkColorTransferFunction* lut)
 void HistogramWidget::setOpacityFunction(vtkPiecewiseFunction* opacity)
 {
   if (m_opacityFunction) {
-    m_eventLink->Disconnect(m_opacityFunction,
-                            vtkCommand::ModifiedEvent, this,
+    m_eventLink->Disconnect(m_opacityFunction, vtkCommand::ModifiedEvent, this,
                             SLOT(onScalarOpacityFunctionChanged()));
   }
   m_opacityFunction = opacity;
   m_histogramColorOpacityEditor->SetOpacityFunction(opacity);
-  m_eventLink->Connect(m_opacityFunction, vtkCommand::ModifiedEvent,
-                       this, SLOT(onScalarOpacityFunctionChanged()));
+  m_eventLink->Connect(m_opacityFunction, vtkCommand::ModifiedEvent, this,
+                       SLOT(onScalarOpacityFunctionChanged()));
 }
 
 vtkColorTransferFunction* HistogramWidget::LUT()
@@ -136,22 +134,18 @@ void HistogramWidget::onCurrentPointEditEvent()
   }
 }
 
-void HistogramWidget::histogramClicked(vtkObject*)
-{
-}
+void HistogramWidget::histogramClicked(vtkObject*) {}
 
-void HistogramWidget::updateUI()
-{
-}
+void HistogramWidget::updateUI() {}
 
 void HistogramWidget::renderViews()
 {
-  
-//  pqView* view =
-//    tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
-//  if (view) {
-//    view->render();
-//  }
+
+  //  pqView* view =
+  //    tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
+  //  if (view) {
+  //    view->render();
+  //  }
 }
 
 void HistogramWidget::showEvent(QShowEvent* event)

--- a/avogadro/qtplugins/coloropacitymap/histogramwidget.h
+++ b/avogadro/qtplugins/coloropacitymap/histogramwidget.h
@@ -1,0 +1,71 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef AVOGADRO_QTPLUGINS_HISTOGRAMWIDGET_H
+#define AVOGADRO_QTPLUGINS_HISTOGRAMWIDGET_H
+
+#include <QWidget>
+
+#include <vtkNew.h>
+#include <vtkWeakPointer.h>
+
+class vtkChartHistogramColorOpacityEditor;
+class vtkContextView;
+class vtkEventQtSlotConnect;
+class vtkPiecewiseFunction;
+class vtkObject;
+class vtkTable;
+
+class QToolButton;
+
+class vtkColorTransferFunction;
+
+namespace Avogadro {
+
+class QVTKGLWidget;
+
+class HistogramWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit HistogramWidget(QWidget* parent_ = nullptr);
+  ~HistogramWidget() override;
+
+  void setLUT(vtkColorTransferFunction* lut);
+  vtkColorTransferFunction* LUT();
+
+  void setOpacityFunction(vtkPiecewiseFunction* opacity);
+  vtkPiecewiseFunction* opacityFunction();
+
+  void setInputData(vtkTable* table, const char* x, const char* y);
+
+signals:
+  void colorMapUpdated();
+  void opacityChanged();
+
+public slots:
+  void onScalarOpacityFunctionChanged();
+  void onCurrentPointEditEvent();
+  void histogramClicked(vtkObject*);
+
+  void updateUI();
+
+protected:
+  void showEvent(QShowEvent* event) override;
+
+private:
+  void renderViews();
+  vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
+  vtkNew<vtkContextView> m_histogramView;
+  vtkNew<vtkEventQtSlotConnect> m_eventLink;
+
+  vtkWeakPointer<vtkColorTransferFunction> m_LUT;
+  vtkWeakPointer<vtkPiecewiseFunction> m_opacityFunction;
+  vtkWeakPointer<vtkTable> m_inputData;
+
+  QVTKGLWidget* m_qvtk;
+};
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_HISTOGRAMWIDGET_H

--- a/avogadro/qtplugins/coloropacitymap/qvtkwidget.cpp
+++ b/avogadro/qtplugins/coloropacitymap/qvtkwidget.cpp
@@ -24,7 +24,5 @@ QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
 
 QVTKGLWidget::~QVTKGLWidget() = default;
 
-void QVTKGLWidget::setEnableHiDPI(bool)
-{
-}
+void QVTKGLWidget::setEnableHiDPI(bool) {}
 } // namespace Avogadro

--- a/avogadro/qtplugins/coloropacitymap/qvtkwidget.cpp
+++ b/avogadro/qtplugins/coloropacitymap/qvtkwidget.cpp
@@ -1,0 +1,30 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "qvtkwidget.h"
+
+#include <QVTKInteractorAdapter.h>
+#include <vtkGenericOpenGLRenderWindow.h>
+#include <vtkNew.h>
+
+#include <QtGui/QSurfaceFormat>
+
+namespace Avogadro {
+
+QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
+  : QVTKOpenGLWidget(parent, f)
+{
+  // Set some defaults for our render window.
+  vtkNew<vtkGenericOpenGLRenderWindow> window;
+  SetRenderWindow(window);
+  auto glFormat = QVTKOpenGLWidget::defaultFormat();
+  glFormat.setSamples(8);
+  setFormat(glFormat);
+}
+
+QVTKGLWidget::~QVTKGLWidget() = default;
+
+void QVTKGLWidget::setEnableHiDPI(bool)
+{
+}
+} // namespace Avogadro

--- a/avogadro/qtplugins/coloropacitymap/qvtkwidget.h
+++ b/avogadro/qtplugins/coloropacitymap/qvtkwidget.h
@@ -1,0 +1,24 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef AVOGADRO_QTPLUGINS_QVTKGLWidget_H
+#define AVOGADRO_QTPLUGINS_QVTKGLWidget_H
+
+#include <QVTKOpenGLWidget.h>
+
+namespace Avogadro {
+
+class QVTKGLWidget : public QVTKOpenGLWidget
+{
+  Q_OBJECT
+
+public:
+  QVTKGLWidget(QWidget* parent = nullptr,
+               Qt::WindowFlags f = Qt::WindowFlags());
+  ~QVTKGLWidget() override;
+
+  void setEnableHiDPI(bool enable) override;
+};
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_QVTKGLWidget_H

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.cpp
@@ -1,0 +1,236 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "vtkChartHistogram.h"
+
+#include <vtkAxis.h>
+#include <vtkCommand.h>
+#include <vtkContext2D.h>
+#include <vtkContextMouseEvent.h>
+#include <vtkContextScene.h>
+#include <vtkDataArray.h>
+#include <vtkObjectFactory.h>
+#include <vtkPen.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkPiecewiseFunctionItem.h>
+#include <vtkPlot.h>
+#include <vtkPlotBar.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkScalarsToColors.h>
+#include <vtkTable.h>
+#include <vtkTextProperty.h>
+#include <vtkTooltipItem.h>
+#include <vtkTransform2D.h>
+
+#include "vtkCustomPiecewiseControlPointsItem.h"
+
+class vtkHistogramMarker : public vtkPlot
+{
+public:
+  static vtkHistogramMarker* New();
+  double PositionX;
+
+  bool Paint(vtkContext2D* painter) override
+  {
+    vtkNew<vtkPen> pen;
+    pen->SetColor(255, 0, 0, 255);
+    pen->SetWidth(2.0);
+    painter->ApplyPen(pen.Get());
+    painter->DrawLine(PositionX, 0, PositionX, 1e9);
+    return true;
+  }
+};
+
+vtkStandardNewMacro(vtkHistogramMarker)
+
+vtkStandardNewMacro(vtkChartHistogram)
+
+vtkChartHistogram::vtkChartHistogram()
+{
+  this->SetBarWidthFraction(1.0);
+  this->SetRenderEmpty(true);
+  this->SetAutoAxes(false);
+  this->ZoomWithMouseWheelOff();
+  this->GetAxis(vtkAxis::LEFT)->SetTitle("");
+  this->GetAxis(vtkAxis::BOTTOM)->SetTitle("");
+  this->GetAxis(vtkAxis::BOTTOM)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 255);
+  this->GetAxis(vtkAxis::LEFT)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::LEFT)->SetRange(0.0001, 10);
+  this->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);
+  this->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
+  this->GetAxis(vtkAxis::LEFT)->SetNotation(vtkAxis::SCIENTIFIC_NOTATION);
+  this->GetAxis(vtkAxis::LEFT)->SetPrecision(1);
+  this->GetAxis(vtkAxis::RIGHT)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::RIGHT)->SetRange(0.0, 1.0);
+  this->GetAxis(vtkAxis::RIGHT)->SetVisible(false);
+
+  int fontSize = 8;
+  this->GetAxis(vtkAxis::LEFT)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetAxis(vtkAxis::BOTTOM)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetAxis(vtkAxis::RIGHT)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetTooltip()->GetTextProperties()->SetFontSize(fontSize);
+
+  // Set up the plot bar
+  this->AddPlot(this->HistogramPlotBar.Get());
+  this->HistogramPlotBar->SetColor(0, 0, 255, 255);
+  this->HistogramPlotBar->GetPen()->SetLineType(vtkPen::NO_PEN);
+  this->HistogramPlotBar->SetSelectable(false);
+
+  // Set up and add the opacity editor chart items
+  this->OpacityFunctionItem->SetOpacity(
+    0.0); // don't show the transfer function
+  this->AddPlot(this->OpacityFunctionItem.Get());
+  this->SetPlotCorner(this->OpacityFunctionItem.Get(), 1);
+
+  this->OpacityControlPointsItem->SetEndPointsXMovable(false);
+  this->OpacityControlPointsItem->SetEndPointsYMovable(true);
+  this->OpacityControlPointsItem->SetEndPointsRemovable(false);
+
+  vtkPen* pen = this->OpacityControlPointsItem->GetPen();
+  pen->SetLineType(vtkPen::SOLID_LINE);
+  pen->SetColor(0, 0, 0);
+  pen->SetOpacity(255);
+  pen->SetWidth(2.0);
+  this->AddPlot(this->OpacityControlPointsItem.Get());
+  this->SetPlotCorner(this->OpacityControlPointsItem.Get(), 1);
+}
+
+vtkChartHistogram::~vtkChartHistogram()
+{
+}
+
+bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent& m)
+{
+  // Determine the location of the click, and emit something we can listen to!
+  vtkPlotBar* histo = nullptr;
+  if (this->GetNumberOfPlots() > 0) {
+    histo = vtkPlotBar::SafeDownCast(this->GetPlot(0));
+  }
+  if (!histo) {
+    return false;
+  }
+  this->CalculateUnscaledPlotTransform(histo->GetXAxis(), histo->GetYAxis(),
+                                       this->Transform.Get());
+  vtkVector2f pos;
+  this->Transform->InverseTransformPoints(m.GetScenePos().GetData(),
+                                          pos.GetData(), 1);
+  this->ContourValue = pos.GetX();
+  this->Marker->PositionX = this->ContourValue;
+  this->Marker->Modified();
+  this->Scene->SetDirty(true);
+  if (this->GetNumberOfPlots() > 0) {
+    // Work around a bug in the charts - ensure corner is invalid for the plot.
+    this->Marker->SetXAxis(nullptr);
+    this->Marker->SetYAxis(nullptr);
+    this->AddPlot(this->Marker.Get());
+  }
+  this->InvokeEvent(vtkCommand::CursorChangedEvent);
+  return true;
+}
+
+void vtkChartHistogram::SetHistogramInputData(vtkTable* table,
+                                              const char* xAxisColumn,
+                                              const char* yAxisColumn)
+{
+  this->HistogramPlotBar->SetInputData(table, xAxisColumn, yAxisColumn);
+
+  // vtkPlotBar doesn't seem to behave well when given a null table,
+  // so we just hide the components.
+  auto setItemsVisible = [this](bool vis) {
+    this->HistogramPlotBar->SetVisible(vis);
+    this->OpacityFunctionItem->SetVisible(vis);
+    this->OpacityControlPointsItem->SetVisible(vis);
+  };
+
+  if (!table) {
+    // Set axis
+    this->GetAxis(vtkAxis::LEFT)->SetRange(0, 1.0);
+    this->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 255);
+
+    // Set visiblity of items
+    setItemsVisible(false);
+
+    return;
+  }
+
+  if (!this->HistogramPlotBar->GetVisible()) {
+    setItemsVisible(true);
+  }
+
+  // Set the range of the axes
+  vtkDataArray* yArray =
+    vtkDataArray::SafeDownCast(table->GetColumnByName(yAxisColumn));
+  if (!yArray) {
+    return;
+  }
+
+  double max = log10(yArray->GetRange()[1]);
+  vtkAxis* leftAxis = this->GetAxis(vtkAxis::LEFT);
+  leftAxis->SetUnscaledMinimum(1.0);
+  leftAxis->SetMaximumLimit(max + 2.0);
+  leftAxis->SetMaximum(static_cast<int>(max) + 1.0);
+
+  vtkDataArray* xArray =
+    vtkDataArray::SafeDownCast(table->GetColumnByName(xAxisColumn));
+  if (xArray && xArray->GetNumberOfTuples() > 2) {
+    double range[2];
+    xArray->GetRange(range);
+    double halfInc = (xArray->GetTuple1(1) - xArray->GetTuple1(0)) / 2.0;
+    vtkAxis* bottomAxis = this->GetAxis(vtkAxis::BOTTOM);
+    bottomAxis->SetBehavior(vtkAxis::FIXED);
+    bottomAxis->SetRange(range[0] - halfInc, range[1] + halfInc);
+  }
+  // reset the right axis
+  vtkAxis* rightAxis = this->GetAxis(vtkAxis::RIGHT);
+  rightAxis->SetBehavior(vtkAxis::FIXED);
+  rightAxis->SetRange(0.0, 1.0);
+}
+
+void vtkChartHistogram::SetScalarVisibility(bool visible)
+{
+  this->HistogramPlotBar->SetScalarVisibility(visible);
+}
+
+void vtkChartHistogram::SetHistogramVisible(bool visible)
+{
+  this->HistogramPlotBar->SetVisible(visible);
+}
+
+void vtkChartHistogram::SetMarkerVisible(bool visible)
+{
+  this->Marker->SetVisible(visible);
+}
+
+void vtkChartHistogram::ScalarVisibilityOn()
+{
+  this->HistogramPlotBar->ScalarVisibilityOn();
+}
+
+void vtkChartHistogram::SetLookupTable(vtkScalarsToColors* lut)
+{
+  this->HistogramPlotBar->SetLookupTable(lut);
+}
+
+void vtkChartHistogram::SelectColorArray(const char* arrayName)
+{
+  this->HistogramPlotBar->SelectColorArray(arrayName);
+}
+
+void vtkChartHistogram::SetOpacityFunction(
+  vtkPiecewiseFunction* opacityFunction)
+{
+  this->OpacityFunctionItem->SetPiecewiseFunction(opacityFunction);
+  this->OpacityControlPointsItem->SetPiecewiseFunction(opacityFunction);
+}
+
+void vtkChartHistogram::SetDPI(int dpi)
+{
+  if (this->GetScene()) {
+    vtkRenderer* renderer = this->GetScene()->GetRenderer();
+    if (renderer && renderer->GetRenderWindow()) {
+      renderer->GetRenderWindow()->SetDPI(dpi);
+    }
+  }
+}

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.cpp
@@ -44,9 +44,9 @@ public:
 
 vtkStandardNewMacro(vtkHistogramMarker)
 
-vtkStandardNewMacro(vtkChartHistogram)
+  vtkStandardNewMacro(vtkChartHistogram)
 
-vtkChartHistogram::vtkChartHistogram()
+    vtkChartHistogram::vtkChartHistogram()
 {
   this->SetBarWidthFraction(1.0);
   this->SetRenderEmpty(true);
@@ -97,9 +97,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->SetPlotCorner(this->OpacityControlPointsItem.Get(), 1);
 }
 
-vtkChartHistogram::~vtkChartHistogram()
-{
-}
+vtkChartHistogram::~vtkChartHistogram() {}
 
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent& m)
 {

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.h
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.h
@@ -49,8 +49,8 @@ public:
   // Set the contour value from the contour marker
   vtkSetMacro(ContourValue, double) vtkGetMacro(ContourValue, double)
 
-  // Set the DPI of the chart.
-  void SetDPI(int dpi);
+    // Set the DPI of the chart.
+    void SetDPI(int dpi);
 
 protected:
   vtkNew<vtkTransform2D> Transform;

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.h
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogram.h
@@ -1,0 +1,69 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizvtkChartHistogram_h
+#define tomvizvtkChartHistogram_h
+
+#include <vtkChartXY.h>
+
+#include <vtkNew.h>
+#include <vtkTransform2D.h>
+
+class vtkContextMouseEvent;
+class vtkCustomPiecewiseControlPointsItem;
+class vtkHistogramMarker;
+class vtkPiecewiseFunction;
+class vtkPiecewiseFunctionItem;
+class vtkPlotBar;
+class vtkScalarsToColors;
+class vtkTable;
+
+class vtkChartHistogram : public vtkChartXY
+{
+public:
+  static vtkChartHistogram* New();
+
+  bool MouseDoubleClickEvent(const vtkContextMouseEvent& mouse) override;
+
+  // Set input for histogram
+  virtual void SetHistogramInputData(vtkTable* table, const char* xAxisColumn,
+                                     const char* yAxisColumn);
+
+  // Set scalar visibility in the histogram plot bar
+  virtual void SetScalarVisibility(bool visible);
+  virtual void ScalarVisibilityOn();
+
+  void SetHistogramVisible(bool visible);
+
+  void SetMarkerVisible(bool visible);
+
+  // Set lookup table
+  virtual void SetLookupTable(vtkScalarsToColors* lut);
+
+  // Set the color array name
+  virtual void SelectColorArray(const char* arrayName);
+
+  // Set opacity function from a transfer function
+  virtual void SetOpacityFunction(vtkPiecewiseFunction* opacityFunction);
+
+  // Set the contour value from the contour marker
+  vtkSetMacro(ContourValue, double) vtkGetMacro(ContourValue, double)
+
+  // Set the DPI of the chart.
+  void SetDPI(int dpi);
+
+protected:
+  vtkNew<vtkTransform2D> Transform;
+  double ContourValue;
+  vtkNew<vtkHistogramMarker> Marker;
+
+  vtkNew<vtkPlotBar> HistogramPlotBar;
+  vtkNew<vtkPiecewiseFunctionItem> OpacityFunctionItem;
+  vtkNew<vtkCustomPiecewiseControlPointsItem> OpacityControlPointsItem;
+
+private:
+  vtkChartHistogram();
+  virtual ~vtkChartHistogram();
+};
+
+#endif // tomvizvtkChartHistogram_h

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.cpp
@@ -1,0 +1,277 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "vtkChartHistogramColorOpacityEditor.h"
+
+#include <vtkAxis.h>
+#include <vtkChart.h>
+#include <vtkColorTransferControlPointsItem.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkColorTransferFunctionItem.h>
+#include <vtkContextItem.h>
+#include <vtkContextScene.h>
+#include <vtkObjectFactory.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkScalarsToColors.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+#include <vtkVector.h>
+
+#include "vtkChartHistogram.h"
+
+class vtkChartHistogramColorOpacityEditor::PIMPL
+{
+public:
+  PIMPL() : Geometry(0, 0), NeedsUpdate(true) {}
+  ~PIMPL() {}
+
+  void ForwardEvent(vtkObject* vtkNotUsed(object), unsigned long eventId,
+                    void* vtkNotUsed(data))
+  {
+    this->Self->InvokeEvent(eventId);
+  }
+
+  // Cached geometry of the chart
+  vtkVector2i Geometry;
+
+  // Dirty bit
+  bool NeedsUpdate;
+
+  // Reference to owner of the PIMPL
+  vtkChartHistogramColorOpacityEditor* Self;
+};
+
+vtkStandardNewMacro(vtkChartHistogramColorOpacityEditor)
+
+vtkChartHistogramColorOpacityEditor::vtkChartHistogramColorOpacityEditor()
+{
+  this->Private = new PIMPL();
+  this->Private->Self = this;
+
+  this->Borders[vtkAxis::LEFT] = 8;
+  this->Borders[vtkAxis::BOTTOM] = 8;
+  this->Borders[vtkAxis::RIGHT] = 8;
+  this->Borders[vtkAxis::TOP] = 20;
+
+  this->HistogramChart->SetHiddenAxisBorder(10);
+  this->HistogramChart->SetLayoutStrategy(vtkChart::AXES_TO_RECT);
+
+  this->ColorTransferFunctionChart->SetBarWidthFraction(1.0);
+  this->ColorTransferFunctionChart->SetHiddenAxisBorder(8);
+  this->ColorTransferFunctionChart->SetRenderEmpty(true);
+  this->ColorTransferFunctionChart->SetAutoAxes(false);
+  this->ColorTransferFunctionChart->ZoomWithMouseWheelOff();
+  this->ColorTransferFunctionChart->SetLayoutStrategy(vtkChart::AXES_TO_RECT);
+
+  this->ColorTransferFunctionItem->SelectableOff();
+
+  this->ColorTransferControlPointsItem->SetEndPointsXMovable(false);
+  this->ColorTransferControlPointsItem->SetEndPointsYMovable(true);
+  this->ColorTransferControlPointsItem->SetEndPointsRemovable(false);
+  this->ColorTransferControlPointsItem->SelectableOff();
+
+  this->ColorTransferFunctionChart->AddPlot(
+    this->ColorTransferFunctionItem.Get());
+  this->ColorTransferFunctionChart->SetPlotCorner(
+    this->ColorTransferFunctionItem.Get(), 1);
+  this->ColorTransferFunctionChart->AddPlot(
+    this->ColorTransferControlPointsItem.Get());
+  this->ColorTransferFunctionChart->SetPlotCorner(
+    this->ColorTransferControlPointsItem.Get(), 1);
+
+  vtkAxis* bottomAxis =
+    this->ColorTransferFunctionChart->GetAxis(vtkAxis::BOTTOM);
+  bottomAxis->SetTitle("");
+  bottomAxis->SetBehavior(vtkAxis::FIXED);
+  bottomAxis->SetVisible(false);
+  bottomAxis->SetRange(0, 255);
+
+  vtkAxis* leftAxis = this->ColorTransferFunctionChart->GetAxis(vtkAxis::LEFT);
+  leftAxis->SetTitle("");
+  leftAxis->SetBehavior(vtkAxis::FIXED);
+  leftAxis->SetVisible(false);
+
+  vtkAxis* topAxis = this->ColorTransferFunctionChart->GetAxis(vtkAxis::TOP);
+  topAxis->SetVisible(false);
+
+  this->AddItem(this->HistogramChart.Get());
+  this->AddItem(this->ColorTransferFunctionChart.Get());
+
+  // Forward events from internal charts to observers of this object
+  this->HistogramChart->AddObserver(vtkCommand::CursorChangedEvent,
+                                    this->Private, &PIMPL::ForwardEvent);
+  this->ColorTransferControlPointsItem->AddObserver(
+    vtkCommand::EndEvent, this->Private, &PIMPL::ForwardEvent);
+  this->ColorTransferControlPointsItem->AddObserver(
+    vtkControlPointsItem::CurrentPointEditEvent, this->Private,
+    &PIMPL::ForwardEvent);
+}
+
+vtkChartHistogramColorOpacityEditor::~vtkChartHistogramColorOpacityEditor()
+{
+  delete this->Private;
+}
+
+void vtkChartHistogramColorOpacityEditor::SetHistogramInputData(
+  vtkTable* table, const char* xAxisColumn, const char* yAxisColumn)
+{
+  this->HistogramChart->SetHistogramInputData(table, xAxisColumn, yAxisColumn);
+
+  if (!table) {
+    this->ColorTransferFunctionChart->SetVisible(false);
+    return;
+  }
+
+  if (!this->ColorTransferFunctionChart->GetVisible()) {
+    this->ColorTransferFunctionChart->SetVisible(true);
+    this->ColorTransferFunctionChart->RecalculateBounds();
+  }
+
+  // The histogram chart bottom axis range was updated in the call above.
+  // Set the same range for the color bar bottom axis here.
+  vtkAxis* histogramBottomAxis = this->HistogramChart->GetAxis(vtkAxis::BOTTOM);
+  double axisRange[2];
+  histogramBottomAxis->GetRange(axisRange);
+
+  vtkAxis* bottomAxis =
+    this->ColorTransferFunctionChart->GetAxis(vtkAxis::BOTTOM);
+  bottomAxis->SetRange(axisRange);
+
+  // The data range may change and cause the labels to change. Hence, update
+  // the geometry.
+  this->Private->NeedsUpdate = true;
+}
+
+void vtkChartHistogramColorOpacityEditor::SetColorTransferFunction(
+  vtkColorTransferFunction* ctf)
+{
+  this->HistogramChart->SetLookupTable(ctf);
+  this->ColorTransferFunctionItem->SetColorTransferFunction(ctf);
+  this->ColorTransferControlPointsItem->SetColorTransferFunction(ctf);
+  this->ColorTransferFunctionChart->RecalculateBounds();
+}
+
+void vtkChartHistogramColorOpacityEditor::SetScalarVisibility(bool visible)
+{
+  this->HistogramChart->SetScalarVisibility(visible);
+}
+
+void vtkChartHistogramColorOpacityEditor::SelectColorArray(
+  const char* arrayName)
+{
+  this->HistogramChart->SelectColorArray(arrayName);
+}
+
+void vtkChartHistogramColorOpacityEditor::SetOpacityFunction(
+  vtkPiecewiseFunction* opacityFunction)
+{
+  this->HistogramChart->SetOpacityFunction(opacityFunction);
+}
+
+vtkAxis* vtkChartHistogramColorOpacityEditor::GetHistogramAxis(int axis)
+{
+  return this->HistogramChart->GetAxis(axis);
+}
+
+bool vtkChartHistogramColorOpacityEditor::GetCurrentControlPointColor(
+  double rgb[3])
+{
+  vtkColorTransferFunction* ctf =
+    this->ColorTransferControlPointsItem->GetColorTransferFunction();
+  if (!ctf) {
+    return false;
+  }
+
+  vtkIdType currentIdx =
+    this->ColorTransferControlPointsItem->GetCurrentPoint();
+  if (currentIdx < 0) {
+    return false;
+  }
+
+  double xrgbms[6];
+  ctf->GetNodeValue(currentIdx, xrgbms);
+  rgb[0] = xrgbms[1];
+  rgb[1] = xrgbms[2];
+  rgb[2] = xrgbms[3];
+
+  return true;
+}
+
+void vtkChartHistogramColorOpacityEditor::SetCurrentControlPointColor(
+  const double rgb[3])
+{
+  vtkColorTransferFunction* ctf =
+    this->ColorTransferControlPointsItem->GetColorTransferFunction();
+  if (!ctf) {
+    return;
+  }
+
+  vtkIdType currentIdx =
+    this->ColorTransferControlPointsItem->GetCurrentPoint();
+  if (currentIdx < 0) {
+    return;
+  }
+
+  double xrgbms[6];
+  ctf->GetNodeValue(currentIdx, xrgbms);
+  xrgbms[1] = rgb[0];
+  xrgbms[2] = rgb[1];
+  xrgbms[3] = rgb[2];
+  ctf->SetNodeValue(currentIdx, xrgbms);
+}
+
+double vtkChartHistogramColorOpacityEditor::GetContourValue()
+{
+  return this->HistogramChart->GetContourValue();
+}
+
+void vtkChartHistogramColorOpacityEditor::SetDPI(int dpi)
+{
+  if (this->HistogramChart.Get()) {
+    this->HistogramChart->SetDPI(dpi);
+  }
+}
+
+bool vtkChartHistogramColorOpacityEditor::Paint(vtkContext2D* painter)
+{
+  vtkContextScene* scene = this->GetScene();
+  int sceneWidth = scene->GetSceneWidth();
+  int sceneHeight = scene->GetSceneHeight();
+  if (this->Private->NeedsUpdate ||
+      sceneWidth != this->Private->Geometry.GetX() ||
+      sceneHeight != this->Private->Geometry.GetY()) {
+    this->Private->NeedsUpdate = false;
+
+    // Update the geometry size cache
+    this->Private->Geometry.Set(sceneWidth, sceneHeight);
+
+    // Upper chart (histogram) expands, lower chart (color bar) is fixed height.
+    float x = this->Borders[vtkAxis::LEFT];
+    float y = this->Borders[vtkAxis::BOTTOM];
+
+    // Add the width of the left axis to x to make room for y labels
+    this->GetHistogramAxis(vtkAxis::LEFT)->Update();
+    float leftAxisWidth = this->GetHistogramAxis(vtkAxis::LEFT)
+                            ->GetBoundingRect(painter)
+                            .GetWidth();
+    x += leftAxisWidth;
+
+    float colorBarThickness = 20;
+    float plotWidth = sceneWidth - x - this->Borders[vtkAxis::RIGHT];
+
+    vtkRectf colorTransferFunctionChartSize(x, y, plotWidth, colorBarThickness);
+    this->ColorTransferFunctionChart->SetSize(colorTransferFunctionChartSize);
+    this->ColorTransferFunctionChart->RecalculateBounds();
+
+    float bottomAxisHeight = this->GetHistogramAxis(vtkAxis::BOTTOM)
+                               ->GetBoundingRect(painter)
+                               .GetHeight();
+    float verticalMargin = bottomAxisHeight;
+    y += colorBarThickness + verticalMargin - 5;
+    vtkRectf histogramChart(x, y, plotWidth,
+                            sceneHeight - y - this->Borders[vtkAxis::TOP]);
+    this->HistogramChart->SetSize(histogramChart);
+  }
+
+  return this->Superclass::Paint(painter);
+}

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.cpp
@@ -43,7 +43,7 @@ public:
 
 vtkStandardNewMacro(vtkChartHistogramColorOpacityEditor)
 
-vtkChartHistogramColorOpacityEditor::vtkChartHistogramColorOpacityEditor()
+  vtkChartHistogramColorOpacityEditor::vtkChartHistogramColorOpacityEditor()
 {
   this->Private = new PIMPL();
   this->Private->Self = this;

--- a/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.h
+++ b/avogadro/qtplugins/coloropacitymap/vtkChartHistogramColorOpacityEditor.h
@@ -1,0 +1,87 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizvtkChartHistogramColorOpacityEditor_h
+#define tomvizvtkChartHistogramColorOpacityEditor_h
+
+#include <vtkAbstractContextItem.h>
+#include <vtkNew.h>
+
+class vtkAxis;
+class vtkChartHistogram;
+class vtkChartXY;
+class vtkColorTransferControlPointsItem;
+class vtkColorTransferFunction;
+class vtkColorTransferFunctionItem;
+class vtkPiecewiseFunction;
+class vtkScalarsToColors;
+class vtkTable;
+
+// This class is a chart that combines a histogram from a data set
+// a color bar editor, and an opacity editor.
+class vtkChartHistogramColorOpacityEditor : public vtkAbstractContextItem
+{
+public:
+  vtkTypeMacro(
+    vtkChartHistogramColorOpacityEditor,
+    vtkAbstractContextItem) static vtkChartHistogramColorOpacityEditor* New();
+
+  // Set the input data.
+  void SetHistogramInputData(vtkTable* table, const char* xAxisColumn,
+                             const char* yAxisColumn);
+
+  // Set the lookup table.
+  void SetColorTransferFunction(vtkColorTransferFunction* lut);
+
+  // Enable or disable scalar visibility.
+  virtual void SetScalarVisibility(bool visible);
+
+  // Set the name of the array by which the histogram should be colored.
+  virtual void SelectColorArray(const char* arrayName);
+
+  // Set the opacity function.
+  virtual void SetOpacityFunction(vtkPiecewiseFunction* opacityFunction);
+
+  // Get an axis from the histogram chart.
+  vtkAxis* GetHistogramAxis(int axis);
+
+  // Get the color of the current color control point. Returns true if there
+  // is a currently selected control point, false otherwise.
+  bool GetCurrentControlPointColor(double rgb[3]);
+
+  // Set the color of the current color control point.
+  void SetCurrentControlPointColor(const double rgb[3]);
+
+  // Get the current contour value
+  double GetContourValue();
+
+  // Set the DPI
+  void SetDPI(int);
+
+  // Paint event for the editor.
+  virtual bool Paint(vtkContext2D* painter) override;
+
+protected:
+  // This provides the histogram, contour value marker, and opacity editor.
+  vtkNew<vtkChartHistogram> HistogramChart;
+
+  // This is used for the color transfer function editor.
+  vtkNew<vtkChartXY> ColorTransferFunctionChart;
+
+  // Controls for color transfer function editor.
+  vtkNew<vtkColorTransferControlPointsItem> ColorTransferControlPointsItem;
+
+  // Display of color transfer function.
+  vtkNew<vtkColorTransferFunctionItem> ColorTransferFunctionItem;
+
+private:
+  vtkChartHistogramColorOpacityEditor();
+  ~vtkChartHistogramColorOpacityEditor() override;
+
+  class PIMPL;
+  PIMPL* Private;
+
+  float Borders[4];
+};
+
+#endif // tomvizvtkChartHistogramColorOpacityEditor_h

--- a/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.cpp
@@ -1,0 +1,71 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "vtkCustomPiecewiseControlPointsItem.h"
+
+#include <vtkContextMouseEvent.h>
+#include <vtkContextScene.h>
+#include <vtkObjectFactory.h>
+#include <vtkPiecewiseFunction.h>
+
+vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem)
+
+vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()
+{
+}
+
+vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem()
+{
+}
+
+bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(
+  const vtkContextMouseEvent& mouse)
+{
+  // Ignore middle- and right-click events
+  if (mouse.GetButton() != vtkContextMouseEvent::LEFT_BUTTON) {
+    return false;
+  }
+
+  vtkVector2f vpos = mouse.GetPos();
+  this->TransformScreenToData(vpos, vpos);
+  double pos[2];
+  pos[0] = vpos.GetX();
+  pos[1] = vpos.GetY();
+
+  bool pointOnFunction = this->PointNearPiecewiseFunction(pos);
+  if (!pointOnFunction) {
+    this->SetCurrentPoint(-1);
+    return false;
+  }
+
+  return this->Superclass::MouseButtonPressEvent(mouse);
+}
+
+bool vtkCustomPiecewiseControlPointsItem::MouseDoubleClickEvent(
+  const vtkContextMouseEvent& mouse)
+{
+  // Ignore middle- and right-click events
+  if (mouse.GetButton() != vtkContextMouseEvent::LEFT_BUTTON) {
+    return false;
+  }
+
+  return this->Superclass::MouseDoubleClickEvent(mouse);
+}
+
+bool vtkCustomPiecewiseControlPointsItem::PointNearPiecewiseFunction(
+  const double position[2])
+{
+  double x = position[0];
+  double y = 0.0;
+
+  vtkPiecewiseFunction* pwf = this->GetPiecewiseFunction();
+  if (!pwf) {
+    return false;
+  }
+
+  // Evaluate the piewewise function at the given point and get the y position.
+  // If we are within a small distance of the piecewise function, return true.
+  // Otherwise, we are too far away from the line, and return false.
+  pwf->GetTable(x, x, 1, &y, 1);
+  return (fabs(y - position[1]) < 0.05);
+}

--- a/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.cpp
+++ b/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.cpp
@@ -10,13 +10,10 @@
 
 vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem)
 
-vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()
-{
-}
+  vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()
+{}
 
-vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem()
-{
-}
+vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem() {}
 
 bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(
   const vtkContextMouseEvent& mouse)

--- a/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.h
+++ b/avogadro/qtplugins/coloropacitymap/vtkCustomPiecewiseControlPointsItem.h
@@ -1,0 +1,41 @@
+/* This source file is part of the Avogadro project.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizvtkCustomPiecewiseControlPointsItem_h
+#define tomvizvtkCustomPiecewiseControlPointsItem_h
+
+#include <vtkPiecewiseControlPointsItem.h>
+
+class vtkContextMouseEvent;
+
+// Special control points item class that overrides the MouseDoubleClickEvent()
+// event handler to do nothing.
+class vtkCustomPiecewiseControlPointsItem : public vtkPiecewiseControlPointsItem
+{
+public:
+  vtkTypeMacro(
+    vtkCustomPiecewiseControlPointsItem,
+    vtkPiecewiseControlPointsItem) static vtkCustomPiecewiseControlPointsItem* New();
+
+  // Override to ignore button presses if the control modifier key is pressed.
+  bool MouseButtonPressEvent(const vtkContextMouseEvent& mouse) override;
+
+  // Override to avoid catching double-click events
+  bool MouseDoubleClickEvent(const vtkContextMouseEvent& mouse) override;
+
+protected:
+  vtkCustomPiecewiseControlPointsItem();
+  virtual ~vtkCustomPiecewiseControlPointsItem();
+
+  // Utility function to determine whether a position is near the piecewise
+  // function.
+  bool PointNearPiecewiseFunction(const double pos[2]);
+
+private:
+  vtkCustomPiecewiseControlPointsItem(
+    const vtkCustomPiecewiseControlPointsItem&); // Not implemented.
+  void operator=(
+    const vtkCustomPiecewiseControlPointsItem&); // Not implemented.
+};
+
+#endif // tomvizvtkCustomPiecewiseControlPointsItem_h

--- a/avogadro/qtplugins/meshes/meshes.cpp
+++ b/avogadro/qtplugins/meshes/meshes.cpp
@@ -56,7 +56,7 @@ void Meshes::process(const Molecule& mol, GroupNode& node)
   GeometryNode* geometry = new GeometryNode;
   node.addChild(geometry);
 
-  unsigned char opacity = 100;
+  unsigned char opacity = 150;
 
   if (mol.meshCount()) {
     const Mesh* mesh = mol.mesh(0);

--- a/avogadro/qtplugins/surfaces/surfaces.cpp
+++ b/avogadro/qtplugins/surfaces/surfaces.cpp
@@ -20,7 +20,7 @@
 #include "gaussiansetconcurrent.h"
 #include "slatersetconcurrent.h"
 
-// Header only, but duplicte symbols if included globally...
+// Header only, but duplicate symbols if included globally...
 namespace {
 #include <gif.h>
 }
@@ -242,6 +242,7 @@ void Surfaces::calculateQM()
   QString progressText;
   if (type == ElectronDensity) {
     progressText = tr("Calculating electron density");
+    m_cube->setName("Electron Denisty");
     if (dynamic_cast<GaussianSet*>(m_basis)) {
       m_gaussianConcurrent->calculateElectronDensity(m_cube);
     } else {
@@ -251,6 +252,7 @@ void Surfaces::calculateQM()
 
   else if (type == MolecularOrbital) {
     progressText = tr("Calculating molecular orbital %L1").arg(index);
+    m_cube->setName("Molecular Orbital " + std::to_string(index + 1));
     if (dynamic_cast<GaussianSet*>(m_basis)) {
       m_gaussianConcurrent->calculateMolecularOrbital(m_cube, index,
                                                       m_dialog->beta());
@@ -334,7 +336,7 @@ void Surfaces::displayMesh()
     m_meshGenerator1 = new QtGui::MeshGenerator;
     connect(m_meshGenerator1, SIGNAL(finished()), SLOT(meshFinished()));
   }
-  m_meshGenerator1->initialize(m_cube, m_mesh1, m_isoValue);
+  m_meshGenerator1->initialize(m_cube, m_mesh1, -m_isoValue);
 
   // TODO - only do this if we're generating an orbital
   //    and we need two meshes
@@ -345,7 +347,7 @@ void Surfaces::displayMesh()
     m_meshGenerator2 = new QtGui::MeshGenerator;
     connect(m_meshGenerator2, SIGNAL(finished()), SLOT(meshFinished()));
   }
-  m_meshGenerator2->initialize(m_cube, m_mesh2, -m_isoValue, true);
+  m_meshGenerator2->initialize(m_cube, m_mesh2, m_isoValue, true);
 
   // Start the mesh generation - this needs an improved mutex with a read lock
   // to function as expected. Write locks are exclusive, read locks can have

--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -37,4 +37,4 @@ set_target_properties(AvogadroVtk PROPERTIES AUTOMOC TRUE)
 target_link_libraries(AvogadroVtk AvogadroRendering AvogadroQtGui
   vtkRenderingOpenGL2 vtkGUISupportQt vtkRenderingVolumeOpenGL2
   vtkRenderingFreeType vtkInteractionStyle vtkChartsCore vtkViewsContext2D
-  vtkRenderingContextOpenGL2 Qt5::Widgets)
+  vtkRenderingContextOpenGL2 vtkDomainsChemistryOpenGL2 Qt5::Widgets)

--- a/avogadro/vtk/vtkglwidget.cpp
+++ b/avogadro/vtk/vtkglwidget.cpp
@@ -88,7 +88,7 @@ void vtkGLWidget::cubeVolume(Core::Cube* cube)
 
   volumeMapper->SetBlendModeToComposite();
   volumeMapper->SetInputData(m_imageData);
-  //volumeMapper->SetInputConnection(t->GetOutputPort());
+  // volumeMapper->SetInputConnection(t->GetOutputPort());
 
   volumeProperty->ShadeOff();
   volumeProperty->SetInterpolationTypeToLinear();
@@ -104,14 +104,14 @@ void vtkGLWidget::cubeVolume(Core::Cube* cube)
       auto magnitude = std::max(std::fabs(range[0]), std::fabs(range[1]));
       color->AddRGBPoint(-magnitude, 1.0, 0.0, 0.0);
       color->AddRGBPoint(-0.01 * magnitude, 1.0, 0.0, 0.0);
-      color->AddRGBPoint( 0.01 * magnitude, 0.0, 0.0, 1.0);
-      color->AddRGBPoint( magnitude, 0.0, 0.0, 1.0);
+      color->AddRGBPoint(0.01 * magnitude, 0.0, 0.0, 1.0);
+      color->AddRGBPoint(magnitude, 0.0, 0.0, 1.0);
 
       compositeOpacity->AddPoint(-magnitude, 1.0);
       compositeOpacity->AddPoint(-0.2 * magnitude, 0.8);
       compositeOpacity->AddPoint(0, 0.0);
-      compositeOpacity->AddPoint( 0.2 * magnitude, 0.8);
-      compositeOpacity->AddPoint( magnitude, 1.0);
+      compositeOpacity->AddPoint(0.2 * magnitude, 0.8);
+      compositeOpacity->AddPoint(magnitude, 1.0);
     }
   }
 
@@ -140,8 +140,7 @@ vtkGLWidget::vtkGLWidget(QWidget* p, Qt::WindowFlags f)
   GetInteractor()->Initialize();
   m_vtkRenderer->SetBackground(1.0, 1.0, 1.0);
 
-  
-  //m_actor->setScene(&this->renderer().scene());
+  // m_actor->setScene(&this->renderer().scene());
   m_moleculeMapper->UseBallAndStickSettings();
   m_actor->SetMapper(m_moleculeMapper);
   m_actor->GetProperty()->SetAmbient(0.0);
@@ -159,9 +158,7 @@ vtkGLWidget::vtkGLWidget(QWidget* p, Qt::WindowFlags f)
   m_contourActor->SetVisibility(0);
 }
 
-vtkGLWidget::~vtkGLWidget()
-{
-}
+vtkGLWidget::~vtkGLWidget() {}
 
 void vtkGLWidget::setMolecule(QtGui::Molecule* mol)
 {
@@ -174,7 +171,7 @@ void vtkGLWidget::setMolecule(QtGui::Molecule* mol)
   connect(m_molecule, SIGNAL(changed(unsigned int)), SLOT(updateScene()));
   connect(m_molecule, SIGNAL(changed(unsigned int)),
           SLOT(moleculeChanged(unsigned int)));
-  
+
   updateCube();
   // Reset the camera, re-render.
   m_vtkRenderer->ResetCamera();
@@ -251,7 +248,7 @@ void vtkGLWidget::setIsoValue(double value)
 {
   m_flyingEdges->SetNumberOfContours(2);
   m_flyingEdges->SetValue(0, -value);
-  m_flyingEdges->SetValue(1,  value);
+  m_flyingEdges->SetValue(1, value);
 }
 
 void vtkGLWidget::setOpacity(double value)
@@ -267,10 +264,8 @@ void vtkGLWidget::updateScene()
     m_vtkMolecule = vtkMolecule::New();
     for (Index i = 0; i < m_molecule->atomCount(); ++i) {
       auto a = m_molecule->atom(i);
-      m_vtkMolecule->AppendAtom(a.atomicNumber(),
-                                a.position3d().x(),
-                                a.position3d().y(),
-                                a.position3d().z());
+      m_vtkMolecule->AppendAtom(a.atomicNumber(), a.position3d().x(),
+                                a.position3d().y(), a.position3d().z());
     }
     for (Index i = 0; i < m_molecule->bondCount(); ++i) {
       auto b = m_molecule->bond(i);
@@ -328,5 +323,5 @@ void vtkGLWidget::resetGeometry()
 {
   m_renderer.resetGeometry();
 }
-}
-}
+} // namespace VTK
+} // namespace Avogadro

--- a/avogadro/vtk/vtkglwidget.h
+++ b/avogadro/vtk/vtkglwidget.h
@@ -28,14 +28,21 @@
 
 #include <QtCore/QPointer>
 
-class vtkAvogadroActor;
-class vtkLookupTable;
-// class vtkRenderViewBase;
+class vtkActor;
+class vtkColorTransferFunction;
+class vtkFlyingEdges3D;
+class vtkMolecule;
+class vtkMoleculeMapper;
+class vtkPiecewiseFunction;
+class vtkPolyDataMapper;
 class vtkRenderer;
 class vtkVolume;
+class vtkImageData;
 
 namespace Avogadro {
-
+namespace Core {
+class Cube;
+}
 namespace QtGui {
 class Molecule;
 class ToolPlugin;
@@ -74,6 +81,57 @@ public:
   const QtGui::ScenePluginModel& sceneModel() const { return m_scenePlugins; }
   /** @}*/
 
+  /**
+   * Get the color loop up table for the volume renderer.
+   */
+  vtkColorTransferFunction* lut() const;
+
+  /**
+   * Get the opacity function for the volume renderer.
+   */
+  vtkPiecewiseFunction* opacityFunction() const;
+
+  /**
+   * Get the vtkImageData that is being rendered.
+   */
+  vtkImageData* imageData() const;
+
+  /**
+   * Set the cube to render.
+   */
+  void setCube(Core::Cube* cube);
+
+  /**
+   * Get the cube being rendered, this is the input for the imageData.
+   */
+  Core::Cube* cube();
+
+  /**
+   * Display the volume rendering.
+   */
+  void renderVolume(bool enable);
+
+  /**
+   * Display an isosurface.
+   */
+  void renderIsosurface(bool enable);
+
+  /**
+   * Set the isovalue for the isosurface.
+   */
+  void setIsoValue(double value);
+
+  /**
+   * Set the isovalue for the isosurface.
+   */
+  void setOpacity(double value);
+
+signals:
+  /**
+   * Emitted if the image data is updated so that histograms etc can update.
+   */
+   void imageDataUpdated();
+
 public slots:
   /**
    * Update the scene plugins for the widget, this will generate geometry in
@@ -92,6 +150,14 @@ public slots:
   /** Reset the geometry when the molecule etc changes. */
   void resetGeometry();
 
+  /** Volume render the supplied cube. */
+  void cubeVolume(Core::Cube* cube);
+
+private slots:
+  void moleculeChanged(unsigned int c);
+
+  void updateCube();
+
 private:
   QPointer<QtGui::Molecule> m_molecule;
   QList<QtGui::ToolPlugin*> m_tools;
@@ -100,11 +166,24 @@ private:
   Rendering::GLRenderer m_renderer;
   QtGui::ScenePluginModel m_scenePlugins;
 
-  vtkNew<vtkAvogadroActor> m_actor;
   // vtkNew<vtkRenderViewBase> m_context;
   vtkNew<vtkRenderer> m_vtkRenderer;
-  vtkNew<vtkLookupTable> m_lut;
-  vtkSmartPointer<vtkVolume> m_volume;
+
+  // The volume rendering pieces.
+  vtkNew<vtkColorTransferFunction> m_lut;
+  vtkNew<vtkPiecewiseFunction> m_opacityFunction;
+  vtkSmartPointer<vtkImageData> m_imageData;
+  vtkNew<vtkVolume> m_volume;
+
+  // The contour pieces.
+  vtkNew<vtkActor> m_contourActor;
+  vtkNew<vtkPolyDataMapper> m_contourMapper;
+  vtkNew<vtkFlyingEdges3D> m_flyingEdges;
+
+  // The molecule actor, data structure, mapper.
+  vtkNew<vtkActor> m_actor;
+  vtkSmartPointer<vtkMolecule> m_vtkMolecule;
+  vtkNew<vtkMoleculeMapper> m_moleculeMapper;
 };
 }
 }

--- a/avogadro/vtk/vtkglwidget.h
+++ b/avogadro/vtk/vtkglwidget.h
@@ -46,7 +46,7 @@ class Cube;
 namespace QtGui {
 class Molecule;
 class ToolPlugin;
-}
+} // namespace QtGui
 
 namespace VTK {
 
@@ -130,7 +130,7 @@ signals:
   /**
    * Emitted if the image data is updated so that histograms etc can update.
    */
-   void imageDataUpdated();
+  void imageDataUpdated();
 
 public slots:
   /**
@@ -185,7 +185,7 @@ private:
   vtkSmartPointer<vtkMolecule> m_vtkMolecule;
   vtkNew<vtkMoleculeMapper> m_moleculeMapper;
 };
-}
-}
+} // namespace VTK
+} // namespace Avogadro
 
 #endif // AVOGADRO_VTKGLWIDGET_H


### PR DESCRIPTION
This is a pretty large commit, I had the intention of breaking it up
more, but it is all highly related and hard to bring in piece-by-piece.
There are a few things to note, such as the fact that VTK now requires
an OpenGL 3.3 core profile, making it incompatible with the Avogadro
rendering. This means that we must defer all rendering to VTK in the VTK
render window, and copy our data into VTK data structures.

The vtkImageData format also uses a different ordering (often referred
to as "Fortran ordering", whereas our Cube class uses the "C ordering"
used in most places (C, C++, Python, etc). So cubes must be reordered
as they are copied over.

The color opacity widget is ported from Tomviz, with some adaptations to
only use VTK, and some work to create a color map that looks good for
typical molecular orbitals. This is needed to see the populations of
values in cubes, and modify the color opacity map for volume rendering.

The widget and the view both update as new cubes are calculated, and
trigger new renders. There is still some work to do, and the active
objects work needs the corresponding additions in the application to
ensure we can see what is currently active. It is very cool to see MOs
pop in, and to benefit from the speed of the flying edges algorithm.
This also reuses cubes, which the standard approach should do too.