### PR TITLE
test ">=0" within machine precision (>-EPS)

### DIFF
--- a/tests/core/unitcelltest.cpp
+++ b/tests/core/unitcelltest.cpp
@@ -15,6 +15,7 @@
 ******************************************************************************/
 
 #include <gtest/gtest.h>
+#include <limits>
 
 #include <avogadro/core/array.h>
 #include <avogadro/core/crystaltools.h>
@@ -260,11 +261,11 @@ TEST(UnitCellTest, wrapAtomsToUnitCell)
   for (std::vector<Vector3>::const_iterator it = fcoords.begin(),
                                             itEnd = fcoords.end();
        it != itEnd; ++it) {
-    EXPECT_GE(it->x(), static_cast<Real>(0.0));
+    EXPECT_GT(it->x(), static_cast<Real>(-std::numeric_limits<Real>::epsilon())); // x >= 0, "mostly" zero
     EXPECT_LE(it->x(), static_cast<Real>(1.0));
-    EXPECT_GE(it->y(), static_cast<Real>(0.0));
+    EXPECT_GT(it->y(), static_cast<Real>(-std::numeric_limits<Real>::epsilon())); // y >= 0, "mostly" zero
     EXPECT_LE(it->y(), static_cast<Real>(1.0));
-    EXPECT_GE(it->z(), static_cast<Real>(0.0));
+    EXPECT_GT(it->z(), static_cast<Real>(-std::numeric_limits<Real>::epsilon())); // z >= 0, "mostly" zero
     EXPECT_LE(it->z(), static_cast<Real>(1.0));
   }
 }


### PR DESCRIPTION
Unit test UnitCellTest.wrapAtomsToUnitCell fails on i386 (i686):

[ RUN      ] UnitCellTest.wrapAtomsToUnitCell
/tmp/autopkgtest-lxc.w4hysxt4/downtmp/build.1Hw/src/tests/core/unitcelltest.cpp:265: Failure
Expected: (it->y()) >= (static_cast<Real>(0.0)), actual: -1.44334e-18 vs 0
[  FAILED  ] UnitCellTest.wrapAtomsToUnitCell (0 ms)

Evidently the precision is too tight for 32-bit i386, such that it->y() is "mostly zero" but crosses just below 0, making the test fail.
Replacing the test ">=0" with ">-EPS" enables the test to pass on i386.

Fixes Issue #812.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
