### PR TITLE
Fix symmetry detection with dummy atoms (e.g, ferrocene example)

### DIFF
--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -213,6 +213,8 @@ void Symmetry::detectSymmetry()
   for (Index i = 0; i < length; ++i) {
     Vector3 ipos = m_molecule->atomPositions3d()[i];
     a[i].n = m_molecule->atomicNumbers()[i];
+    if (a[i].n < 1 || a[i].n > 118)
+      a[i].n = 1; // pretend to be an H atom for libmsym
     a[i].v[0] = ipos[0];
     a[i].v[1] = ipos[1];
     a[i].v[2] = ipos[2];

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -55,7 +55,7 @@ msym_thresholds_t medium_thresholds = {
 
 msym_thresholds_t loose_thresholds = {
   /*.zero =*/0.06,
-  /*.geometry =*/0.06,
+  /*.geometry =*/0.1,
   /*.angle =*/0.06,
   /*.equivalence =*/0.025,
   /*.eigfact =*/1.0e-3,
@@ -64,10 +64,10 @@ msym_thresholds_t loose_thresholds = {
 };
 
 msym_thresholds_t sloppy_thresholds = {
-  /*.zero =*/0.08,
+  /*.zero =*/0.1,
   /*.geometry =*/0.1,
   /*.angle =*/0.1,
-  /*.equivalence =*/0.06,
+  /*.equivalence =*/0.075,
   /*.eigfact =*/1.0e-3,
   /*.permutation =*/1.0e-1,
   /*.orthogonalization =*/0.1
@@ -403,6 +403,9 @@ msym_thresholds_t* SymmetryWidget::getThresholds() const
 {
   msym_thresholds_t* thresholds = NULL;
   switch (m_ui->toleranceCombo->currentIndex()) {
+    case 3: // sloppy
+      thresholds = &sloppy_thresholds;
+      break;
     case 2: // loose
       thresholds = &loose_thresholds;
       break;

--- a/avogadro/qtplugins/symmetry/symmetrywidget.ui
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.ui
@@ -218,7 +218,7 @@
      <item>
       <widget class="QComboBox" name="toleranceCombo">
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <item>
         <property name="text">
@@ -233,6 +233,11 @@
        <item>
         <property name="text">
          <string>Loose</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Very Loose</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
Pretends that dummy atoms are hydrogens, but it works
Also add a "very loose" / sloppy threshold class

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
