### PR TITLE
Faster bond perception

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -840,7 +840,7 @@ void Molecule::perceiveBondsSimple(const double tolerance, const double min)
   // note that the "worst case" here would need to be an invalid molecule
   for (Index i = 0; i < atomCount(); i++) {
     Vector3 ipos = m_positions3d[i];
-    const std::array<size_t, 3>& bin_index = atoms_bin[i];
+    const std::array<size_t, 3> &bin_index = atoms_bin[i];
     for (Index xi = std::max(0, signed(bin_index[0]) - 1);
         xi < std::min(bin_count[0], bin_index[0] + 2); xi++) {
       for (Index yi = std::max(0, signed(bin_index[1]) - 1);

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -803,7 +803,7 @@ void Molecule::perceiveBondsSimple(const double tolerance, const double min)
   // find molecule bounding box
   Vector3 min_pos = m_positions3d[0];
   Vector3 max_pos = m_positions3d[0];
-  for (Index i = 1; i < atomCount(); i++) {
+  for (Index i = 0; i < atomCount(); i++) {
     Vector3 ipos = m_positions3d[i];
     for (size_t c = 0; c < 3; c++) {
       min_pos(c) = std::min(ipos(c), min_pos(c));
@@ -825,14 +825,14 @@ void Molecule::perceiveBondsSimple(const double tolerance, const double min)
     )
   );
   std::vector<std::array<size_t, 3>> atoms_bin(atomCount());
-  for (Index i = 1; i < atomCount(); i++) {
+  for (Index i = 0; i < atomCount(); i++) {
     Vector3 ipos = m_positions3d[i];
     std::array<size_t, 3> bin_index;
     for (size_t c = 0; c < 3; c++) {
       bin_index[c] = std::floor((ipos(c) - min_pos(c)) / bin_size);
     }
     bins.at(bin_index[0]).at(bin_index[1]).at(bin_index[2]).push_back(i);
-    atoms_bin.push_back(bin_index);
+    atoms_bin[i] = bin_index;
   }
 
   // check for bonds
@@ -840,12 +840,12 @@ void Molecule::perceiveBondsSimple(const double tolerance, const double min)
   // note that the "worst case" here would need to be an invalid molecule
   for (Index i = 0; i < atomCount(); i++) {
     Vector3 ipos = m_positions3d[i];
-    std::array<size_t, 3> bin_index = atoms_bin[i];
-    for (Index xi = std::max(size_t(0), bin_index[0] - 1);
+    const std::array<size_t, 3>& bin_index = atoms_bin[i];
+    for (Index xi = std::max(0, signed(bin_index[0]) - 1);
         xi < std::min(bin_count[0], bin_index[0] + 2); xi++) {
-      for (Index yi = std::max(size_t(0), bin_index[1] - 1);
+      for (Index yi = std::max(0, signed(bin_index[1]) - 1);
           yi < std::min(bin_count[1], bin_index[1] + 2); yi++) {
-        for (Index zi = std::max(size_t(0), bin_index[2] - 1);
+        for (Index zi = std::max(0, signed(bin_index[2]) - 1);
             zi < std::min(bin_count[2], bin_index[2] + 2); zi++) {
           std::vector<Index> bin = bins[xi][yi][zi];
           for (size_t bj = 0; bj < bin.size(); ++bj) {


### PR DESCRIPTION
This Pull Requests implements a new bond perception algorithm that is O(n) in the average case, down from O(n²). Among other probable improvements, this represents 5 - 15 times faster PDB import, making the Avogadro PDB path faster than Open Babel.

While the previous code tested every possible pair of atoms in a molecule, this new version first puts atoms in a 3D array of cubic bins with side equal to twice the maximum covalent radius plus tolerance, then only checks each atom against other atoms inside its bin and those in a 3D Moore neighborhood. For valid molecules, the number of operations performed must be, on average, linear to the number of atoms.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
