### PR TITLE
Fix #679 - incorrect PDB unit cells

### DIFF
--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -65,12 +65,14 @@ bool PdbFormat::read(std::istream& in, Core::Molecule& mol)
     // e.g.   CRYST1    4.912    4.912    6.696  90.00  90.00 120.00 P1 1
     // https://www.wwpdb.org/documentation/file-format-content/format33/sect8.html
     else if (startsWith(buffer, "CRYST1")) {
+      // PDB reports in degrees and Angstroms
+      //   Avogadro uses radians internally
       Real a = lexicalCast<Real>(buffer.substr(6, 9), ok);
       Real b = lexicalCast<Real>(buffer.substr(15, 9), ok);
       Real c = lexicalCast<Real>(buffer.substr(24, 9), ok);
-      Real alpha = lexicalCast<Real>(buffer.substr(33, 7), ok);
-      Real beta = lexicalCast<Real>(buffer.substr(40, 7), ok);
-      Real gamma = lexicalCast<Real>(buffer.substr(47, 8), ok);
+      Real alpha = lexicalCast<Real>(buffer.substr(33, 7), ok) * DEG_TO_RAD;
+      Real beta = lexicalCast<Real>(buffer.substr(40, 7), ok) * DEG_TO_RAD;
+      Real gamma = lexicalCast<Real>(buffer.substr(47, 8), ok) * DEG_TO_RAD;
 
       Core::UnitCell* cell = new Core::UnitCell(a, b, c, alpha, beta, gamma);
       mol.setUnitCell(cell);


### PR DESCRIPTION
Code didn't convert between PDB degrees and radians used in UnitCell

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
