### PR TITLE
vtk: add support for vtk-9.0

### DIFF
--- a/avogadro/qtplugins/coloropacitymap/qvtkwidget.h
+++ b/avogadro/qtplugins/coloropacitymap/qvtkwidget.h
@@ -4,7 +4,7 @@
 #ifndef AVOGADRO_QTPLUGINS_QVTKGLWidget_H
 #define AVOGADRO_QTPLUGINS_QVTKGLWidget_H
 
-#include <QVTKOpenGLWidget.h>
+#include <qvtkopenglwidget.h>
 
 namespace Avogadro {
 
@@ -17,7 +17,7 @@ public:
                Qt::WindowFlags f = Qt::WindowFlags());
   ~QVTKGLWidget() override;
 
-  void setEnableHiDPI(bool enable) override;
+  void setEnableHiDPI(bool enable) AVOGADRO_SETENABLEHIDPI_OVERRIDE;
 };
 } // namespace Avogadro
 

--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -11,13 +11,21 @@ endif()
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
+find_package(VTK QUIET REQUIRED)
+if(VTK_MAJOR_VERSION GREATER 8)
+  set(VCP "") # shorthand for VTK_COMPONENT_PREFIX
+  set(VMP "VTK::") # shorthand for VTK_MODULE_PREFIX
+else()
+  set(VCP "vtk")
+  set(VMP "vtk")
+  include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
+endif()
+
 find_package(VTK
-  COMPONENTS
-    vtkRenderingOpenGL2 vtkGUISupportQt vtkDomainsChemistry
-    vtkRenderingVolumeOpenGL2 vtkViewsCore vtkRenderingFreeType
-    vtkChartsCore vtkViewsContext2D vtkRenderingContextOpenGL2
-  REQUIRED)
-include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
+  REQUIRED COMPONENTS
+    ${VCP}RenderingOpenGL2 ${VCP}GUISupportQt ${VCP}DomainsChemistry
+    ${VCP}RenderingVolumeOpenGL2 ${VCP}ViewsCore ${VCP}RenderingFreeType
+    ${VCP}ChartsCore ${VCP}ViewsContext2D ${VCP}RenderingContextOpenGL2)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${VTK_DEFINITIONS})
 
 set(HEADERS
@@ -35,6 +43,6 @@ set(SOURCES
 avogadro_add_library(AvogadroVtk ${HEADERS} ${SOURCES})
 set_target_properties(AvogadroVtk PROPERTIES AUTOMOC TRUE)
 target_link_libraries(AvogadroVtk AvogadroRendering AvogadroQtGui
-  vtkRenderingOpenGL2 vtkGUISupportQt vtkRenderingVolumeOpenGL2
-  vtkRenderingFreeType vtkInteractionStyle vtkChartsCore vtkViewsContext2D
-  vtkRenderingContextOpenGL2 vtkDomainsChemistryOpenGL2 Qt5::Widgets)
+  ${VMP}RenderingOpenGL2 ${VMP}GUISupportQt ${VMP}RenderingVolumeOpenGL2
+  ${VMP}RenderingFreeType ${VMP}InteractionStyle ${VMP}ChartsCore ${VMP}ViewsContext2D
+  ${VMP}RenderingContextOpenGL2 ${VMP}DomainsChemistryOpenGL2 Qt5::Widgets)

--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(VTK
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${VTK_DEFINITIONS})
 
 set(HEADERS
+  qvtkopenglwidget.h
   vtkAvogadroActor.h
   vtkglwidget.h
   vtkplot.h
@@ -42,6 +43,7 @@ set(SOURCES
 
 avogadro_add_library(AvogadroVtk ${HEADERS} ${SOURCES})
 set_target_properties(AvogadroVtk PROPERTIES AUTOMOC TRUE)
+target_include_directories(AvogadroVtk PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(AvogadroVtk AvogadroRendering AvogadroQtGui
   ${VMP}RenderingOpenGL2 ${VMP}GUISupportQt ${VMP}RenderingVolumeOpenGL2
   ${VMP}RenderingFreeType ${VMP}InteractionStyle ${VMP}ChartsCore ${VMP}ViewsContext2D

--- a/avogadro/vtk/qvtkopenglwidget.h
+++ b/avogadro/vtk/qvtkopenglwidget.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+
+  This source file is part of the Avogadro project.
+
+  Copyright 2021 Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef AVOGADRO_VTK_QVTKOPENGLWIDGET_H
+#define AVOGADRO_VTK_QVTKOPENGLWIDGET_H
+
+#include <vtkVersionMacros.h>
+
+#if VTK_MAJOR_VERSION >= 9
+#define AVOGADRO_QVTKOPENGLWIDGET QVTKOpenGLStereoWidget
+#define AVOGADRO_SETENABLEHIDPI_OVERRIDE
+#include <QVTKOpenGLStereoWidget.h>
+#else
+#define AVOGADRO_QVTKOPENGLWIDGET QVTKOpenGLWidget
+#define AVOGADRO_SETENABLEHIDPI_OVERRIDE override
+#include <QVTKOpenGLWidget.h>
+#endif
+
+namespace Avogadro {
+using QVTKOpenGLWidget = ::AVOGADRO_QVTKOPENGLWIDGET;
+} // namespace Avogadro
+
+#endif // AVOGADRO_VTK_QVTKOPENGLWIDGET_H

--- a/avogadro/vtk/vtkglwidget.h
+++ b/avogadro/vtk/vtkglwidget.h
@@ -19,7 +19,6 @@
 
 #include "avogadrovtkexport.h"
 
-#include <QVTKOpenGLWidget.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
@@ -27,6 +26,8 @@
 #include <avogadro/rendering/glrenderer.h>
 
 #include <QtCore/QPointer>
+
+#include "qvtkopenglwidget.h"
 
 class vtkActor;
 class vtkColorTransferFunction;

--- a/avogadro/vtk/vtkplot.cpp
+++ b/avogadro/vtk/vtkplot.cpp
@@ -34,7 +34,6 @@
 #include <vtkTextProperty.h>
 
 #include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
 
 #include "vtkplot.h"
 

--- a/avogadro/vtk/vtkplot.h
+++ b/avogadro/vtk/vtkplot.h
@@ -26,7 +26,8 @@
 #include <string>
 #include <vector>
 
-class QVTKOpenGLWidget;
+#include "qvtkopenglwidget.h"
+
 class vtkAxis;
 class vtkChartXY;
 class vtkContextView;


### PR DESCRIPTION
- add support for vtk-9.0 module system
- create `Avogadro::QVTKOpenGLWidget` alias
- provide `AVOGADRO_SETENABLEHIDPI_OVERRIDE` for handling of `setEnableHiDPI` de-virtualization in 9.0

This is more of a _proof of concept_ than a serious pull request, mainly aimed to show that it's actually not as complicated (in my opinion) as #516 makes it out to seem. Avogadro2 builds and runs atop these changes without a problem. The only hick-up I've encountered was that VTK needed either to be built with all modules enabled or had to have [this patch](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7646/diffs?commit_id=11fbec70d2424b2eab64f4b963b5cf3131c0bb4f) applied.

---

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
