### PR TITLE
Enable script formats like cclib to ask for bond perception on read

### DIFF
--- a/avogadro/qtplugins/scriptfileformats/fileformatscript.h
+++ b/avogadro/qtplugins/scriptfileformats/fileformatscript.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_FILEFORMATSCRIPT_H
@@ -72,7 +61,7 @@ namespace QtPlugins {
  *   `"cjson"`, or `"xyz"`. See the `--write` documentation for more detail.
  * - `outputFormat` indicates the format that the script can convert to from the
  *   implemented format by the `--read` command. Allowed values are `"cml"`,
- *   `"cjson"`, or `"xyz"`. See the `--read` documentation for more detail.
+ *   `"cjson"`, `"sdf"`, `"pdb"` or `"xyz"`. See the `--read` documentation for more detail.
  * - `operations` specifies the scripts capabilies. The array should contain
  *   `"read"` if the script implements the `--read` option, and/or `"write"` if
  *   `--write` is available.
@@ -88,6 +77,8 @@ namespace QtPlugins {
  *   format supports.
  * - `mimeTypes` is an array specifying the mime types that this format
  *   supports.
+ * - `bond` is a boolean indicating whether the format expects Avogadro
+ *   to perceive bonds after reading the file.
  *
  * Required members are
  * - `operations`
@@ -127,6 +118,8 @@ public:
     NotUsed,
     Cjson,
     Cml,
+    Mdl,
+    Pdb,
     Xyz
   };
 
@@ -176,6 +169,7 @@ private:
 private:
   QtGui::PythonScript* m_interpreter;
   bool m_valid;
+  bool m_bondOnRead;
   Operations m_operations;
   Format m_inputFormat;
   Format m_outputFormat;


### PR DESCRIPTION
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
