### PR TITLE
Fix Manipulation and Bond Centric Manipulation tools

### DIFF
--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
@@ -351,8 +351,7 @@ QUndoCommand* BondCentricTool::mousePressEvent(QMouseEvent* e)
   Rendering::Identifier ident = m_renderer->hit(e->pos().x(), e->pos().y());
 
   // If no hits, return. Also ensure that the hit molecule is the one we expect.
-  const Core::Molecule* mol = &m_molecule->molecule();
-  if (!ident.isValid() || ident.molecule != mol)
+  if (!ident.isValid() || ident.molecule != &m_molecule->molecule())
     return nullptr;
 
   // If the hit is a left click on a bond, make it the selected bond and map

--- a/avogadro/qtplugins/manipulator/manipulator.cpp
+++ b/avogadro/qtplugins/manipulator/manipulator.cpp
@@ -133,7 +133,7 @@ QUndoCommand* Manipulator::mouseMoveEvent(QMouseEvent* e)
   Vector2f windowPos(e->localPos().x(), e->localPos().y());
 
   if (mol->isSelectionEmpty() && m_object.type == Rendering::AtomType &&
-      m_object.molecule == mol) {
+      m_object.molecule == &m_molecule->molecule()) {
     // translate single atom position
     RWAtom atom = m_molecule->atom(m_object.index);
     Vector3f oldPos(atom.position3d().cast<float>());


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


The issue fixed in this Pull Request is described at [this Debian package bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005006). Simply, the Manipulation and Bond Centric Manipulation tools don't work.

The problem seems to arise from an Avogadro::Core::Molecule& being cast to a pointer and then stored. For some reason, this gives a different value as just using it in an expression without storing it first. I must admit I don't understand this, and it might be some special feature of the language I'm not aware of, or a compiler bug.

However, by the code one can deduce that both approaches should be expected to give the same result, so it's safe to simply replace the stored variable with an expression, and this workaround fully restores both tools.