### PR TITLE
Utilize new geometry endpoints for MongoChem

### DIFF
--- a/avogadro/qtplugins/mongochem/calculationsubmitter.h
+++ b/avogadro/qtplugins/mongochem/calculationsubmitter.h
@@ -56,6 +56,9 @@ private slots:
   void uploadMolecule();
   void finishUploadMolecule(const QVariant& results);
 
+  void uploadGeometry();
+  void finishUploadGeometry(const QVariant& results);
+
   void fetchCalculation();
   void finishFetchCalculation(const QVariant& results);
 
@@ -94,6 +97,7 @@ private:
 
   // These will be set during the process
   QString m_moleculeId;
+  QString m_geometryId;
   QString m_pendingCalculationId;
   QString m_clusterId;
   QString m_queueId;

--- a/avogadro/qtplugins/mongochem/mongochemwidget.h
+++ b/avogadro/qtplugins/mongochem/mongochemwidget.h
@@ -54,6 +54,8 @@ private slots:
   void finishDownloadMolecule(const QVariant& results);
   void uploadMolecule();
   void finishUploadMolecule(const QVariant& results);
+  void uploadGeometry(const QString& moleculeId);
+  void finishUploadGeometry(const QVariant& results);
   void submitCalculation();
   void finishSubmitCalculation(const QVariantMap& results);
   void finishWatchCalculation(const QByteArray& cjson);


### PR DESCRIPTION
For submitting a calculation, always upload a geometry, and use that
geometry in the calculation. This prevents an issue of always re-using
the molecule that is in the database, rather than the molecule that the
user has drawn. Now, the molecule that the user has drawn will always be
used.
    
In addition, when the user uploads a molecule that they have drawn, it
always uploads a geometry as well, so that it actually gets uploaded
even when the molecule already exists in the database.