### PR TITLE
Fix header for SortFilterProxyModel - available under BSD license

### DIFF
--- a/avogadro/qtplugins/insertfragment/sortfiltertreeproxymodel.cpp
+++ b/avogadro/qtplugins/insertfragment/sortfiltertreeproxymodel.cpp
@@ -1,20 +1,7 @@
-/**********************************************************************
-  SortFilterTreeProxyModel - Sorting / Filter proxy which works on trees
-
-  Based on code from http://kodeclutz.blogspot.com/2008/12/filtering-qtreeview.html
-
-  This file is part of the Avogadro molecular editor project.
-  For more information, see <http://avogadro.openmolecules.net/>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation version 2 of the License.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
- ***********************************************************************/
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
 
 #include "sortfiltertreeproxymodel.h"
 

--- a/avogadro/qtplugins/insertfragment/sortfiltertreeproxymodel.h
+++ b/avogadro/qtplugins/insertfragment/sortfiltertreeproxymodel.h
@@ -1,19 +1,7 @@
-/**********************************************************************
-  SortFilterTreeProxyModel - Sorting / Filter proxy which works on trees
-
+/******************************************************************************
   This source file is part of the Avogadro project.
-  See http://stackoverflow.com/questions/3212392/qtreeview-qfilesystemmodel-setrootpath-and-qsortfilterproxymodel-with-regexp-fo
-
-  Copyright 2020 Geoffrey R. Hutchison
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
- ***********************************************************************/
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
 
 #ifndef SORTFILTERTREEPROXYMODEL_H
 #define SORTFILTERTREEPROXYMODEL_H


### PR DESCRIPTION
I wrote the code for Avo1 and hereby relicense. Should have fixed
the header when I first put it into the code.

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
