### PR TITLE
Fixes #483 by forcing a C locale when building the cml file

### DIFF
--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -13,7 +13,6 @@
   limitations under the License.
 
 ******************************************************************************/
-
 #include "cmlformat.h"
 
 #ifdef AVO_USE_HDF5
@@ -32,6 +31,7 @@
 #include <bitset>
 #include <cmath>
 #include <map>
+#include <clocale>
 #include <sstream>
 #include <streambuf>
 
@@ -431,8 +431,9 @@ bool CmlFormat::read(std::istream& file, Core::Molecule& mol)
 
 bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
 {
+  char* old_locale = std::setlocale(LC_NUMERIC, NULL);
+  std::setlocale(LC_NUMERIC, "C");
   xml_document document;
-
   // Add a custom declaration node.
   xml_node declaration = document.prepend_child(pugi::node_declaration);
   declaration.append_attribute("version") = "1.0";
@@ -623,7 +624,7 @@ bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
 #endif
 
   document.save(out, "  ");
-
+  std::setlocale(LC_NUMERIC, old_locale);
   return true;
 }
 


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
