### PR TITLE
QtTextRenderStrategy::argbToRgba(): Fix oob array access.

### DIFF
--- a/avogadro/qtopengl/qttextrenderstrategy.cpp
+++ b/avogadro/qtopengl/qttextrenderstrategy.cpp
@@ -252,14 +252,13 @@ void QtTextRenderStrategy::argbToRgba(unsigned char* buffer, size_t pixels)
   // output: 0xAABBGGRR (little endian)
 
   quint32* cur = reinterpret_cast<quint32*>(buffer);
-  quint32* end = cur + pixels;
+  quint32* end = &cur[pixels];
 
   while (cur < end) {
-    // Skip empty pixels
-    while (*cur == 0 && cur < end)
-      ++cur;
-    argbToRgbaWorker<QSysInfo::ByteOrder>(*cur, *cur);
-    ++cur;
+    // Ignore empty pixels
+    if (*cur)
+      argbToRgbaWorker<QSysInfo::ByteOrder>(*cur, *cur);
+    cur++;
   }
 }
 


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
