### PR TITLE
Default behavior check

### DIFF
--- a/avogadro/qtgui/pluginlayermanager.cpp
+++ b/avogadro/qtgui/pluginlayermanager.cpp
@@ -82,22 +82,6 @@ void PluginLayerManager::setEnabled(bool enable)
   if (molecule->enable[m_name].size() != qttyLayers) {
     molecule->enable[m_name].resize(qttyLayers, false);
   }
-  // if this is a fully fresh run, set some intial trues
-  if ((m_name == BallAndStick::getName() || m_name == Cartoons::getName())) {
-    QSettings settings;
-    bool enable;
-    if (m_name == BallAndStick::getName()) {
-      enable = settings.value("ballandstick/enable", true).toBool();
-      settings.setValue("ballandstick/enable", false);
-    } else if (m_name == Cartoons::getName()) {
-      enable = settings.value("cartoon/enable", true).toBool();
-      settings.setValue("cartoon/enable", false);
-    }
-    if (enable) {
-      molecule->enable[m_name][0] = true;
-      return;
-    }
-  }
   size_t activeLayer = molecule->layer.activeLayer();
   molecule->enable[m_name][activeLayer] = enable;
 }

--- a/avogadro/qtgui/sceneplugin.h
+++ b/avogadro/qtgui/sceneplugin.h
@@ -93,6 +93,13 @@ public:
 
   virtual QWidget* setupWidget();
 
+  /**
+  * Returns if this plugin should be considered in the default behavior,
+  * or it should reset to true or false.
+  */
+  enum DefaultBehavior { Ignore, False, True };
+  virtual DefaultBehavior defaultBehavior() const { return Ignore; }
+
 signals:
   void drawablesChanged();
 

--- a/avogadro/qtplugins/ballandstick/ballandstick.h
+++ b/avogadro/qtplugins/ballandstick/ballandstick.h
@@ -35,7 +35,10 @@ public:
 
   QWidget* setupWidget() override;
 
-  static std::string getName() { return "Ball and Stick"; }
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::True;
+  }
 
 public slots:
   void atomRadiusChanged(int value);
@@ -45,7 +48,7 @@ public slots:
 
 private:
   Rendering::GroupNode* m_group;
-  std::string m_name = getName();
+  std::string m_name = "Ball and Stick";
   float m_atomScale = 0.3f;
   float m_bondRadius = 0.1f;
 };

--- a/avogadro/qtplugins/cartoons/cartoons.h
+++ b/avogadro/qtplugins/cartoons/cartoons.h
@@ -36,6 +36,11 @@ public:
 
   QWidget* setupWidget() override;
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::True;
+  }
+
 public slots:
   // straights line between alpha carbons
   void showBackbone(bool show);
@@ -53,11 +58,9 @@ public slots:
   // of 3) we crea a big N-bezier line
   void showRope(bool show);
 
-  static std::string getName() { return "Cartoons"; }
-
 private:
   Rendering::GroupNode* m_group;
-  std::string m_name = getName();
+  std::string m_name = "Cartoons";
 
   std::map<size_t, AtomsPairList> getBackboneByResidues(
     const QtGui::Molecule& molecule, size_t layer);

--- a/avogadro/qtplugins/label/label.h
+++ b/avogadro/qtplugins/label/label.h
@@ -30,8 +30,13 @@ public:
   }
 
   QWidget* setupWidget() override;
-  void process(const Core::Molecule& molecule, Rendering::GroupNode& node) override;
+  void process(const Core::Molecule& molecule,
+               Rendering::GroupNode& node) override;
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::False;
+  }
 public slots:
   void atomLabel(bool show);
   void residueLabel(bool show);

--- a/avogadro/qtplugins/licorice/licorice.h
+++ b/avogadro/qtplugins/licorice/licorice.h
@@ -33,6 +33,11 @@ public:
     return tr("Render atoms as licorice / sticks.");
   }
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::False;
+  }
+
 private:
   std::string m_name = "Licorice";
 };

--- a/avogadro/qtplugins/vanderwaals/vanderwaals.h
+++ b/avogadro/qtplugins/vanderwaals/vanderwaals.h
@@ -33,6 +33,11 @@ public:
     return tr("Simple display of VdW spheres.");
   }
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::False;
+  }
+
 private:
   std::string m_name = "Van der Waals";
 };

--- a/avogadro/qtplugins/vanderwaalsao/vanderwaalsao.h
+++ b/avogadro/qtplugins/vanderwaalsao/vanderwaalsao.h
@@ -45,6 +45,11 @@ public:
     return tr("Simple display of VdW spheres with ambient occlusion.");
   }
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::False;
+  }
+
 private:
   std::string m_name = "Van der Waals (AO)";
 };

--- a/avogadro/qtplugins/wireframe/wireframe.h
+++ b/avogadro/qtplugins/wireframe/wireframe.h
@@ -34,6 +34,11 @@ public:
 
   QWidget* setupWidget() override;
 
+  DefaultBehavior defaultBehavior() const override
+  {
+    return DefaultBehavior::False;
+  }
+
 public slots:
   void multiBonds(bool show);
   void showHydrogens(bool show);


### PR DESCRIPTION
Added `ScenePlugin::defaultBehavior` to know if a plugin should be True/False or just ignored as a default behavior. 
Also, roll back in the previous try. 

This is related to: https://github.com/OpenChemistry/avogadroapp/pull/235

Signed-off-by: Marc Prat Masó <marc.prat.maso@estudiantat.upc.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
