### PR TITLE
Improve residue code

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2011-2014 Kitware, Inc. and Geoffrey Hutchison
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "molecule.h"

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -908,7 +908,7 @@ void Molecule::addResidue(Residue& residue)
   m_residues.push_back(residue);
 }
 
-Residue& Molecule::residue(int index)
+Residue& Molecule::residue(Index index)
 {
   return m_residues[index];
 }

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2011-2012 Kitware, Inc. and Geoffrey Hutchison
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_CORE_MOLECULE_H

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -619,7 +619,7 @@ public:
   bool setTimeStep(double timestep, int index);
   double timeStep(int index, bool& status);
 
-  /** Returns a vector of forces for the atoms in the molecule. */
+  /** @return a vector of forces for the atoms in the molecule. */
   const Array<Vector3>& forceVectors() const;
 
   /** \overload */
@@ -650,7 +650,9 @@ public:
 
   Residue& addResidue(std::string& name, Index& number, char& id);
   void addResidue(Residue& residue);
-  Residue& residue(int index);
+  Residue& residue(Index index);
+
+  Array<Residue>& residues() { return m_residues;}
 
 protected:
   mutable Graph m_graph;     // A transformation of the molecule to a graph.

--- a/avogadro/core/residue.cpp
+++ b/avogadro/core/residue.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2018 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "residue.h"

--- a/avogadro/core/residue.cpp
+++ b/avogadro/core/residue.cpp
@@ -23,19 +23,19 @@ namespace Core {
 
 Residue::Residue() {}
 
-Residue::Residue(std::string& name) : m_residueName(name) {}
+Residue::Residue(std::string& name) : m_residueName(name), m_heterogen(false) {}
 
 Residue::Residue(std::string& name, Index& number)
-  : m_residueName(name), m_residueId(number)
+  : m_residueName(name), m_residueId(number), m_heterogen(false)
 {}
 
 Residue::Residue(std::string& name, Index& number, char& id)
-  : m_residueName(name), m_residueId(number), m_chainId(id)
+  : m_residueName(name), m_residueId(number), m_chainId(id), m_heterogen(false)
 {}
 
 Residue::Residue(const Residue& other)
   : m_residueName(other.m_residueName), m_residueId(other.m_residueId),
-    m_atomNameMap(other.m_atomNameMap)
+    m_atomNameMap(other.m_atomNameMap), m_heterogen(other.m_heterogen)
 {}
 
 Residue& Residue::operator=(Residue other)
@@ -43,6 +43,7 @@ Residue& Residue::operator=(Residue other)
   m_residueName = other.m_residueName;
   m_residueId = other.m_residueId;
   m_atomNameMap = other.m_atomNameMap;
+  m_heterogen = other.m_heterogen;
   return *this;
 }
 
@@ -61,6 +62,17 @@ std::vector<Atom> Residue::residueAtoms()
     res.push_back(it->second);
   }
   return res;
+}
+
+Atom Residue::getAtomByName(std::string name)
+{
+  Atom empty;
+  auto search = m_atomNameMap.find(name);
+  if (search != m_atomNameMap.end()) {
+    return search->second;
+  }
+
+  return empty;
 }
 
 void Residue::resolveResidueBonds(Molecule& mol)
@@ -89,11 +101,9 @@ void Residue::resolveResidueBonds(Molecule& mol)
 
 int Residue::getAtomicNumber(std::string name)
 {
-  std::map<std::string, int> resAtoms;
-  if (residueDict.find(m_residueName) != residueDict.end()) {
-    resAtoms = residueDict[m_residueName].residueAtoms();
-    if (resAtoms.find(name) != resAtoms.end())
-      return resAtoms[name];
+  auto search = m_atomNameMap.find(name);
+  if (search != m_atomNameMap.end()) {
+    return search->second.atomicNumber();
   }
 
   return 0;

--- a/avogadro/core/residue.h
+++ b/avogadro/core/residue.h
@@ -70,20 +70,29 @@ public:
   /** Adds an atom to the residue class */
   void addResidueAtom(std::string& name, Atom& atom);
 
-  /** Returns a vector containing the atoms added to the residue */
+  /** \return a vector containing the atoms added to the residue */
   std::vector<Atom> residueAtoms();
 
   /** Sets bonds to atoms in the residue based on data from residuedata header
    */
   void resolveResidueBonds(Molecule& mol);
 
+  Atom getAtomByName(std::string name);
+
   int getAtomicNumber(std::string name);
+
+  void setHeterogen(bool heterogen) { m_heterogen = heterogen;}
+
+  /** \return is this residue a heterogen (HET / HETATM)
+   */
+  bool isHeterogen() { return m_heterogen; }
 
 protected:
   std::string m_residueName;
   Index m_residueId;
   char m_chainId;
   AtomNameMap m_atomNameMap;
+  bool m_heterogen;
 };
 
 } // namespace Core

--- a/avogadro/core/residue.h
+++ b/avogadro/core/residue.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2018 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_CORE_RESIDUE_H

--- a/avogadro/io/mmtfformat.cpp
+++ b/avogadro/io/mmtfformat.cpp
@@ -122,8 +122,9 @@ bool MMTFFormat::read(std::istream& file, Molecule& molecule)
                   static_cast<Real>(structure.yCoordList[atomIndex]),
                   static_cast<Real>(structure.zCoordList[atomIndex])));
 
-        // Stores if the compounds is a heteroatom
-        // mmtf::is_hetatm(group.chemCompType.c_str());
+        // Stores if the group / residue is a heteroatom
+        if (mmtf::is_hetatm(group.chemCompType.c_str()))
+          residue.setHeterogen(true);
         std::string atomName = group.atomNameList[l];
         residue.addResidueAtom(atomName, atom);
         atomIndex++;

--- a/avogadro/io/mmtfformat.cpp
+++ b/avogadro/io/mmtfformat.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "mmtfformat.h"

--- a/avogadro/io/mmtfformat.h
+++ b/avogadro/io/mmtfformat.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_IO_MMTFFORMAT_H

--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -1,3 +1,8 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
 #include "pdbformat.h"
 
 #include <avogadro/core/elements.h>

--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -79,6 +79,8 @@ bool PdbFormat::read(std::istream& in, Core::Molecule& mol)
         }
 
         r = &mol.addResidue(residueName, currentResidueId, chainId);
+        if (startsWith(buffer, "HETATM"))
+          r->setHeterogen(true);
       }
 
       string atomName = lexicalCast<string>(buffer.substr(12, 4), ok);

--- a/avogadro/io/pdbformat.h
+++ b/avogadro/io/pdbformat.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_IO_PDBFORMAT_H


### PR DESCRIPTION
- Allow retrieving all residues (for iterating)
- Mark residues as heterogen (HET / HETATOM)
- Allow retrieving atoms by name (e.g. get the c-alpha)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
