### PR TITLE
Fix erratic editing behavior

### DIFF
--- a/avogadro/qtgui/rwmolecule_undo.h
+++ b/avogadro/qtgui/rwmolecule_undo.h
@@ -89,7 +89,7 @@ public:
   {
     assert(m_molecule.atomCount() == m_atomId);
     if (m_usingPositions)
-      m_molecule.addAtom(m_atomicNumber, Vector3::Zero(), m_atomId);
+      m_molecule.addAtom(m_atomicNumber, Vector3::Zero(), m_atomUid);
     else
       m_molecule.addAtom(m_atomicNumber, m_atomUid);
     m_molecule.layer().addAtom(m_layer, m_atomId);


### PR DESCRIPTION
This fixes the regression described at https://github.com/OpenChemistry/avogadroapp/issues/239. This issue appeared with https://github.com/OpenChemistry/avogadrolibs/commit/d2dcfaead5080597c877246a7253c483f7668c3c, due to a small change in `avogadro/qtgui/rwmolecule_undo.h` wherein `RWMolecule::addAtom()` was made to be passed `m_atomId` rather than `m_atomUid`, when it should expect a UID.

The consequence was that, when two carbons were bonded and their hydrogens adjusted, the hydrogens on one of the carbons would be removed and not be added back, due to the passed UIDs actually being their IDs, which happened to be equal to the removed hydrogens' UIDs.

Then, trying to add atoms around this molecule with 5 atoms would pass atom ID 5 as UID, this being the UID of one of the existing hydrogens, which would simply get moved to the clicked location.


Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
