### PR TITLE
Replace obsolescent `LINK_(PRIVATE|PUBLIC)` with `(PRIVATE|PUBLIC)`

### DIFF
--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -95,4 +95,4 @@ endif()
 
 avogadro_add_library(AvogadroCore ${HEADERS} ${SOURCES})
 target_link_libraries(AvogadroCore
-  LINK_PRIVATE ${SPGLIB_LIBRARY} ${EXTRA_LINK_LIB})
+  PRIVATE ${SPGLIB_LIBRARY} ${EXTRA_LINK_LIB})

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -72,11 +72,11 @@ endif()
 avogadro_add_library(AvogadroIO ${HEADERS} ${SOURCES})
 
 target_link_libraries(AvogadroIO
-  LINK_PUBLIC AvogadroCore
-  LINK_PRIVATE struct)
+  PUBLIC AvogadroCore
+  PRIVATE struct)
 if(USE_HDF5)
-  target_link_libraries(AvogadroIO LINK_PRIVATE ${HDF5_LIBRARIES})
+  target_link_libraries(AvogadroIO PRIVATE ${HDF5_LIBRARIES})
 endif()
 if(WIN32)
-  target_link_libraries(AvogadroIO LINK_PRIVATE ws2_32)
+  target_link_libraries(AvogadroIO PRIVATE ws2_32)
 endif()

--- a/avogadro/qtplugins/CMakeLists.txt
+++ b/avogadro/qtplugins/CMakeLists.txt
@@ -72,7 +72,7 @@ function(avogadro_plugin name description type header pluginClass sources)
     ${rc_srcs}
     ${name}Plugin.cpp
   )
-  target_link_libraries(${name} LINK_PRIVATE AvogadroCore AvogadroQtGui)
+  target_link_libraries(${name} PRIVATE AvogadroCore AvogadroQtGui)
 
   if("${_plugin_object}" STREQUAL "STATIC")
     set_target_properties(${name} PROPERTIES COMPILE_DEFINITIONS
@@ -219,5 +219,5 @@ set(SOURCES
 )
 
 avogadro_add_library(AvogadroQtPlugins ${HEADERS} ${SOURCES})
-target_link_libraries(AvogadroQtPlugins LINK_PUBLIC ${Qt5Core_LIBRARIES}
-  LINK_PRIVATE ${AvogadroLibs_STATIC_PLUGINS} AvogadroQtGui)
+target_link_libraries(AvogadroQtPlugins PUBLIC ${Qt5Core_LIBRARIES}
+  PRIVATE ${AvogadroLibs_STATIC_PLUGINS} AvogadroQtGui)

--- a/avogadro/qtplugins/apbs/CMakeLists.txt
+++ b/avogadro/qtplugins/apbs/CMakeLists.txt
@@ -20,4 +20,4 @@ avogadro_plugin(apbs
 )
 
 target_link_libraries(apbs
-  LINK_PRIVATE AvogadroIO AvogadroMoleQueue)
+  PRIVATE AvogadroIO AvogadroMoleQueue)

--- a/avogadro/qtplugins/ballandstick/CMakeLists.txt
+++ b/avogadro/qtplugins/ballandstick/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(BallStick
   ballandstick.cpp
   "")
 
-target_link_libraries(BallStick LINK_PRIVATE AvogadroRendering)
+target_link_libraries(BallStick PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/bondcentrictool/CMakeLists.txt
+++ b/avogadro/qtplugins/bondcentrictool/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(BondCentric
   "${bondcentrictool_rcs}"
 )
 
-target_link_libraries(BondCentric LINK_PRIVATE AvogadroQtOpenGL)
+target_link_libraries(BondCentric PRIVATE AvogadroQtOpenGL)

--- a/avogadro/qtplugins/clientserver/CMakeLists.txt
+++ b/avogadro/qtplugins/clientserver/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(avogadroserver
   )
 
 target_link_libraries(avogadroserver
-  LINK_PRIVATE vtkParallelCore AvogadroProtoCall)
+  PRIVATE vtkParallelCore AvogadroProtoCall)
 
 install(TARGETS avogadroserver
   RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR}
@@ -72,4 +72,4 @@ avogadro_plugin(ClientServer
   )
 
 target_link_libraries(ClientServer
-  LINK_PRIVATE AvogadroIO vtkParallelCore AvogadroProtoCall)
+  PRIVATE AvogadroIO vtkParallelCore AvogadroProtoCall)

--- a/avogadro/qtplugins/coloropacitymap/CMakeLists.txt
+++ b/avogadro/qtplugins/coloropacitymap/CMakeLists.txt
@@ -24,6 +24,6 @@ avogadro_plugin(ColorOpacityMap
 )
 
 target_link_libraries(ColorOpacityMap
-  LINK_PRIVATE
+  PRIVATE
     AvogadroQtOpenGL
     AvogadroVtk)

--- a/avogadro/qtplugins/commandscripts/CMakeLists.txt
+++ b/avogadro/qtplugins/commandscripts/CMakeLists.txt
@@ -14,7 +14,7 @@ avogadro_plugin(commands
   "${command_srcs}"
 )
 
-target_link_libraries(commands LINK_PRIVATE AvogadroIO)
+target_link_libraries(commands PRIVATE AvogadroIO)
 
 # Bundled command scripts
 set(commands

--- a/avogadro/qtplugins/copypaste/CMakeLists.txt
+++ b/avogadro/qtplugins/copypaste/CMakeLists.txt
@@ -9,4 +9,4 @@ avogadro_plugin(CopyPaste
   ""
 )
 
-target_link_libraries(CopyPaste LINK_PRIVATE AvogadroIO)
+target_link_libraries(CopyPaste PRIVATE AvogadroIO)

--- a/avogadro/qtplugins/cp2kinput/CMakeLists.txt
+++ b/avogadro/qtplugins/cp2kinput/CMakeLists.txt
@@ -13,4 +13,4 @@ avogadro_plugin(Cp2kInput
   cp2kinputdialog.ui
 )
 
-target_link_libraries(Cp2kInput LINK_PRIVATE AvogadroMoleQueue)
+target_link_libraries(Cp2kInput PRIVATE AvogadroMoleQueue)

--- a/avogadro/qtplugins/crystal/CMakeLists.txt
+++ b/avogadro/qtplugins/crystal/CMakeLists.txt
@@ -29,4 +29,4 @@ avogadro_plugin(CrystalScene
   CrystalScene
   crystalscene.cpp)
 
-target_link_libraries(CrystalScene LINK_PRIVATE AvogadroRendering)
+target_link_libraries(CrystalScene PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/editor/CMakeLists.txt
+++ b/avogadro/qtplugins/editor/CMakeLists.txt
@@ -21,4 +21,4 @@ avogadro_plugin(Editor
   "${editor_rcs}"
 )
 
-target_link_libraries(Editor LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Editor PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/fetchpdb/CMakeLists.txt
+++ b/avogadro/qtplugins/fetchpdb/CMakeLists.txt
@@ -12,4 +12,4 @@ avogadro_plugin(FetchPDB
 )
 
 target_link_libraries(FetchPDB
-  LINK_PRIVATE AvogadroIO ${Qt5Network_LIBRARIES})
+  PRIVATE AvogadroIO ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/force/CMakeLists.txt
+++ b/avogadro/qtplugins/force/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(Force
   force.cpp
   "")
 
-target_link_libraries(Force LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Force PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/gamessinput/CMakeLists.txt
+++ b/avogadro/qtplugins/gamessinput/CMakeLists.txt
@@ -14,4 +14,4 @@ avogadro_plugin(GamessInput
   gamessinputdialog.ui
 )
 
-target_link_libraries(GamessInput LINK_PRIVATE AvogadroMoleQueue)
+target_link_libraries(GamessInput PRIVATE AvogadroMoleQueue)

--- a/avogadro/qtplugins/importpqr/CMakeLists.txt
+++ b/avogadro/qtplugins/importpqr/CMakeLists.txt
@@ -17,4 +17,4 @@ avogadro_plugin(ImportPQR
   ""
 )
 
-target_link_libraries(ImportPQR LINK_PRIVATE ${Qt5Network_LIBRARIES})
+target_link_libraries(ImportPQR PRIVATE ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/licorice/CMakeLists.txt
+++ b/avogadro/qtplugins/licorice/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(Licorice
   licorice.cpp
   "")
 
-target_link_libraries(Licorice LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Licorice PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/manipulator/CMakeLists.txt
+++ b/avogadro/qtplugins/manipulator/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(Manipulator
   "${manipulator_rcs}"
 )
 
-target_link_libraries(Manipulator LINK_PRIVATE AvogadroQtOpenGL)
+target_link_libraries(Manipulator PRIVATE AvogadroQtOpenGL)

--- a/avogadro/qtplugins/measuretool/CMakeLists.txt
+++ b/avogadro/qtplugins/measuretool/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(MeasureTool
   "${measuretool_rcs}"
 )
 
-target_link_libraries(MeasureTool LINK_PRIVATE AvogadroQtOpenGL)
+target_link_libraries(MeasureTool PRIVATE AvogadroQtOpenGL)

--- a/avogadro/qtplugins/meshes/CMakeLists.txt
+++ b/avogadro/qtplugins/meshes/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(Meshes
   meshes.cpp
   "")
 
-target_link_libraries(Meshes LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Meshes PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/mongochem/CMakeLists.txt
+++ b/avogadro/qtplugins/mongochem/CMakeLists.txt
@@ -27,4 +27,4 @@ avogadro_plugin(MongoChem
   "${uis}"
 )
 
-target_link_libraries(MongoChem LINK_PRIVATE ${Qt5Network_LIBRARIES})
+target_link_libraries(MongoChem PRIVATE ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/navigator/CMakeLists.txt
+++ b/avogadro/qtplugins/navigator/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(Navigator
   "${navigator_rcs}"
 )
 
-target_link_libraries(Navigator LINK_PRIVATE AvogadroQtOpenGL)
+target_link_libraries(Navigator PRIVATE AvogadroQtOpenGL)

--- a/avogadro/qtplugins/networkdatabases/CMakeLists.txt
+++ b/avogadro/qtplugins/networkdatabases/CMakeLists.txt
@@ -12,4 +12,4 @@ avogadro_plugin(NetworkDatabases
 )
 
 target_link_libraries(NetworkDatabases
-  LINK_PRIVATE AvogadroIO ${Qt5Network_LIBRARIES})
+  PRIVATE AvogadroIO ${Qt5Network_LIBRARIES})

--- a/avogadro/qtplugins/openbabel/CMakeLists.txt
+++ b/avogadro/qtplugins/openbabel/CMakeLists.txt
@@ -20,4 +20,4 @@ avogadro_plugin(OpenBabel
   "${openbabel_uis}"
 )
 
-target_link_libraries(OpenBabel LINK_PRIVATE AvogadroIO)
+target_link_libraries(OpenBabel PRIVATE AvogadroIO)

--- a/avogadro/qtplugins/overlayaxes/CMakeLists.txt
+++ b/avogadro/qtplugins/overlayaxes/CMakeLists.txt
@@ -15,4 +15,4 @@ avogadro_plugin(OverlayAxes
   overlayaxes.cpp
   "")
 
-target_link_libraries(OverlayAxes LINK_PRIVATE AvogadroRendering)
+target_link_libraries(OverlayAxes PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/playertool/CMakeLists.txt
+++ b/avogadro/qtplugins/playertool/CMakeLists.txt
@@ -11,4 +11,4 @@ avogadro_plugin(PlayerTool
   playertool.qrc
 )
 
-target_link_libraries(PlayerTool LINK_PRIVATE gwavi)
+target_link_libraries(PlayerTool PRIVATE gwavi)

--- a/avogadro/qtplugins/plotpdf/CMakeLists.txt
+++ b/avogadro/qtplugins/plotpdf/CMakeLists.txt
@@ -16,4 +16,4 @@ avogadro_plugin(PlotPdf
   "${plotpdf_uis}"
 )
 
-target_link_libraries(PlotPdf LINK_PRIVATE AvogadroVtk)
+target_link_libraries(PlotPdf PRIVATE AvogadroVtk)

--- a/avogadro/qtplugins/plotrmsd/CMakeLists.txt
+++ b/avogadro/qtplugins/plotrmsd/CMakeLists.txt
@@ -11,4 +11,4 @@ avogadro_plugin(PlotRmsd
   ""
 )
 
-target_link_libraries(PlotRmsd LINK_PRIVATE AvogadroVtk)
+target_link_libraries(PlotRmsd PRIVATE AvogadroVtk)

--- a/avogadro/qtplugins/plotxrd/CMakeLists.txt
+++ b/avogadro/qtplugins/plotxrd/CMakeLists.txt
@@ -22,4 +22,4 @@ avogadro_plugin(PlotXrd
   "${plotxrd_uis}"
 )
 
-target_link_libraries(PlotXrd LINK_PRIVATE AvogadroVtk)
+target_link_libraries(PlotXrd PRIVATE AvogadroVtk)

--- a/avogadro/qtplugins/plugindownloader/CMakeLists.txt
+++ b/avogadro/qtplugins/plugindownloader/CMakeLists.txt
@@ -19,5 +19,5 @@ avogadro_plugin(PluginDownloader
   ""
 )
 
-target_link_libraries(PluginDownloader LINK_PRIVATE ${Qt5Network_LIBRARIES}
+target_link_libraries(PluginDownloader PRIVATE ${Qt5Network_LIBRARIES}
   ${LIBARCHIVE_LIBRARIES})

--- a/avogadro/qtplugins/povray/CMakeLists.txt
+++ b/avogadro/qtplugins/povray/CMakeLists.txt
@@ -9,4 +9,4 @@ avogadro_plugin(POVRay
   ""
 )
 
-target_link_libraries(POVRay LINK_PRIVATE AvogadroRendering)
+target_link_libraries(POVRay PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/qtaim/CMakeLists.txt
+++ b/avogadro/qtplugins/qtaim/CMakeLists.txt
@@ -19,7 +19,7 @@ avogadro_plugin(QTAIMExtension
 )
 
 target_link_libraries(QTAIMExtension
-  LINK_PRIVATE
+  PRIVATE
     Qt5::Concurrent)
 
 # The settings widget is not built -- its settings weren't actually used by the
@@ -33,5 +33,5 @@ avogadro_plugin(QTAIMScenePlugin
 )
 
 target_link_libraries(QTAIMScenePlugin
-  LINK_PRIVATE
+  PRIVATE
     AvogadroRendering)

--- a/avogadro/qtplugins/quantuminput/CMakeLists.txt
+++ b/avogadro/qtplugins/quantuminput/CMakeLists.txt
@@ -14,7 +14,7 @@ avogadro_plugin(QuantumInput
   "${quantuminput_srcs}"
 )
 
-target_link_libraries(QuantumInput LINK_PRIVATE AvogadroIO AvogadroMoleQueue)
+target_link_libraries(QuantumInput PRIVATE AvogadroIO AvogadroMoleQueue)
 
 set(_prefix "${AvogadroLibs_SOURCE_DIR}/../avogadrogenerators")
 # Look in parallel directory for the avogadrogenerators repository.

--- a/avogadro/qtplugins/resetview/CMakeLists.txt
+++ b/avogadro/qtplugins/resetview/CMakeLists.txt
@@ -9,4 +9,4 @@ avogadro_plugin(ResetView
   ""
 )
 
-target_link_libraries(ResetView LINK_PRIVATE AvogadroRendering)
+target_link_libraries(ResetView PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
+++ b/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
@@ -12,7 +12,7 @@ avogadro_plugin(ScriptFileFormats
   ""
 )
 
-target_link_libraries(ScriptFileFormats LINK_PRIVATE AvogadroQuantumIO)
+target_link_libraries(ScriptFileFormats PRIVATE AvogadroQuantumIO)
 
 # Bundled format scripts:
 set(format_scripts

--- a/avogadro/qtplugins/selectiontool/CMakeLists.txt
+++ b/avogadro/qtplugins/selectiontool/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(Selection
   "${tool_rcs}"
 )
 
-target_link_libraries(Selection LINK_PRIVATE AvogadroQtOpenGL)
+target_link_libraries(Selection PRIVATE AvogadroQtOpenGL)

--- a/avogadro/qtplugins/surfaces/CMakeLists.txt
+++ b/avogadro/qtplugins/surfaces/CMakeLists.txt
@@ -18,7 +18,7 @@ avogadro_plugin(Surfaces
 )
 
 target_link_libraries(Surfaces
-  LINK_PRIVATE
+  PRIVATE
     AvogadroQuantumIO
     AvogadroQtOpenGL
     Qt5::Concurrent

--- a/avogadro/qtplugins/svg/CMakeLists.txt
+++ b/avogadro/qtplugins/svg/CMakeLists.txt
@@ -11,4 +11,4 @@ avogadro_plugin(SVG
   ""
 )
 
-target_link_libraries(SVG LINK_PRIVATE AvogadroRendering Qt5::Svg)
+target_link_libraries(SVG PRIVATE AvogadroRendering Qt5::Svg)

--- a/avogadro/qtplugins/symmetry/CMakeLists.txt
+++ b/avogadro/qtplugins/symmetry/CMakeLists.txt
@@ -35,6 +35,6 @@ avogadro_plugin(SymmetryScene
   SymmetryScene
   symmetryscene.cpp)
 
-target_link_libraries(Symmetry LINK_PRIVATE ${LIBMSYM_LIBRARIES})
-target_link_libraries(SymmetryScene LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Symmetry PRIVATE ${LIBMSYM_LIBRARIES})
+target_link_libraries(SymmetryScene PRIVATE AvogadroRendering)
 

--- a/avogadro/qtplugins/vanderwaals/CMakeLists.txt
+++ b/avogadro/qtplugins/vanderwaals/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(VanDerWaals
   vanderwaals.cpp
   "")
 
-target_link_libraries(VanDerWaals LINK_PRIVATE AvogadroRendering)
+target_link_libraries(VanDerWaals PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/vanderwaalsao/CMakeLists.txt
+++ b/avogadro/qtplugins/vanderwaalsao/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(VanDerWaalsAO
   vanderwaalsao.cpp
   "")
 
-target_link_libraries(VanDerWaalsAO LINK_PRIVATE AvogadroRendering)
+target_link_libraries(VanDerWaalsAO PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/vrml/CMakeLists.txt
+++ b/avogadro/qtplugins/vrml/CMakeLists.txt
@@ -9,4 +9,4 @@ avogadro_plugin(VRML
   ""
 )
 
-target_link_libraries(VRML LINK_PRIVATE AvogadroRendering)
+target_link_libraries(VRML PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/wireframe/CMakeLists.txt
+++ b/avogadro/qtplugins/wireframe/CMakeLists.txt
@@ -6,4 +6,4 @@ avogadro_plugin(Wireframe
   wireframe.cpp
   "")
 
-target_link_libraries(Wireframe LINK_PRIVATE AvogadroRendering)
+target_link_libraries(Wireframe PRIVATE AvogadroRendering)

--- a/avogadro/qtplugins/yaehmop/CMakeLists.txt
+++ b/avogadro/qtplugins/yaehmop/CMakeLists.txt
@@ -19,4 +19,4 @@ avogadro_plugin(Yaehmop
   "${yaehmop_uis}"
 )
 
-target_link_libraries(Yaehmop LINK_PRIVATE AvogadroVtk)
+target_link_libraries(Yaehmop PRIVATE AvogadroVtk)

--- a/avogadro/quantumio/CMakeLists.txt
+++ b/avogadro/quantumio/CMakeLists.txt
@@ -30,4 +30,4 @@ set(SOURCES
 )
 
 avogadro_add_library(AvogadroQuantumIO ${HEADERS} ${SOURCES})
-target_link_libraries(AvogadroQuantumIO LINK_PUBLIC AvogadroIO)
+target_link_libraries(AvogadroQuantumIO PUBLIC AvogadroIO)


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.3/command/target_link_libraries.html#libraries-for-a-target-and-or-its-dependents-legacy

Signed-off-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
