### PR TITLE
Fix #650 - deleting selected atoms

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -346,6 +346,9 @@ bool Molecule::removeAtom(Index index)
   if (m_colors.size() == atomCount())
     m_colors.swapAndPop(index);
 
+  if (m_selectedAtoms.size() == atomCount())
+    m_selectedAtoms.erase(m_selectedAtoms.begin() + index);
+
   Index affectedIndex = static_cast<Index>(m_atomicNumbers.size() - 1);
   m_atomicNumbers.swapAndPop(index);
   removeBonds(index);

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "copypaste.h"
@@ -156,7 +145,9 @@ void CopyPaste::cut()
   if (m_molecule->isSelectionEmpty())
     m_molecule->undoMolecule()->clearAtoms();
   else {
-    for (Index i = 0; i < m_molecule->atomCount(); ++i)
+    // Remove atoms from the largest to the smallest index
+    // (that way, the index doesn't change)
+    for (Index i = m_molecule->atomCount(); i > 0; --i)
       if (m_molecule->atomSelected(i))
         m_molecule->undoMolecule()->removeAtom(i);
   }
@@ -170,7 +161,9 @@ void CopyPaste::clear()
   if (m_molecule->isSelectionEmpty())
     m_molecule->undoMolecule()->clearAtoms();
   else {
-    for (Index i = 0; i < m_molecule->atomCount(); ++i)
+    // Remove atoms from the largest to the smallest index
+    // (that way, the index doesn't change)
+    for (Index i = m_molecule->atomCount(); i > 0; --i)
       if (m_molecule->atomSelected(i))
         m_molecule->undoMolecule()->removeAtom(i);
   }

--- a/avogadro/qtplugins/copypaste/copypaste.h
+++ b/avogadro/qtplugins/copypaste/copypaste.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_COPYPASTE_H


### PR DESCRIPTION
Two bugs in one - selected items weren't updated by Molecule class
and atoms were removed in a bad order. (Remove in reverse to keep
Index correct)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
