### PR TITLE
Camera requires a deep copy of Eigen data.

### DIFF
--- a/avogadro/rendering/camera.cpp
+++ b/avogadro/rendering/camera.cpp
@@ -31,6 +31,26 @@ Camera::Camera()
   m_data->modelView.setIdentity();
 }
 
+Camera::Camera(const Camera& o)
+  : m_width(o.m_width), m_height(o.m_height), m_pixelScale(o.m_pixelScale),
+    m_projectionType(o.m_projectionType),
+    m_orthographicScale(o.m_orthographicScale), m_data(new EigenData(*o.m_data))
+{}
+
+Camera& Camera::operator=(const Camera& o)
+{
+  if (this != &o) {
+    m_width = o.m_width;
+    m_height = o.m_height;
+    m_pixelScale = o.m_pixelScale;
+    m_projectionType = o.m_projectionType;
+    m_orthographicScale = o.m_orthographicScale;
+    m_data = std::move(std::unique_ptr<EigenData>(new EigenData(*o.m_data)));
+  }
+
+  return *this;
+}
+
 Camera::~Camera() {}
 
 void Camera::translate(const Vector3f& translate_)

--- a/avogadro/rendering/camera.h
+++ b/avogadro/rendering/camera.h
@@ -52,6 +52,8 @@ class AVOGADRORENDERING_EXPORT Camera
 {
 public:
   Camera();
+  Camera(const Camera& o);
+  Camera& operator=(const Camera& o);
   ~Camera();
 
   /**
@@ -222,7 +224,7 @@ private:
   float m_pixelScale;
   Projection m_projectionType;
   float m_orthographicScale;
-  std::shared_ptr<EigenData> m_data;
+  std::unique_ptr<EigenData> m_data;
 };
 
 inline const Eigen::Affine3f& Camera::projection() const


### PR DESCRIPTION
The patch fixes the regression introduced
in pull request #428. It adds the missing
copy constructor and assignment operator.
A unique pointer is used to store Eigen
data instead of the shared pointer.

Signed-off-by: Libor Bukata <lbukata@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
