### PR TITLE
[i18n] Fix fuzzy entry for Nihonium (not Zirconium!)

### DIFF
--- a/i18n/ar.po
+++ b/i18n/ar.po
@@ -1036,9 +1036,8 @@ msgid "Copernicium"
 msgstr "الكوبرنيسيوم"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "زركونيوم"
+msgstr "نيهونيوم"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1046,7 +1045,7 @@ msgstr "الفليروفيوم"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "موسكوفيوم"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1054,11 +1053,11 @@ msgstr "ليفرموريوم"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "تينيسين"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "أوغانيسون"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/bg.po
+++ b/i18n/bg.po
@@ -1033,32 +1033,31 @@ msgstr "Рентгий"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Коперниций"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Цирконий"
+msgstr "Нихоний"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Флеровий"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Московий"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Ливерморий"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Тенесин"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Оганесон"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/bs.po
+++ b/i18n/bs.po
@@ -1039,32 +1039,31 @@ msgstr "Rentgenijum"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Kopernicij"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Cirkonijum"
+msgstr "Nihonij"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovij"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskovij"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorij"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenesin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganeson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/ca.po
+++ b/i18n/ca.po
@@ -1045,9 +1045,8 @@ msgid "Copernicium"
 msgstr "Copernici"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconi"
+msgstr "Nihoni"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1055,7 +1054,7 @@ msgstr "Flerovi"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovi"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1063,11 +1062,11 @@ msgstr "Livermori"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennes"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganessó"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/ca@valencia.po
+++ b/i18n/ca@valencia.po
@@ -1045,9 +1045,8 @@ msgid "Copernicium"
 msgstr "Copernici"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconi"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/cs.po
+++ b/i18n/cs.po
@@ -1047,9 +1047,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkon"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1057,7 +1056,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1065,11 +1064,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/da.po
+++ b/i18n/da.po
@@ -1039,17 +1039,16 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1057,11 +1056,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennesin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -1044,9 +1044,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1054,7 +1053,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1062,11 +1061,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenness"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/el.po
+++ b/i18n/el.po
@@ -1047,9 +1047,8 @@ msgid "Copernicium"
 msgstr "Κοπερνίκιο"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Ζιρκόνιο"
+msgstr "Νιχόνιο"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1057,7 +1056,7 @@ msgstr "Φλερόβιο"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Μοσκόβιο"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1065,11 +1064,11 @@ msgstr "Λιβερμόριο"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Τενέσιο"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Ογκανέσσιο"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/en_AU.po
+++ b/i18n/en_AU.po
@@ -1039,32 +1039,31 @@ msgstr "Roentgenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessine"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/en_CA.po
+++ b/i18n/en_CA.po
@@ -1039,32 +1039,31 @@ msgstr "Roentgenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessine"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/en_GB.po
+++ b/i18n/en_GB.po
@@ -1046,9 +1046,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1056,7 +1055,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1064,11 +1063,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessine"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1043,9 +1043,8 @@ msgid "Copernicium"
 msgstr "Copernicio"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Circonio"
+msgstr "Nihonio"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1053,7 +1052,7 @@ msgstr "Flerovio"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovio"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1061,11 +1060,11 @@ msgstr "Livermorio"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Teneso"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesón"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/et.po
+++ b/i18n/et.po
@@ -1029,32 +1029,31 @@ msgstr "Röntgeenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Koperniikium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Tsirkoonium"
+msgstr "Nihoonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Fleroovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskoovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermoorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessiin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganessoon"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/eu.po
+++ b/i18n/eu.po
@@ -1045,9 +1045,8 @@ msgid "Copernicium"
 msgstr "Kopernizio"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonio"
+msgstr "Nihonio"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1055,7 +1054,7 @@ msgstr "Flerovio"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskovio"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1063,11 +1062,11 @@ msgstr "Livermorio"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Teneso"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganeson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/fi.po
+++ b/i18n/fi.po
@@ -1039,29 +1039,28 @@ msgid "Copernicium"
 msgstr "Kopernikium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessiini"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1044,9 +1044,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1054,7 +1053,7 @@ msgstr "Flérovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1062,11 +1061,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennesse"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/gl.po
+++ b/i18n/gl.po
@@ -1044,25 +1044,24 @@ msgid "Copernicium"
 msgstr "Copernicio"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Circonio"
+msgstr "Nihonio"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovio"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovio"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorio"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Ténnesso"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"

--- a/i18n/he.po
+++ b/i18n/he.po
@@ -1030,29 +1030,28 @@ msgid "Copernicium"
 msgstr "קופרניקיום"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "זירקוניום"
+msgstr "ניהוניום"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "פלרוביום"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "מוסקוביום"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "ליברמוריום"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "טנסין"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "אוגאנסון"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/hi.po
+++ b/i18n/hi.po
@@ -1030,9 +1030,8 @@ msgid "Copernicium"
 msgstr ""
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "ज़िरकोनियम"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/hu.po
+++ b/i18n/hu.po
@@ -1044,32 +1044,31 @@ msgstr "Röntgenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Kopernícium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Cirkónium"
+msgstr "Nihónium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Fleróvium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moszkóvium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermórium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenesszium"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganeszon"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -1052,9 +1052,8 @@ msgid "Copernicium"
 msgstr "Kopernisium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1062,7 +1061,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1070,11 +1069,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenesin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganeson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -1048,9 +1048,8 @@ msgid "Copernicium"
 msgstr "Copernicio"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconio"
+msgstr "Nihonio"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1058,7 +1057,7 @@ msgstr "Flerovio"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovio"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1066,11 +1065,11 @@ msgstr "Livermorio"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennesso"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/ja.po
+++ b/i18n/ja.po
@@ -1044,9 +1044,8 @@ msgid "Copernicium"
 msgstr "コペルニシウム(Copernicium)"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "ジルコニウム (Zirconium)"
+msgstr "ニホニウム (Zirconium)"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1054,7 +1053,7 @@ msgstr "フレロビウム (Flerovium)"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "モスコビウム (Moscovium)"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1062,11 +1061,11 @@ msgstr "リバモリウム (Livermorium)"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "テネシン (Tennessine)"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "オガネソン (Oganesson)"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/kn.po
+++ b/i18n/kn.po
@@ -1030,9 +1030,8 @@ msgid "Copernicium"
 msgstr ""
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "ಜರ್ಕೋನಿಯಮ್"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/ko.po
+++ b/i18n/ko.po
@@ -1041,29 +1041,28 @@ msgid "Copernicium"
 msgstr "코페르니슘"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "지르코늄"
+msgstr ""니호늄
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "플레로븀"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "모스코븀"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "리버모륨"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "테네신"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "오가네손"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/ms.po
+++ b/i18n/ms.po
@@ -1048,9 +1048,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1058,7 +1057,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1066,11 +1065,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessin"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/nb.po
+++ b/i18n/nb.po
@@ -1041,13 +1041,12 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
@@ -1055,15 +1054,15 @@ msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenness"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/nl.po
+++ b/i18n/nl.po
@@ -1042,9 +1042,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1052,7 +1051,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1060,11 +1059,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tennessine"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/oc.po
+++ b/i18n/oc.po
@@ -1042,9 +1042,8 @@ msgid "Copernicium"
 msgstr ""
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zircòni"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/pl.po
+++ b/i18n/pl.po
@@ -1033,32 +1033,31 @@ msgstr "Roentgen"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Kopernik"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Cyrkon"
+msgstr "Nihon"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Flerow"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskow"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Liwermor"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenes"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganeson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1055,9 +1055,8 @@ msgid "Copernicium"
 msgstr "Copernício"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zircónio"
+msgstr "Nihônio"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1065,7 +1064,7 @@ msgstr "Fleróvio"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moscóvio"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1073,11 +1072,11 @@ msgstr "Livermório"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenesso"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/pt_BR.po
+++ b/i18n/pt_BR.po
@@ -1042,9 +1042,8 @@ msgid "Copernicium"
 msgstr "Copernício"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zircônio"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1049,9 +1049,8 @@ msgid "Copernicium"
 msgstr "Коперниций"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Цирконий"
+msgstr "Нихоний"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1059,7 +1058,7 @@ msgstr "Флеровий"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Московий"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1067,11 +1066,11 @@ msgstr "Ливерморий"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Теннессин"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Оганесон"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/sk.po
+++ b/i18n/sk.po
@@ -1036,32 +1036,31 @@ msgstr "Roentgenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Kopernícium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkón"
+msgstr "Nihónium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Fleróvium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskóvium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermórium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenés"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesón"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/sl.po
+++ b/i18n/sl.po
@@ -1049,9 +1049,8 @@ msgid "Copernicium"
 msgstr "kopernicij"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "cirkonij"
+msgstr "nihonij"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1059,7 +1058,7 @@ msgstr "flerovij"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "moskovij"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1067,11 +1066,11 @@ msgstr "Livermorij"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "tenes"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "oganeson"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/sq.po
+++ b/i18n/sq.po
@@ -1027,32 +1027,31 @@ msgstr "Rontgenium"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr ""
+msgstr "Coperniciumi"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihoniumi"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
-msgstr ""
+msgstr "Fleroviumi"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskoviumi"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
-msgstr ""
+msgstr "Livermoriumi"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenesini"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesoni"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/sr.po
+++ b/i18n/sr.po
@@ -1046,9 +1046,8 @@ msgid "Copernicium"
 msgstr "Коперницијум"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Цирконијум"
+msgstr "Нихонијум"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1056,7 +1055,7 @@ msgstr "Флеровијум"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Московијум"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1064,11 +1063,11 @@ msgstr "Ливерморијум"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Тенесин"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Оганесон"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/sv.po
+++ b/i18n/sv.po
@@ -1031,9 +1031,8 @@ msgid "Copernicium"
 msgstr "Copernicium"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonium"
+msgstr "Nihonium"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1041,7 +1040,7 @@ msgstr "Flerovium"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Moskovium"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1049,11 +1048,11 @@ msgstr "Livermorium"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Tenness"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Oganesson"
 
 #: qtgui/filebrowsewidget.cpp:39
 msgid "Browse"

--- a/i18n/tr.po
+++ b/i18n/tr.po
@@ -1092,9 +1092,8 @@ msgid "Copernicium"
 msgstr "Kopernikyum"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirkonyum"
+msgstr "Nihoniyum"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/uk.po
+++ b/i18n/uk.po
@@ -1050,9 +1050,8 @@ msgid "Copernicium"
 msgstr "Коперніцій"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Цирконій"
+msgstr "Ніхоній"
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"
@@ -1060,7 +1059,7 @@ msgstr "Флеровій"
 
 #: qtgui/elementtranslator.cpp:374
 msgid "Moscovium"
-msgstr ""
+msgstr "Московій"
 
 #: qtgui/elementtranslator.cpp:377
 msgid "Livermorium"
@@ -1068,11 +1067,11 @@ msgstr "Ліверморій"
 
 #: qtgui/elementtranslator.cpp:380
 msgid "Tennessine"
-msgstr ""
+msgstr "Теннессин"
 
 #: qtgui/elementtranslator.cpp:383
 msgid "Oganesson"
-msgstr ""
+msgstr "Оганесон"
 
 #: qtgui/filebrowsewidget.cpp:39
 #, fuzzy

--- a/i18n/vi.po
+++ b/i18n/vi.po
@@ -1042,9 +1042,8 @@ msgid "Copernicium"
 msgstr "Cô-péc-ni-xi"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zi-cô-ni"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/zh_CN.po
+++ b/i18n/zh_CN.po
@@ -1075,9 +1075,8 @@ msgid "Copernicium"
 msgstr "鎶"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "锆"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -1042,12 +1042,11 @@ msgstr "Roentgenium (錀)"
 
 #: qtgui/elementtranslator.cpp:365
 msgid "Copernicium"
-msgstr "Copernicium 鎶"
+msgstr "Copernicium (鎶)"
 
 #: qtgui/elementtranslator.cpp:368
-#, fuzzy
 msgid "Nihonium"
-msgstr "Zirconium (鋯)"
+msgstr ""
 
 #: qtgui/elementtranslator.cpp:371
 msgid "Flerovium"


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
