### PR TITLE
Fix to make sure clang-format only runs on branches not master

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -17,21 +17,23 @@ jobs:
 
     - name: 'Run clang-format-diff'
       run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/openchemistry/avogadrolibs
-        git fetch origin master:master
+        if [ ${GITHUB_BRANCH} != "master" ]; then
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/openchemistry/avogadrolibs
+          git fetch origin master:master
 
-        echo `which clang-format-diff-6.0`
-        export MASTER_SHA=`cat .git/refs/heads/master`
-        echo MASTER_SHA=${MASTER_SHA}
+          echo `which clang-format-diff-6.0`
+          export MASTER_SHA=`cat .git/refs/heads/master`
+          echo MASTER_SHA=${MASTER_SHA}
 
-        git diff `cat .git/refs/heads/master` --name-only
-        DIFF=`git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-6.0 -p1`
-        if [ -z "$DIFF" ]; then
-          printf "clang-format-diff reports no problems"
-          exit 0
-        else
-          git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-6.0 -p1 >${{ runner.workspace }}/clang-format.diff
-          exit 1
+          git diff `cat .git/refs/heads/master` --name-only
+          DIFF=`git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-6.0 -p1`
+          if [ -z "$DIFF" ]; then
+            printf "clang-format-diff reports no problems"
+            exit 0
+          else
+            git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-6.0 -p1 >${{ runner.workspace }}/clang-format.diff
+            exit 1
+          fi
         fi
 
     - name: Upload patch


### PR DESCRIPTION
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
