### PR TITLE
Hot fix cartoons cliping

### DIFF
--- a/avogadro/rendering/curvegeometry.h
+++ b/avogadro/rendering/curvegeometry.h
@@ -77,13 +77,13 @@ public:
 
   void addPoint(const Vector3f& pos, const Vector3ub& color, float radius,
                 size_t i);
+  const std::vector<Line*>& lines() const { return m_lines; };
 
 protected:
   std::vector<Line*> m_lines;
   std::map<size_t, size_t> m_indexMap;
   ShaderInfo m_shaderInfo;
   bool m_dirty;
-  std::vector<size_t> m_factorials;
   bool m_canBeFlat;
 
   virtual void update(int index);

--- a/avogadro/rendering/geometryvisitor.cpp
+++ b/avogadro/rendering/geometryvisitor.cpp
@@ -17,6 +17,7 @@
 #include "geometryvisitor.h"
 
 #include "ambientocclusionspheregeometry.h"
+#include "curvegeometry.h"
 #include "linestripgeometry.h"
 #include "spheregeometry.h"
 
@@ -92,6 +93,35 @@ void GeometryVisitor::visit(AmbientOcclusionSphereGeometry& geometry)
   tmpRadius = std::sqrt(tmpRadius);
   m_centers.push_back(tmpCenter);
   m_radii.push_back(tmpRadius);
+}
+
+void GeometryVisitor::visit(CurveGeometry& cg)
+{
+  const auto& lines = cg.lines();
+  if (lines.size() == 0) {
+    return;
+  }
+  m_dirty = true;
+  float qtty = 0.0f;
+  Vector3f tmpCenter(Vector3f::Zero());
+  for (const auto& line : lines) {
+    for (const auto& point : line->points) {
+      tmpCenter += point->pos;
+    }
+    qtty += line->points.size();
+  }
+  tmpCenter /= qtty;
+
+  float tmpRadius = 0.0f;
+  for (const auto& line : lines) {
+    for (const auto& point : line->points) {
+      float distance = (point->pos - tmpCenter).squaredNorm();
+      if (distance > tmpRadius)
+        tmpRadius = distance;
+    }
+  }
+  m_centers.push_back(tmpCenter);
+  m_radii.push_back(std::sqrt(tmpRadius));
 }
 
 void GeometryVisitor::visit(LineStripGeometry& lsg)

--- a/avogadro/rendering/geometryvisitor.h
+++ b/avogadro/rendering/geometryvisitor.h
@@ -51,6 +51,7 @@ public:
   void visit(Drawable&) override;
   void visit(SphereGeometry&) override;
   void visit(AmbientOcclusionSphereGeometry&) override;
+  void visit(CurveGeometry&) override;
   void visit(CylinderGeometry&) override { return; }
   void visit(MeshGeometry&) override { return; }
   void visit(TextLabel2D&) override { return; }

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -145,6 +145,7 @@ void GLRenderer::setTextRenderStrategy(TextRenderStrategy* tren)
       void visit(Drawable&) override { return; }
       void visit(SphereGeometry&) override { return; }
       void visit(AmbientOcclusionSphereGeometry&) override { return; }
+      void visit(CurveGeometry&) override { return; }
       void visit(CylinderGeometry&) override { return; }
       void visit(MeshGeometry&) override { return; }
       void visit(Texture2D&) { return; }

--- a/avogadro/rendering/glrendervisitor.cpp
+++ b/avogadro/rendering/glrendervisitor.cpp
@@ -17,6 +17,7 @@
 #include "glrendervisitor.h"
 
 #include "ambientocclusionspheregeometry.h"
+#include "curvegeometry.h"
 #include "cylindergeometry.h"
 #include "linestripgeometry.h"
 #include "meshgeometry.h"
@@ -50,6 +51,12 @@ void GLRenderVisitor::visit(SphereGeometry& geometry)
 }
 
 void GLRenderVisitor::visit(AmbientOcclusionSphereGeometry& geometry)
+{
+  if (geometry.renderPass() == m_renderPass)
+    geometry.render(m_camera);
+}
+
+void GLRenderVisitor::visit(CurveGeometry& geometry)
 {
   if (geometry.renderPass() == m_renderPass)
     geometry.render(m_camera);

--- a/avogadro/rendering/glrendervisitor.h
+++ b/avogadro/rendering/glrendervisitor.h
@@ -60,6 +60,7 @@ public:
   void visit(Drawable&) override;
   void visit(SphereGeometry&) override;
   void visit(AmbientOcclusionSphereGeometry&) override;
+  void visit(CurveGeometry&) override;
   void visit(CylinderGeometry&) override;
   void visit(MeshGeometry&) override;
   void visit(TextLabel2D& geometry) override;

--- a/avogadro/rendering/povrayvisitor.h
+++ b/avogadro/rendering/povrayvisitor.h
@@ -52,6 +52,7 @@ public:
   void visit(Drawable&) override;
   void visit(SphereGeometry&) override;
   void visit(AmbientOcclusionSphereGeometry&) override;
+  void visit(CurveGeometry&) override { return; }
   void visit(CylinderGeometry&) override;
   void visit(MeshGeometry&) override;
   void visit(TextLabel2D&) override { return; }

--- a/avogadro/rendering/visitor.h
+++ b/avogadro/rendering/visitor.h
@@ -34,6 +34,7 @@ class SphereGeometry;
 class TextLabel2D;
 class TextLabel3D;
 class AmbientOcclusionSphereGeometry;
+class CurveGeometry;
 
 /**
  * @class Visitor visitor.h <avogadro/rendering/visitor.h>
@@ -59,6 +60,7 @@ public:
   virtual void visit(Drawable&) { return; }
   virtual void visit(SphereGeometry&) { return; }
   virtual void visit(AmbientOcclusionSphereGeometry&) { return; }
+  virtual void visit(CurveGeometry&) { return; }
   virtual void visit(CylinderGeometry&) { return; }
   virtual void visit(MeshGeometry&) { return; }
   virtual void visit(TextLabel2D&) { return; }

--- a/avogadro/rendering/vrmlvisitor.h
+++ b/avogadro/rendering/vrmlvisitor.h
@@ -52,6 +52,7 @@ public:
   void visit(Drawable&) override;
   void visit(SphereGeometry&) override;
   void visit(AmbientOcclusionSphereGeometry&) override;
+  void visit(CurveGeometry&) override { return; }
   void visit(CylinderGeometry&) override;
   void visit(MeshGeometry&) override;
   void visit(TextLabel2D&) override { return; }


### PR DESCRIPTION
In the previous PR I forgot to add the `GeometryVisitor::visit` and `GLRenderVisitor::visit` functions for the `CurveGeometry` class where they calculate the zFar/zNear and the render pass respectively, necessary if it can be rendered alone.  

Signed-off-by: Marc Prat Masó <marc.prat.maso@estudiantat.upc.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
