### PR TITLE
Add missing link libraries for Surface plugin

### DIFF
--- a/avogadro/qtplugins/surfaces/CMakeLists.txt
+++ b/avogadro/qtplugins/surfaces/CMakeLists.txt
@@ -18,4 +18,9 @@ avogadro_plugin(Surfaces
 )
 
 target_link_libraries(Surfaces
-  LINK_PRIVATE AvogadroQuantumIO ${Qt5Concurrent_LIBRARIES})
+  LINK_PRIVATE
+    AvogadroQuantumIO
+    AvogadroQtOpenGL
+    libgwavi
+    ${Qt5Concurrent_LIBRARIES}
+)


### PR DESCRIPTION
Add the internal library target libgwavi, as linking the plugin with the
'--no-undefined' linker flag reports undefined symbols:

/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld:
  CMakeFiles/Surfaces.dir/surfaces.cpp.o: in function
 `Avogadro::QtPlugins::Surfaces::recordMovie()':
  surfaces.cpp:(.text+0x2d2c):
undefined reference to `gwavi_open'

Also add AvogadroQtOpenGL, as it also required.

Fixes issue #436.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
