### PR TITLE
Fix a pile of rendering bugs on high-res by saving viewport

### DIFF
--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -239,9 +239,6 @@ void Editor::draw(Rendering::GroupNode& node)
   overlayTProp.setFontFamily(TextProperties::Mono);
   overlayTProp.setColorRgb(64, 255, 220);
   overlayTProp.setAlign(TextProperties::HLeft, TextProperties::VBottom);
-  // adjust font size for pixel scale in 2D
-  // TODO: should use per-window scale
-  overlayTProp.setPixelHeight(overlayTProp.pixelHeight() * qGuiApp->devicePixelRatio());
 
   TextLabel2D* label = new TextLabel2D;
   label->setText(overlayText.toStdString());

--- a/avogadro/qtplugins/measuretool/measuretool.cpp
+++ b/avogadro/qtplugins/measuretool/measuretool.cpp
@@ -239,9 +239,6 @@ void MeasureTool::draw(Rendering::GroupNode& node)
   overlayTProp.setFontFamily(TextProperties::Mono);
   overlayTProp.setColorRgb(64, 255, 220);
   overlayTProp.setAlign(TextProperties::HLeft, TextProperties::VBottom);
-  // adjust font size for pixel scale in 2D
-  // TODO: should use per-window scale
-  overlayTProp.setPixelHeight(overlayTProp.pixelHeight() * qGuiApp->devicePixelRatio());
 
   TextLabel2D* label = new TextLabel2D;
   label->setText(overlayText.toStdString());

--- a/avogadro/qtplugins/overlayaxes/overlayaxes.cpp
+++ b/avogadro/qtplugins/overlayaxes/overlayaxes.cpp
@@ -58,8 +58,13 @@ void CustomMesh::render(const Camera& camera)
   Affine3f mv(camera.modelView());
   mv.matrix().block<3, 1>(0, 3) = Vector3f::Zero();
 
+  // Save the actual viewport - works better on high resolution screens
+  GLint viewport[4];
+  glGetIntegerv(GL_VIEWPORT, viewport);
+
   // The largest window dimension, used to scale the axes
-  const int maxDim = std::max(camera.width(), camera.height());
+  // (again, grab from the actual viewport)
+  const int maxDim = std::max(viewport[2], viewport[3]);
 
   Camera meshCamera(camera);
   meshCamera.setViewport(maxDim / 10, maxDim / 10);
@@ -72,9 +77,7 @@ void CustomMesh::render(const Camera& camera)
 
   MeshGeometry::render(meshCamera);
 
-  glViewport(static_cast<GLint>(0), static_cast<GLsizei>(0),
-             static_cast<GLint>(camera.width()),
-             static_cast<GLsizei>(camera.height()));
+  glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 }
 } // end anon namespace
 

--- a/avogadro/rendering/camera.cpp
+++ b/avogadro/rendering/camera.cpp
@@ -24,7 +24,7 @@ namespace Avogadro {
 namespace Rendering {
 
 Camera::Camera()
-  : m_width(0), m_height(0), m_pixelScale(1.0), m_projectionType(Perspective),
+  : m_width(0), m_height(0), m_projectionType(Perspective),
     m_orthographicScale(1.0), m_data(new EigenData)
 {
   m_data->projection.setIdentity();
@@ -32,7 +32,7 @@ Camera::Camera()
 }
 
 Camera::Camera(const Camera& o)
-  : m_width(o.m_width), m_height(o.m_height), m_pixelScale(o.m_pixelScale),
+  : m_width(o.m_width), m_height(o.m_height),
     m_projectionType(o.m_projectionType),
     m_orthographicScale(o.m_orthographicScale), m_data(new EigenData(*o.m_data))
 {}
@@ -42,7 +42,6 @@ Camera& Camera::operator=(const Camera& o)
   if (this != &o) {
     m_width = o.m_width;
     m_height = o.m_height;
-    m_pixelScale = o.m_pixelScale;
     m_projectionType = o.m_projectionType;
     m_orthographicScale = o.m_orthographicScale;
     m_data = std::move(std::unique_ptr<EigenData>(new EigenData(*o.m_data)));
@@ -127,8 +126,8 @@ Vector3f Camera::unProject(const Vector3f& point) const
   Eigen::Matrix4f mvp =
     m_data->projection.matrix() * m_data->modelView.matrix();
   Vector4f result(
-    2.0f * m_pixelScale * point.x() / static_cast<float>(m_width) - 1.0f,
-    2.0f * (static_cast<float>(m_height) - m_pixelScale * point.y()) /
+    2.0f * point.x() / static_cast<float>(m_width) - 1.0f,
+    2.0f * (static_cast<float>(m_height) - point.y()) /
         static_cast<float>(m_height) -
       1.0f,
     2.0f * point.z() - 1.0f, 1.0f);
@@ -184,11 +183,6 @@ void Camera::setViewport(int w, int h)
 {
   m_width = w;
   m_height = h;
-}
-
-void Camera::setDevicePixelRatio(float scale)
-{
-  m_pixelScale = scale;
 }
 
 void Camera::setProjection(const Eigen::Affine3f& transform)

--- a/avogadro/rendering/camera.h
+++ b/avogadro/rendering/camera.h
@@ -160,16 +160,6 @@ public:
   int height() const { return m_height; }
 
   /**
-   * Set the resolution of the viewport (i.e., from physical to logical pixels)
-   */
-  void setDevicePixelRatio(float scale);
-
-  /**
-   * Get the scale of the viewport pixels.
-   */
-  float devicePixelRatio() const { return m_pixelScale; }
-
-  /**
    * Set the model view matrix to the identity. This resets the model view
    * matrix.
    */
@@ -221,7 +211,6 @@ public:
 private:
   int m_width;
   int m_height;
-  float m_pixelScale;
   Projection m_projectionType;
   float m_orthographicScale;
   std::unique_ptr<EigenData> m_data;


### PR DESCRIPTION
The overlay axes now save the exact viewport via OpenGL
- Fixes #451 - selection draws correctly (viewport reset)
- Fixes #384 - bond-centric draws correctly
- Reverts #548 - font size is now correct
- As a bonus, the overlay axes are now the right size

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
