### PR TITLE
Render selected atoms in VdW and licorice modes

### DIFF
--- a/avogadro/qtplugins/licorice/licorice.cpp
+++ b/avogadro/qtplugins/licorice/licorice.cpp
@@ -30,7 +30,7 @@ void Licorice::process(const Molecule& molecule, Rendering::GroupNode& node)
 {
   // Use a common radius for all spheres and cylinders.
   float radius(0.2f);
-  float selectedRadius(radius * 1.5f);
+  float selectedRadius(radius * 2.0f);
 
   // Add a sphere node to contain all of the spheres.
   GeometryNode* geometry = new GeometryNode;

--- a/avogadro/qtplugins/licorice/licorice.cpp
+++ b/avogadro/qtplugins/licorice/licorice.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "licorice.h"
@@ -28,23 +17,20 @@ namespace QtPlugins {
 
 using Core::Elements;
 using Core::Molecule;
+using Rendering::CylinderGeometry;
 using Rendering::GeometryNode;
 using Rendering::GroupNode;
 using Rendering::SphereGeometry;
-using Rendering::CylinderGeometry;
 
-Licorice::Licorice(QObject* p) : ScenePlugin(p), m_enabled(false)
-{
-}
+Licorice::Licorice(QObject* p) : ScenePlugin(p), m_enabled(false) {}
 
-Licorice::~Licorice()
-{
-}
+Licorice::~Licorice() {}
 
 void Licorice::process(const Molecule& molecule, Rendering::GroupNode& node)
 {
   // Use a common radius for all spheres and cylinders.
   float radius(0.2f);
+  float selectedRadius(radius * 1.5f);
 
   // Add a sphere node to contain all of the spheres.
   GeometryNode* geometry = new GeometryNode;
@@ -52,11 +38,21 @@ void Licorice::process(const Molecule& molecule, Rendering::GroupNode& node)
   SphereGeometry* spheres = new SphereGeometry;
   spheres->identifier().molecule = &molecule;
   spheres->identifier().type = Rendering::AtomType;
+  auto selectedSpheres = new SphereGeometry;
+  selectedSpheres->setOpacity(0.42);
   geometry->addDrawable(spheres);
+  geometry->addDrawable(selectedSpheres);
+
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     Core::Atom atom = molecule.atom(i);
     Vector3ub color = atom.color();
     spheres->addSphere(atom.position3d().cast<float>(), color, radius);
+
+    if (atom.selected()) {
+      color = Vector3ub(0, 0, 255);
+      selectedSpheres->addSphere(atom.position3d().cast<float>(), color,
+                                 selectedRadius);
+    }
   }
 
   CylinderGeometry* cylinders = new CylinderGeometry;
@@ -86,5 +82,5 @@ void Licorice::setEnabled(bool enable)
 {
   m_enabled = enable;
 }
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/licorice/licorice.h
+++ b/avogadro/qtplugins/licorice/licorice.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_LICORICE_H
@@ -41,7 +30,7 @@ public:
 
   QString description() const override
   {
-    return tr("Render atoms as licorice.");
+    return tr("Render atoms as licorice / sticks.");
   }
 
   bool isEnabled() const override;

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "vanderwaals.h"
@@ -30,13 +19,9 @@ using Rendering::GeometryNode;
 using Rendering::GroupNode;
 using Rendering::SphereGeometry;
 
-VanDerWaals::VanDerWaals(QObject* p) : ScenePlugin(p), m_enabled(false)
-{
-}
+VanDerWaals::VanDerWaals(QObject* p) : ScenePlugin(p), m_enabled(false) {}
 
-VanDerWaals::~VanDerWaals()
-{
-}
+VanDerWaals::~VanDerWaals() {}
 
 void VanDerWaals::process(const Core::Molecule& molecule,
                           Rendering::GroupNode& node)
@@ -47,15 +32,25 @@ void VanDerWaals::process(const Core::Molecule& molecule,
   SphereGeometry* spheres = new SphereGeometry;
   spheres->identifier().molecule = &molecule;
   spheres->identifier().type = Rendering::AtomType;
+  auto selectedSpheres = new SphereGeometry;
+  selectedSpheres->setOpacity(0.42);
+
   geometry->addDrawable(spheres);
+  geometry->addDrawable(selectedSpheres);
 
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     Core::Atom atom = molecule.atom(i);
     unsigned char atomicNumber = atom.atomicNumber();
 
     Vector3ub color = atom.color();
-    spheres->addSphere(atom.position3d().cast<float>(), color,
-                       static_cast<float>(Elements::radiusVDW(atomicNumber)));
+    float radius = static_cast<float>(Elements::radiusVDW(atomicNumber));
+    spheres->addSphere(atom.position3d().cast<float>(), color, radius);
+    if (atom.selected()) {
+      color = Vector3ub(0, 0, 255);
+      radius += 0.2f;
+      selectedSpheres->addSphere(atom.position3d().cast<float>(), color,
+                                 radius);
+    }
   }
 }
 
@@ -68,5 +63,5 @@ void VanDerWaals::setEnabled(bool enable)
 {
   m_enabled = enable;
 }
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.cpp
@@ -47,7 +47,7 @@ void VanDerWaals::process(const Core::Molecule& molecule,
     spheres->addSphere(atom.position3d().cast<float>(), color, radius);
     if (atom.selected()) {
       color = Vector3ub(0, 0, 255);
-      radius += 0.2f;
+      radius += 0.3f;
       selectedSpheres->addSphere(atom.position3d().cast<float>(), color,
                                  radius);
     }

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.h
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_VANDERWAALS_H

--- a/avogadro/qtplugins/wireframe/wireframe.cpp
+++ b/avogadro/qtplugins/wireframe/wireframe.cpp
@@ -21,6 +21,7 @@
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/groupnode.h>
 #include <avogadro/rendering/linestripgeometry.h>
+#include <avogadro/rendering/spheregeometry.h>
 
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QDoubleSpinBox>
@@ -38,6 +39,7 @@ using Core::Array;
 using Rendering::GeometryNode;
 using Rendering::GroupNode;
 using Rendering::LineStripGeometry;
+using Rendering::SphereGeometry;
 
 Wireframe::Wireframe(QObject* p)
   : ScenePlugin(p), m_enabled(false), m_group(nullptr), m_setupWidget(nullptr),
@@ -61,7 +63,12 @@ void Wireframe::process(const Molecule& molecule, Rendering::GroupNode& node)
   LineStripGeometry* lines = new LineStripGeometry;
   lines->identifier().molecule = &molecule;
   lines->identifier().type = Rendering::BondType;
+  auto selectedAtoms = new SphereGeometry;
+  selectedAtoms->setOpacity(0.42);
+  Vector3ub selectedColor(0, 0, 255);
+
   geometry->addDrawable(lines);
+  geometry->addDrawable(selectedAtoms);
   for (Index i = 0; i < molecule.bondCount(); ++i) {
     Core::Bond bond = molecule.bond(i);
     if (!m_showHydrogens && (bond.atom1().atomicNumber() == 1 ||
@@ -79,6 +86,10 @@ void Wireframe::process(const Molecule& molecule, Rendering::GroupNode& node)
     colors.push_back(color1);
     colors.push_back(color2);
     lines->addLineStrip(points, colors, 1.0f);
+    if (bond.atom1().selected())
+      selectedAtoms->addSphere(pos1, selectedColor, 0.3f);
+    if (bond.atom2().selected())
+      selectedAtoms->addSphere(pos2, selectedColor, 0.3f);
   }
 }
 


### PR DESCRIPTION
Fixes most of #696

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
