### PR TITLE
Use libmsym id field (even as a void*) to track atom ids

### DIFF
--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "symmetry.h"
@@ -212,6 +201,8 @@ void Symmetry::detectSymmetry()
 
   for (Index i = 0; i < length; ++i) {
     Vector3 ipos = m_molecule->atomPositions3d()[i];
+    // this is yucky, but msym uses type <void*> for id :-(
+    a[i].id = reinterpret_cast<void*>(i);
     a[i].n = m_molecule->atomicNumbers()[i];
     if (a[i].n < 1 || a[i].n > 118)
       a[i].n = 1; // pretend to be an H atom for libmsym

--- a/avogadro/qtplugins/symmetry/symmetry.h
+++ b/avogadro/qtplugins/symmetry/symmetry.h
@@ -1,18 +1,7 @@
-/*******************************************************************************
-
+/******************************************************************************
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-*******************************************************************************/
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SYMMETRY_H
 #define AVOGADRO_QTPLUGINS_SYMMETRY_H

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "symmetrywidget.h"
@@ -291,28 +280,21 @@ void SymmetryWidget::equivalenceSelectionChanged(
     return;
 
   const msym_equivalence_set_t* smes = &m_es[group];
+  if (smes == nullptr)
+    return;
   const msym_element_t* a = smes->elements[atomInGroup];
   if (a == nullptr)
     return;
 
   unsigned int length = m_molecule->atomCount();
+  // unselect all the atoms
   for (Index i = 0; i < length; ++i) {
-    // qDebug() << "checking atom" << i << " for " << a->n;
     m_molecule->setAtomSelected(i, false);
-    if (m_molecule->atomicNumbers()[i] != a->n)
-      continue;
-
-    Vector3 ipos = m_molecule->atomPositions3d()[i];
-    //qDebug() << a->v[0] << ipos[0] - m_cm[0];
-    //qDebug() << a->v[1] << ipos[1] - m_cm[1];
-    //qDebug() << a->v[2] << ipos[2] - m_cm[2];
-    if (fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05 &&
-        fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05 &&
-        fabs(a->v[0] - (ipos[0] - m_cm[0])) < 0.05) {
-      m_molecule->setAtomSelected(i, true);
-      // qDebug() << " got one!";
-    }
   }
+  // this is yucky, but libmsym uses <void*> for id
+  Index selectedAtom = reinterpret_cast<Index>(a->id);
+  m_molecule->setAtomSelected(selectedAtom, true);
+
   m_molecule->emitChanged(QtGui::Molecule::Atoms);
 }
 

--- a/avogadro/qtplugins/symmetry/symmetrywidget.h
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SYMMETRYWIDGET_H


### PR DESCRIPTION
Since the only code using the id field is this, we use
reinterpret_cast on both sides.

Greatly simplifies the code and speeds matching 
(since you don't have to compare coords, etc.)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
