### PR TITLE
Fix #650 part 2

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -346,8 +346,13 @@ bool Molecule::removeAtom(Index index)
   if (m_colors.size() == atomCount())
     m_colors.swapAndPop(index);
 
-  if (m_selectedAtoms.size() == atomCount())
-    m_selectedAtoms.erase(m_selectedAtoms.begin() + index);
+  if (m_selectedAtoms.size() == atomCount()) {
+    // swap and pop on std::vector<bool>
+    if (index != m_selectedAtoms.size() - 1) {
+      m_selectedAtoms[index] = m_selectedAtoms.back();
+    }
+    m_selectedAtoms.pop_back();
+  }
 
   Index affectedIndex = static_cast<Index>(m_atomicNumbers.size() - 1);
   m_atomicNumbers.swapAndPop(index);


### PR DESCRIPTION
Bug raised by @mquevill - delete a non-selected atom

Since deleting atoms renumbers, make sure selected atoms stays
with "swap and pop" form from atom index, etc.

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
