### PR TITLE
Try downgrading cibuildwheel as a quick fix...

### DIFF
--- a/scripts/github-actions/install.sh
+++ b/scripts/github-actions/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ev
 
-pip install cibuildwheel
+pip install cibuildwheel==2.0.0
 
 if [[ $RUNNER_OS == "Windows" ]]; then
     git clone --recursive -b 3.3.9 --depth 1 https://gitlab.com/libeigen/eigen /c/eigen


### PR DESCRIPTION
This is an attempt to be a quick fix of #701. A better fix will be
to figure out why the new version `delocate` is failing, and fix
that so that we can upgrade `cibuildwheel`.