### PR TITLE
Reverse direction of zoom with scrolling

### DIFF
--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -139,8 +139,18 @@ QUndoCommand* Navigator::mouseDoubleClickEvent(QMouseEvent* e)
 QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
 {
   /// @todo Use scale for orthographic projections
-  // Zoom
-  zoom(m_renderer->scene().center(), -e->angleDelta() * 0.125);
+  // Amount to zoom
+  float d = 0.0f;
+
+  QPoint numPixels = e->pixelDelta();
+  QPoint numDegrees = e->angleDelta() * 0.125;
+
+  if (!numPixels.isNull())
+    d = numPixels.y();
+  else if (!numDegrees.isNull())
+    d = numDegrees.y();
+
+  zoom(m_renderer->scene().center(), -d);
 
   e->accept();
   emit updateRequested();

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -140,7 +140,7 @@ QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
 {
   /// @todo Use scale for orthographic projections
   // Zoom
-  zoom(m_renderer->scene().center(), e->delta() * 0.1);
+  zoom(m_renderer->scene().center(), -e->angleDelta() * 0.125);
 
   e->accept();
   emit updateRequested();


### PR DESCRIPTION
This affects both mouse and touchpad. It also replaces the obsolete `.delta()` function with `.angleDelta()`. The pixel-level function `.pixelDelta()` does not have direct meaning when performing zoom. The conversion between the two delta functions is 1/8, hence the change in scaling to match the pixel-level control speed in Qt.

Fixes #670.

Signed-off-by: Michael Quevillon <mquevill@nd.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
