### PR TITLE
Allow manipulate to rotate selected fragments

### DIFF
--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -72,14 +72,27 @@ private:
   void updatePressedButtons(QMouseEvent*, bool release);
 
   void resetObject() { m_object = Rendering::Identifier(); }
+  void translate(Vector3 delta);
+  void rotate(Vector3 delta, Vector3 centroid);
+  void tilt(Vector3 delta, Vector3 centroid);
 
   QAction* m_activateAction;
   QtGui::RWMolecule* m_molecule;
   Rendering::GLRenderer* m_renderer;
   Rendering::Identifier m_object;
-  Qt::MouseButtons m_pressedButtons;
   QPoint m_lastMousePosition;
   Vector3f m_lastMouse3D;
+  Qt::MouseButtons m_pressedButtons;
+
+  enum ToolAction
+  {
+    Nothing = 0,
+    Rotation,
+    Translation,
+    ZoomTilt,
+    Zoom
+  };
+  ToolAction m_currentAction;
 };
 
 } // namespace QtOpenGL


### PR DESCRIPTION
First step to full operation of the manipulate tool
Adapts code from https://github.com/cryos/avogadro/pull/852
(Thanks to @csantosbh)

Fixes #519

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
