### PR TITLE
When dragging to create a new atom, use starting coords

### DIFF
--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -550,14 +550,14 @@ void Editor::atomLeftDrag(QMouseEvent* e)
   if (!m_newObject.isValid()) {
     // Add a new atom bonded to the clicked atom
     RWAtom clickedAtom = m_molecule->atom(m_clickedObject.index);
-    newAtom = m_molecule->addAtom(m_toolWidget->atomicNumber());
+    newAtom = m_molecule->addAtom(m_toolWidget->atomicNumber(), clickedAtom.position3d());
 
     // Handle the automatic bond order
     int bondOrder = m_toolWidget->bondOrder();
     if (bondOrder == 0) {
       // automatic - guess the size
       bondOrder = expectedBondOrder(clickedAtom, newAtom);
-    }
+    } 
     m_molecule->addBond(clickedAtom, newAtom, bondOrder);
 
     // now if we need to adjust hydrogens, do it


### PR DESCRIPTION
Fixes #680 as suggested by @MSoegtropIMC

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
