### PR TITLE
Use the data method on std::vector

### DIFF
--- a/avogadro/core/array.h
+++ b/avogadro/core/array.h
@@ -155,12 +155,12 @@ public:
   T* data()
   {
     detachWithCopy();
-    return &d->data[0];
+    return d->data.data();
   }
 
-  const T* data() const { return &d->data[0]; }
+  const T* data() const { return d->data.data(); }
 
-  const T* constData() const { return &d->data[0]; }
+  const T* constData() const { return d->data.data(); }
 
   size_t size() const { return d->data.size(); }
 


### PR DESCRIPTION
We no longer support older compilers that lacked the data method on
std::vector, and so we should move to use this standard method. This was
brought up in issue #478 by John Bollinger.