### PR TITLE
Revert "Fix Eigen alignment issue in Camera class."

### DIFF
--- a/avogadro/rendering/camera.cpp
+++ b/avogadro/rendering/camera.cpp
@@ -25,38 +25,40 @@ namespace Rendering {
 
 Camera::Camera()
   : m_width(0), m_height(0), m_pixelScale(1.0), m_projectionType(Perspective),
-    m_orthographicScale(1.0), m_data(new EigenData)
+    m_orthographicScale(1.0)
 {
-  m_data->projection.setIdentity();
-  m_data->modelView.setIdentity();
+  m_projection.setIdentity();
+  m_modelView.setIdentity();
 }
 
-Camera::~Camera() {}
+Camera::~Camera()
+{
+}
 
 void Camera::translate(const Vector3f& translate_)
 {
-  m_data->modelView.translate(translate_);
+  m_modelView.translate(translate_);
 }
 
 void Camera::preTranslate(const Vector3f& translate_)
 {
-  m_data->modelView.pretranslate(translate_);
+  m_modelView.pretranslate(translate_);
 }
 
 void Camera::rotate(float angle, const Vector3f& axis)
 {
-  m_data->modelView.rotate(Eigen::AngleAxisf(angle, axis));
+  m_modelView.rotate(Eigen::AngleAxisf(angle, axis));
 }
 
 void Camera::preRotate(float angle, const Vector3f& axis)
 {
-  m_data->modelView.prerotate(Eigen::AngleAxisf(angle, axis));
+  m_modelView.prerotate(Eigen::AngleAxisf(angle, axis));
 }
 
 void Camera::scale(float s)
 {
   if (m_projectionType == Perspective)
-    m_data->modelView.scale(s);
+    m_modelView.scale(s);
   else
     m_orthographicScale *= s;
 }
@@ -69,30 +71,29 @@ void Camera::lookAt(const Vector3f& eye, const Vector3f& center,
   Vector3f s = f.cross(u).normalized();
   u = s.cross(f);
 
-  m_data->modelView.setIdentity();
-  m_data->modelView(0, 0) = s.x();
-  m_data->modelView(0, 1) = s.y();
-  m_data->modelView(0, 2) = s.z();
-  m_data->modelView(1, 0) = u.x();
-  m_data->modelView(1, 1) = u.y();
-  m_data->modelView(1, 2) = u.z();
-  m_data->modelView(2, 0) = -f.x();
-  m_data->modelView(2, 1) = -f.y();
-  m_data->modelView(2, 2) = -f.z();
-  m_data->modelView(0, 3) = -s.dot(eye);
-  m_data->modelView(1, 3) = -u.dot(eye);
-  m_data->modelView(2, 3) = f.dot(eye);
+  m_modelView.setIdentity();
+  m_modelView(0, 0) = s.x();
+  m_modelView(0, 1) = s.y();
+  m_modelView(0, 2) = s.z();
+  m_modelView(1, 0) = u.x();
+  m_modelView(1, 1) = u.y();
+  m_modelView(1, 2) = u.z();
+  m_modelView(2, 0) = -f.x();
+  m_modelView(2, 1) = -f.y();
+  m_modelView(2, 2) = -f.z();
+  m_modelView(0, 3) = -s.dot(eye);
+  m_modelView(1, 3) = -u.dot(eye);
+  m_modelView(2, 3) = f.dot(eye);
 }
 
 float Camera::distance(const Vector3f& point) const
 {
-  return (m_data->modelView * point).norm();
+  return (m_modelView * point).norm();
 }
 
 Vector3f Camera::project(const Vector3f& point) const
 {
-  Eigen::Matrix4f mvp =
-    m_data->projection.matrix() * m_data->modelView.matrix();
+  Eigen::Matrix4f mvp = m_projection.matrix() * m_modelView.matrix();
   Vector4f tPoint(point.x(), point.y(), point.z(), 1.0f);
   tPoint = mvp * tPoint;
   Vector3f result(
@@ -104,8 +105,7 @@ Vector3f Camera::project(const Vector3f& point) const
 
 Vector3f Camera::unProject(const Vector3f& point) const
 {
-  Eigen::Matrix4f mvp =
-    m_data->projection.matrix() * m_data->modelView.matrix();
+  Eigen::Matrix4f mvp = m_projection.matrix() * m_modelView.matrix();
   Vector4f result(
     2.0f * m_pixelScale * point.x() / static_cast<float>(m_width) - 1.0f,
     2.0f * (static_cast<float>(m_height) - m_pixelScale * point.y()) /
@@ -126,21 +126,21 @@ Vector3f Camera::unProject(const Vector2f& point,
 void Camera::calculatePerspective(float fieldOfView, float aspectRatio,
                                   float zNear, float zFar)
 {
-  m_data->projection.setIdentity();
+  m_projection.setIdentity();
   float f = 1.0f / std::tan(fieldOfView * float(M_PI) / 360.0f);
-  m_data->projection(0, 0) = f / aspectRatio;
-  m_data->projection(1, 1) = f;
-  m_data->projection(2, 2) = (zNear + zFar) / (zNear - zFar);
-  m_data->projection(2, 3) = (2.0f * zFar * zNear) / (zNear - zFar);
-  m_data->projection(3, 2) = -1;
-  m_data->projection(3, 3) = 0;
+  m_projection(0, 0) = f / aspectRatio;
+  m_projection(1, 1) = f;
+  m_projection(2, 2) = (zNear + zFar) / (zNear - zFar);
+  m_projection(2, 3) = (2.0f * zFar * zNear) / (zNear - zFar);
+  m_projection(3, 2) = -1;
+  m_projection(3, 3) = 0;
 }
 
 void Camera::calculatePerspective(float fieldOfView, float zNear, float zFar)
 {
-  calculatePerspective(
-    fieldOfView, static_cast<float>(m_width) / static_cast<float>(m_height),
-    zNear, zFar);
+  calculatePerspective(fieldOfView, static_cast<float>(m_width) /
+                                      static_cast<float>(m_height),
+                       zNear, zFar);
 }
 
 void Camera::calculateOrthographic(float left, float right, float bottom,
@@ -150,14 +150,14 @@ void Camera::calculateOrthographic(float left, float right, float bottom,
   right *= m_orthographicScale;
   bottom *= m_orthographicScale;
   top *= m_orthographicScale;
-  m_data->projection.setIdentity();
-  m_data->projection(0, 0) = 2.0f / (right - left);
-  m_data->projection(0, 3) = -(right + left) / (right - left);
-  m_data->projection(1, 1) = 2.0f / (top - bottom);
-  m_data->projection(1, 3) = -(top + bottom) / (top - bottom);
-  m_data->projection(2, 2) = -2.0f / (zFar - zNear);
-  m_data->projection(2, 3) = -(zFar + zNear) / (zFar - zNear);
-  m_data->projection(3, 3) = 1;
+  m_projection.setIdentity();
+  m_projection(0, 0) = 2.0f / (right - left);
+  m_projection(0, 3) = -(right + left) / (right - left);
+  m_projection(1, 1) = 2.0f / (top - bottom);
+  m_projection(1, 3) = -(top + bottom) / (top - bottom);
+  m_projection(2, 2) = -2.0f / (zFar - zNear);
+  m_projection(2, 3) = -(zFar + zNear) / (zFar - zNear);
+  m_projection(3, 3) = 1;
 }
 
 void Camera::setViewport(int w, int h)
@@ -173,13 +173,13 @@ void Camera::setDevicePixelRatio(float scale)
 
 void Camera::setProjection(const Eigen::Affine3f& transform)
 {
-  m_data->projection = transform;
+  m_projection = transform;
 }
 
 void Camera::setModelView(const Eigen::Affine3f& transform)
 {
-  m_data->modelView = transform;
+  m_modelView = transform;
 }
 
-} // namespace Rendering
-} // namespace Avogadro
+} // End Rendering namespace
+} // End Avogadro namespace

--- a/avogadro/rendering/camera.h
+++ b/avogadro/rendering/camera.h
@@ -22,7 +22,6 @@
 #include <avogadro/core/vector.h> // For vector types.
 
 #include <Eigen/Geometry> // For member variables.
-#include <memory>
 
 namespace Avogadro {
 namespace Rendering {
@@ -31,14 +30,6 @@ enum Projection
 {
   Perspective,
   Orthographic
-};
-
-// Separate Eigen datastructures to ensure sufficient memory alignment.
-struct EigenData
-{
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  Eigen::Affine3f projection;
-  Eigen::Affine3f modelView;
 };
 
 /**
@@ -171,7 +162,7 @@ public:
    * Set the model view matrix to the identity. This resets the model view
    * matrix.
    */
-  void setIdentity() { m_data->modelView.setIdentity(); }
+  void setIdentity() { m_modelView.setIdentity(); }
 
   /**
    * Set the projection transform.
@@ -217,25 +208,26 @@ public:
   float orthographicScale() const { return m_orthographicScale; }
 
 private:
+  Eigen::Affine3f m_projection;
+  Eigen::Affine3f m_modelView;
   int m_width;
   int m_height;
   float m_pixelScale;
   Projection m_projectionType;
   float m_orthographicScale;
-  std::shared_ptr<EigenData> m_data;
 };
 
 inline const Eigen::Affine3f& Camera::projection() const
 {
-  return m_data->projection;
+  return m_projection;
 }
 
 inline const Eigen::Affine3f& Camera::modelView() const
 {
-  return m_data->modelView;
+  return m_modelView;
 }
 
-} // namespace Rendering
-} // namespace Avogadro
+} // End Rendering namespace
+} // End Avogadro namespace
 
 #endif // AVOGADRO_RENDERING_CAMERA_H


### PR DESCRIPTION
Reverts OpenChemistry/avogadrolibs#428

Camera is somehow not properly set - confirmed by @psavery and @ghutchis (Mac).

Worked on test build before the merge, but loading a molecule now clips badly.

Happy to re-merge once issue is sorted out.