### PR TITLE
Improve in selection tool

### DIFF
--- a/avogadro/core/atom.h
+++ b/avogadro/core/atom.h
@@ -172,6 +172,14 @@ public:
   /** @} */
 
   /**
+   * The layer of this atom
+   * @{
+   */
+  void setLayer(size_t layer);
+  size_t layer() const;
+  /** @} */
+
+  /**
    * Is the atom selected.
    * {@
    */
@@ -337,6 +345,18 @@ template <class Molecule_T>
 Vector3ub AtomTemplate<Molecule_T>::color() const
 {
   return m_molecule->color(m_index);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setLayer(size_t layer)
+{
+  m_molecule->setLayer(m_index, layer);
+}
+
+template <class Molecule_T>
+size_t AtomTemplate<Molecule_T>::layer() const
+{
+  return m_molecule->layer(m_index);
 }
 
 template <class Molecule_T>

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -175,6 +175,9 @@ public:
    */
   bool setColor(Index atomId, Vector3ub color);
 
+  bool setLayer(Index atomId, size_t layer);
+  size_t layer(Index atomId) const;
+
   /** Returns a vector of 2d atom positions for the atoms in the molecule. */
   const Array<Vector2>& atomPositions2d() const;
 
@@ -802,6 +805,20 @@ inline bool Molecule::setColor(Index atomId, Vector3ub color)
       }
     }
     m_colors[atomId] = color;
+    return true;
+  }
+  return false;
+}
+
+inline size_t Molecule::layer(Index atomId) const
+{
+  return m_layers.getLayerID(atomId);
+}
+
+inline bool Molecule::setLayer(Index atomId, size_t layer)
+{
+  if (atomId < atomCount()) {
+    m_layers.addAtom(layer, atomId);
     return true;
   }
   return false;

--- a/avogadro/qtgui/pluginlayermanager.cpp
+++ b/avogadro/qtgui/pluginlayermanager.cpp
@@ -122,12 +122,20 @@ bool PluginLayerManager::bondEnabled(Index atom1, Index atom2) const
   return atomEnabled(atom1) || atomEnabled(atom2);
 }
 
-bool PluginLayerManager::activeLayerLocked()
+bool PluginLayerManager::activeLayerLocked() const
 {
   assert(m_activeMolecule != nullptr);
   auto& molecule = m_molToInfo[m_activeMolecule];
   size_t active = molecule->layer.activeLayer();
   return molecule->locked[active];
+}
+
+bool PluginLayerManager::atomLocked(size_t atom) const
+{
+  assert(m_activeMolecule != nullptr);
+  auto& molecule = m_molToInfo[m_activeMolecule];
+  size_t layer = molecule->layer.getLayerID(atom);
+  return molecule->locked[layer];
 }
 
 size_t PluginLayerManager::layerCount() const

--- a/avogadro/qtgui/pluginlayermanager.h
+++ b/avogadro/qtgui/pluginlayermanager.h
@@ -28,7 +28,8 @@ public:
   ~PluginLayerManager();
 
   /** @return if the active layer in the molecule is locked. */
-  static bool activeLayerLocked();
+  bool activeLayerLocked() const;
+  bool atomLocked(size_t atom) const;
 
   /** check if there's existent data in the key and reload it in the custom
    * class. */

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -232,6 +232,18 @@ bool RWMolecule::setColor(Index atomId, Vector3ub color)
   return true;
 }
 
+bool RWMolecule::setLayer(Index atomId, size_t layer)
+{
+  if (atomId >= atomCount())
+    return false;
+
+  SetLayerCommand* comm =
+    new SetLayerCommand(*this, atomId, m_molecule.layer(atomId), layer);
+  comm->setText(tr("Change Atom Layer"));
+  m_undoStack.push(comm);
+  return true;
+}
+
 RWMolecule::BondType RWMolecule::addBond(Index atom1, Index atom2,
                                          unsigned char order)
 {

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -302,6 +302,9 @@ public:
    */
   bool setColor(Index atomId, Vector3ub color);
 
+  bool setLayer(Index atomId, size_t layer);
+  size_t layer(Index atomId) const;
+
   /**
    * Create a new bond in the molecule.
    * @param atom1 The first atom in the bond.
@@ -752,6 +755,11 @@ inline signed char RWMolecule::formalCharge(Index atomId) const
 inline Vector3ub RWMolecule::color(Index atomId) const
 {
   return m_molecule.color(atomId);
+}
+
+inline size_t RWMolecule::layer(Index atomId) const
+{
+  return m_molecule.layer(atomId);
 }
 
 inline RWMolecule::BondType RWMolecule::addBond(const AtomType& atom1,

--- a/avogadro/qtgui/rwmolecule_undo.h
+++ b/avogadro/qtgui/rwmolecule_undo.h
@@ -348,13 +348,28 @@ public:
       m_newColor(newColor)
   {}
 
-  void redo() override { m_molecule.colors()[m_atomId] = m_newColor; }
+  void redo() override { m_molecule.setColor(m_atomId, m_newColor); }
 
-  void undo() override { m_molecule.colors()[m_atomId] = m_oldColor; }
+  void undo() override { m_molecule.setColor(m_atomId, m_oldColor); }
 };
-} // end namespace
 
-namespace {
+class SetLayerCommand : public RWMolecule::UndoCommand
+{
+  Index m_atomId;
+  size_t m_oldLayer;
+  size_t m_newLayer;
+
+public:
+  SetLayerCommand(RWMolecule& m, Index atomId, size_t oldLayer, size_t newLayer)
+    : UndoCommand(m), m_atomId(atomId), m_oldLayer(oldLayer),
+      m_newLayer(newLayer)
+  {}
+
+  void redo() override { m_molecule.setLayer(m_atomId, m_newLayer); }
+
+  void undo() override { m_molecule.setLayer(m_atomId, m_oldLayer); }
+};
+
 class AddBondCommand : public RWMolecule::UndoCommand
 {
   unsigned char m_bondOrder;

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -14,7 +14,6 @@
 
 #include <avogadro/qtgui/hydrogentools.h>
 #include <avogadro/qtgui/molecule.h>
-#include <avogadro/qtgui/pluginlayermanager.h>
 #include <avogadro/qtgui/rwmolecule.h>
 
 #include <avogadro/qtopengl/glwidget.h>
@@ -51,7 +50,6 @@ namespace Avogadro {
 namespace QtPlugins {
 
 using QtGui::Molecule;
-using QtGui::PluginLayerManager;
 using QtGui::RWAtom;
 using QtGui::RWBond;
 using QtGui::RWMolecule;
@@ -71,7 +69,7 @@ Editor::Editor(QObject* parent_)
     m_toolWidget(new EditorToolWidget(qobject_cast<QWidget*>(parent_))),
     m_pressedButtons(Qt::NoButton),
     m_clickedAtomicNumber(INVALID_ATOMIC_NUMBER), m_bondAdded(false),
-    m_fixValenceLater(false)
+    m_fixValenceLater(false), m_layerManager("Rditor")
 {
   m_activateAction->setText(tr("Draw"));
   m_activateAction->setIcon(QIcon(":/icons/editor.png"));
@@ -96,7 +94,7 @@ QUndoCommand* Editor::mousePressEvent(QMouseEvent* e)
 
   if (m_pressedButtons & Qt::LeftButton) {
     m_clickedObject = m_renderer->hit(e->pos().x(), e->pos().y());
-    if (PluginLayerManager::activeLayerLocked()) {
+    if (m_layerManager.activeLayerLocked()) {
       e->accept();
       return nullptr;
     }
@@ -140,7 +138,7 @@ QUndoCommand* Editor::mouseReleaseEvent(QMouseEvent* e)
 {
   if (!m_renderer || !m_molecule)
     return nullptr;
-  if (PluginLayerManager::activeLayerLocked()) {
+  if (m_layerManager.activeLayerLocked()) {
     e->accept();
     return nullptr;
   }
@@ -174,7 +172,7 @@ QUndoCommand* Editor::mouseMoveEvent(QMouseEvent* e)
     return nullptr;
   if (m_pressedButtons & Qt::LeftButton)
     if (m_clickedObject.type == Rendering::AtomType) {
-      if (PluginLayerManager::activeLayerLocked()) {
+      if (m_layerManager.activeLayerLocked()) {
         e->accept();
         return nullptr;
       }
@@ -190,7 +188,7 @@ QUndoCommand* Editor::keyPressEvent(QKeyEvent* e)
     return nullptr;
   e->accept();
 
-  if (PluginLayerManager::activeLayerLocked()) {
+  if (m_layerManager.activeLayerLocked()) {
     return nullptr;
   }
   // Set a timer to clear the buffer on first keypress:

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -69,7 +69,7 @@ Editor::Editor(QObject* parent_)
     m_toolWidget(new EditorToolWidget(qobject_cast<QWidget*>(parent_))),
     m_pressedButtons(Qt::NoButton),
     m_clickedAtomicNumber(INVALID_ATOMIC_NUMBER), m_bondAdded(false),
-    m_fixValenceLater(false), m_layerManager("Rditor")
+    m_fixValenceLater(false), m_layerManager("Editor")
 {
   m_activateAction->setText(tr("Draw"));
   m_activateAction->setIcon(QIcon(":/icons/editor.png"));

--- a/avogadro/qtplugins/editor/editor.h
+++ b/avogadro/qtplugins/editor/editor.h
@@ -21,6 +21,7 @@
 
 #include <avogadro/core/avogadrocore.h>
 #include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/pluginlayermanager.h>
 #include <avogadro/rendering/primitive.h>
 
 #include <QtCore/QPoint>
@@ -107,6 +108,7 @@ private:
   bool m_bondAdded;
   bool m_fixValenceLater;
   QString m_keyPressBuffer;
+  QtGui::PluginLayerManager m_layerManager;
 
   Real m_bondDistance;
 };

--- a/avogadro/qtplugins/select/select.cpp
+++ b/avogadro/qtplugins/select/select.cpp
@@ -34,8 +34,8 @@ namespace Avogadro {
 namespace QtPlugins {
 
 Select::Select(QObject* parent_)
-  : Avogadro::QtGui::ExtensionPlugin(parent_), m_molecule(nullptr),
-    m_elements(nullptr)
+  : Avogadro::QtGui::ExtensionPlugin(parent_), m_layerManager("Select"),
+    m_molecule(nullptr), m_elements(nullptr)
 {
   QAction* action = new QAction(tr("Select All"), this);
   action->setShortcut(QKeySequence("Ctrl+A"));
@@ -94,11 +94,17 @@ void Select::setMolecule(QtGui::Molecule* mol)
   m_molecule = mol;
 }
 
+bool Select::evalSelect(bool input, Index index) const
+{
+  return !m_layerManager.atomLocked(index) && input;
+}
+
 void Select::selectAll()
 {
   if (m_molecule) {
-    for (Index i = 0; i < m_molecule->atomCount(); ++i)
-      m_molecule->atom(i).setSelected(true);
+    for (Index i = 0; i < m_molecule->atomCount(); ++i) {
+      m_molecule->atom(i).setSelected(evalSelect(true, i));
+    }
 
     m_molecule->emitChanged(Molecule::Atoms);
   }
@@ -134,9 +140,9 @@ void Select::selectElement(int element)
     return;
 
   for (Index i = 0; i < m_molecule->atomCount(); ++i) {
-    if (m_molecule->atomicNumber(i) == element)
-      m_molecule->atom(i).setSelected(true);
-    else
+    if (m_molecule->atomicNumber(i) == element) {
+      m_molecule->atom(i).setSelected(evalSelect(true, i));
+    } else
       m_molecule->atom(i).setSelected(false);
   }
 
@@ -166,14 +172,15 @@ void Select::selectAtomIndex()
         int start = range.first().toInt(&ok1);
         int last = range.back().toInt(&ok2);
         if (ok1 && ok2) {
-          for (Index i = start; i <= last; ++i)
-            m_molecule->atom(i).setSelected(true);
+          for (Index i = start; i <= last; ++i) {
+            m_molecule->atom(i).setSelected(evalSelect(true, i));
+          }
         }
       }
     } else {
       int i = item.toInt(&ok);
       if (ok)
-        m_molecule->atom(i).setSelected(true);
+        m_molecule->atom(i).setSelected(evalSelect(true, i));
     }
   }
 
@@ -203,8 +210,8 @@ void Select::selectResidue()
       auto residueList = m_molecule->residues();
       if (index >= 1 && index < residueList.size()) {
         auto residue = residueList[index];
-        for (auto atom : residue.residueAtoms()) {
-          atom.setSelected(true);
+        for (auto& atom : residue.residueAtoms()) {
+          atom.setSelected(evalSelect(true, atom.index()));
         }
       } // index makes sense
       continue;
@@ -222,7 +229,7 @@ void Select::selectResidue()
         auto residue = residueList[index];
         if (name == residue.residueName().c_str()) {
           for (auto atom : residue.residueAtoms()) {
-            atom.setSelected(true);
+            atom.setSelected(evalSelect(true, atom.index()));
           }
         } // check if name matches specified (e.g. HIS57 is really a HIS)
       }   // index makes sense
@@ -232,7 +239,7 @@ void Select::selectResidue()
         if (label == residue.residueName().c_str()) {
           // select the atoms of the residue
           for (auto atom : residue.residueAtoms()) {
-            atom.setSelected(true);
+            atom.setSelected(evalSelect(true, atom.index()));
           }
         } // residue matches label
       }   // for(residues)
@@ -247,8 +254,8 @@ void Select::invertSelection()
 {
   if (m_molecule) {
     for (Index i = 0; i < m_molecule->atomCount(); ++i)
-      m_molecule->atom(i).setSelected(!m_molecule->atomSelected(i));
-
+      m_molecule->atom(i).setSelected(
+        evalSelect(!m_molecule->atomSelected(i), i));
     m_molecule->emitChanged(Molecule::Atoms);
   }
 }

--- a/avogadro/qtplugins/select/select.h
+++ b/avogadro/qtplugins/select/select.h
@@ -18,10 +18,11 @@
 #define AVOGADRO_QTPLUGINS_SELECT_H
 
 #include <avogadro/qtgui/extensionplugin.h>
+#include <avogadro/qtgui/pluginlayermanager.h>
 
 namespace Avogadro {
 
-namespace QtGui{
+namespace QtGui {
 class PeriodicTableView;
 }
 namespace QtPlugins {
@@ -57,6 +58,9 @@ private:
   QList<QAction*> m_actions;
   QtGui::Molecule* m_molecule;
   QtGui::PeriodicTableView* m_elements;
+  QtGui::PluginLayerManager m_layerManager;
+
+  bool evalSelect(bool input, Index index) const;
 };
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/selectiontool/selectiontool.h
+++ b/avogadro/qtplugins/selectiontool/selectiontool.h
@@ -24,6 +24,7 @@
 #include <avogadro/qtgui/toolplugin.h>
 
 #include <avogadro/core/avogadrocore.h>
+#include <avogadro/qtgui/pluginlayermanager.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/primitive.h>
 
@@ -62,6 +63,7 @@ public:
 
 private slots:
   void applyColor(Vector3ub color);
+  void applyLayer(int layer);
 
 private:
   void clearAtoms();
@@ -80,6 +82,7 @@ private:
   bool m_drawSelectionBox, m_initSelectionBox, m_doubleClick;
   Vector2 m_start;
   Vector2 m_end;
+  QtGui::PluginLayerManager m_layerManager;
 };
 
 inline void SelectionTool::setMolecule(QtGui::Molecule* mol)

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
@@ -28,6 +28,8 @@ SelectionToolWidget::SelectionToolWidget(QWidget* parent)
   m_ui->setupUi(this);
   connect(m_ui->applyColorButton, SIGNAL(clicked()), this,
           SLOT(userClickedColor()));
+  connect(m_ui->changeLayerDropDown, SIGNAL(currentIndexChanged(int)), this,
+          SIGNAL(changeLayer(int)));
 }
 
 SelectionToolWidget::~SelectionToolWidget()
@@ -35,13 +37,13 @@ SelectionToolWidget::~SelectionToolWidget()
   delete m_ui;
 }
 
-void SelectionToolWidget::setColor(Vector3ub color)
+void SelectionToolWidget::setDropDown(size_t current, size_t max)
 {
-  QColor new_color(color[0], color[1], color[2]);
-  QPalette pal = m_ui->applyColorButton->palette();
-  pal.setColor(QPalette::Button, new_color);
-  m_ui->applyColorButton->setPalette(pal);
-  m_ui->applyColorButton->update();
+  m_ui->changeLayerDropDown->clear();
+  for (size_t i = 0; i < max; ++i) {
+    m_ui->changeLayerDropDown->addItem(QString::number(i + 1));
+  }
+  m_ui->changeLayerDropDown->setCurrentIndex(current);
 }
 
 void SelectionToolWidget::userClickedColor()

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
@@ -36,17 +36,17 @@ public:
   explicit SelectionToolWidget(QWidget* parent = nullptr);
   ~SelectionToolWidget();
 
-  void setColor(Vector3ub color);
+  void setDropDown(size_t current, size_t max);
 
 signals:
   void colorApplied(Vector3ub color);
+  void changeLayer(int layer);
 
 private slots:
   void userClickedColor();
 
 private:
   Ui::SelectionToolWidget* m_ui;
-  Vector3ub m_currentColor;
 };
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.ui
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.ui
@@ -14,6 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <!-- color Applied -->
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -29,6 +30,18 @@
      <property name="text">
       <string/>
      </property>
+    </widget>
+   </item>
+   <!-- change Layer  -->
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Change Layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="changeLayerDropDown">
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
- Locking a layer deny select atom in it.
- Easy way to select and change the atom layer (ctrl+x and ctrl+v was too slow), and also includes do/undo. 
- do/undo in atom coloring

![image](https://user-images.githubusercontent.com/10197352/129344911-532f9412-75ce-4d3c-a002-33a79759365a.png)


Signed-off-by: Marc Prat Masó <marc.prat.maso@estudiantat.upc.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
