### PR TITLE
Fix #602 - use Molden order for f-orbitals

### DIFF
--- a/avogadro/core/gaussiansettools.cpp
+++ b/avogadro/core/gaussiansettools.cpp
@@ -337,17 +337,31 @@ inline void GaussianSetTools::pointF(unsigned int moIndex, const Vector3& delta,
     for (int j = 0; j < 10; ++j)
       components[j] += gtoCN[cIndex++] * tmpGTO;
   }
+
+  double xxx = delta.x() * delta.x() * delta.x(); // xxx
+  double xxy = delta.x() * delta.x() * delta.y(); // xxy
+  double xxz = delta.x() * delta.x() * delta.z(); // xxz
+  double xyy = delta.x() * delta.y() * delta.y(); // xyy
+  double xyz = delta.x() * delta.y() * delta.z(); // xyz
+  double xzz = delta.x() * delta.z() * delta.z(); // xzz
+  double yyy = delta.y() * delta.y() * delta.y(); // yyy
+  double yyz = delta.y() * delta.y() * delta.z(); // yyz
+  double yzz = delta.y() * delta.z() * delta.z(); // yzz
+  double zzz = delta.z() * delta.z() * delta.z(); // zzz
+
   double componentsF[10] = {
-    delta.x() * delta.x() * delta.x(), // xxx
-    delta.x() * delta.x() * delta.y(), // xxy
-    delta.x() * delta.x() * delta.z(), // xxz
-    delta.x() * delta.y() * delta.y(), // xyy
-    delta.x() * delta.y() * delta.z(), // xyz
-    delta.x() * delta.z() * delta.z(), // xzz
-    delta.y() * delta.y() * delta.y(), // yyy
-    delta.y() * delta.y() * delta.z(), // yyz
-    delta.y() * delta.z() * delta.z(), // yzz
-    delta.z() * delta.z() * delta.z()  // zzz
+    // molden order
+    // e.g https://gau2grid.readthedocs.io/en/latest/order.html
+    xxx,
+    yyy,
+    zzz,
+    xyy,
+    xxy,
+    xxz,
+    xzz,
+    yzz,
+    yyz,
+    xyz
   };
 
   for (int i = 0; i < 10; ++i)


### PR DESCRIPTION
Needs some code for re-ordering CCA-based input & g, h orbitals

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
