### PR TITLE
Extend to support changes in Open Babel 3.0.0

### DIFF
--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -53,7 +53,8 @@ OBProcess::OBProcess(QObject* parent_)
 #else
       QDir dir(QCoreApplication::applicationDirPath() + "/../share/openbabel");
       QStringList filters;
-      filters << "2.*";
+      filters << "3.*"
+              << "2.*";
       QStringList dirs = dir.entryList(filters);
       if (dirs.size() == 1) {
         env.insert("BABEL_DATADIR", QCoreApplication::applicationDirPath() +
@@ -63,7 +64,10 @@ OBProcess::OBProcess(QObject* parent_)
       }
       dir.setPath(QCoreApplication::applicationDirPath() + "/../lib/openbabel");
       dirs = dir.entryList(filters);
-      if (dirs.size() == 1) {
+      if (dirs.size() == 0) {
+        env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
+                                     "/../lib/openbabel/");
+      } else if (dirs.size() == 1) {
         env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
                                      "/../lib/openbabel/" + dirs[0]);
       } else {


### PR DESCRIPTION
The version wildcard was extended, and it appears to offer a flat plugin
directory in some cases now. Hopefully the obabel executable still
respects the environment variables, I will try and do a little more
testing. We are finding the right directories now.