### PR TITLE
Formal charges

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -827,52 +827,6 @@ void Molecule::perceiveBondsFromResidueData()
   }
 }
 
-void Molecule::perceiveSubstitutedCations()
-{
-  for (Index i = 0; i < atomCount(); i++) {
-    unsigned char requiredBondCount(0);
-    switch(atomicNumber(i)) {
-      case 7:
-      case 15:
-      case 33:
-      case 51:
-        requiredBondCount = 4;
-        break;
-      case 8:
-      case 16:
-      case 34:
-      case 52:
-        requiredBondCount = 3;
-    }
-    if (!requiredBondCount)
-      continue;
-
-    unsigned char bondCount(0);
-    Index j = 0;
-    for (const auto &bond : bonds(i)) {
-      unsigned char otherAtomicNumber(0);
-      Index index1(bond.atom1().index());
-      Index index2(bond.atom2().index());
-      if (index1 == i) {
-        otherAtomicNumber = atomicNumber(index2);
-        bondCount += bond.order();
-      } else if (index2 == i) {
-        otherAtomicNumber = atomicNumber(index1);
-        bondCount += bond.order();
-      }
-      if (otherAtomicNumber && otherAtomicNumber != 6) {
-        bondCount = 0;
-        break;
-      }
-      j++;
-    }
-
-    if (bondCount == requiredBondCount) {
-      setFormalCharge(i, 1);
-    }
-  }
-}
-
 int Molecule::coordinate3dCount()
 {
   return static_cast<int>(m_coordinates3d.size());

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -835,11 +835,13 @@ void Molecule::perceiveSubstitutedCations()
       case 7:
       case 15:
       case 33:
+      case 51:
         requiredBondCount = 4;
         break;
       case 8:
       case 16:
-      case 32:
+      case 34:
+      case 52:
         requiredBondCount = 3;
     }
     if (!requiredBondCount)
@@ -847,7 +849,7 @@ void Molecule::perceiveSubstitutedCations()
 
     unsigned char bondCount(0);
     Index j = 0;
-    for (auto &bond : bonds(i)) {
+    for (const auto &bond : bonds(i)) {
       unsigned char otherAtomicNumber(0);
       Index index1(bond.atom1().index());
       Index index2(bond.atom2().index());

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -847,7 +847,7 @@ void Molecule::perceiveSubstitutedCations()
 
     unsigned char bondCount(0);
     Index j = 0;
-    for (auto& bond : bonds(i)) {
+    for (auto &bond : bonds(i)) {
       unsigned char otherAtomicNumber(0);
       Index index1(bond.atom1().index());
       Index index2(bond.atom2().index());

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -847,16 +847,16 @@ void Molecule::perceiveSubstitutedCations()
 
     unsigned char bondCount(0);
     Index j = 0;
-    for (auto& pair : m_bondPairs) {
+    for (auto& bond : bonds(i)) {
       unsigned char otherAtomicNumber(0);
-      if (pair.first == pair.second) {
-      }
-      if (pair.first == i) {
-        otherAtomicNumber = atomicNumber(pair.second);
-        bondCount += m_bondOrders[j];
-      } else if (pair.second == i) {
-        otherAtomicNumber = atomicNumber(pair.first);
-        bondCount += m_bondOrders[j];
+      Index index1(bond.atom1().index());
+      Index index2(bond.atom2().index());
+      if (index1 == i) {
+        otherAtomicNumber = atomicNumber(index2);
+        bondCount += bond.order();
+      } else if (index2 == i) {
+        otherAtomicNumber = atomicNumber(index1);
+        bondCount += bond.order();
       }
       if (otherAtomicNumber && otherAtomicNumber != 6) {
         bondCount = 0;

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -827,6 +827,50 @@ void Molecule::perceiveBondsFromResidueData()
   }
 }
 
+void Molecule::perceiveSubstitutedCations()
+{
+  for (Index i = 0; i < atomCount(); i++) {
+    unsigned char requiredBondCount(0);
+    switch(atomicNumber(i)) {
+      case 7:
+      case 15:
+      case 33:
+        requiredBondCount = 4;
+        break;
+      case 8:
+      case 16:
+      case 32:
+        requiredBondCount = 3;
+    }
+    if (!requiredBondCount)
+      continue;
+
+    unsigned char bondCount(0);
+    Index j = 0;
+    for (auto& pair : m_bondPairs) {
+      unsigned char otherAtomicNumber(0);
+      if (pair.first == pair.second) {
+      }
+      if (pair.first == i) {
+        otherAtomicNumber = atomicNumber(pair.second);
+        bondCount += m_bondOrders[j];
+      } else if (pair.second == i) {
+        otherAtomicNumber = atomicNumber(pair.first);
+        bondCount += m_bondOrders[j];
+      }
+      if (otherAtomicNumber && otherAtomicNumber != 6) {
+        bondCount = 0;
+        break;
+      }
+      j++;
+    }
+
+    if (bondCount == requiredBondCount) {
+      setFormalCharge(i, 1);
+    }
+  }
+}
+
 int Molecule::coordinate3dCount()
 {
   return static_cast<int>(m_coordinates3d.size());

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -489,6 +489,12 @@ public:
    */
   void perceiveBondsFromResidueData();
 
+  /**
+   * Perceives all-carbon-substituted onium ions of nitrogen, oxygen,
+   * phosphorus, sulfur, arsenic and selenium.
+   */
+  void perceiveSubstitutedCations();
+
   int coordinate3dCount();
   bool setCoordinate3d(int coord);
   Array<Vector3> coordinate3d(int index) const;

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -153,10 +153,10 @@ bool CjsonFormat::read(std::istream& file, Molecule& molecule)
   }
 
   // formal charges
-  json charges = atoms["charges"];
-  if (charges.is_array() && charges.size() == atomCount) {
+  json formalCharges = atoms["formalCharges"];
+  if (formalCharges.is_array() && formalCharges.size() == atomCount) {
     for (size_t i = 0; i < atomCount; ++i) {
-      molecule.atom(i).setFormalCharge(charges[i]);
+      molecule.atom(i).setFormalCharge(formalCharges[i]);
     }
   }
 
@@ -763,11 +763,11 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
   root["atoms"]["labels"] = labels;
 
   // formal charges
-  json charges;
+  json formalCharges;
   for (size_t i = 0; i < molecule.atomCount(); ++i) {
-    charges.push_back(molecule.formalCharge(i));
+    formalCharges.push_back(molecule.formalCharge(i));
   }
-  root["atoms"]["charges"] = charges;
+  root["atoms"]["formalCharges"] = formalCharges;
 
   auto layer = LayerManager::getMoleculeInfo(&molecule)->layer;
   if (layer.atomCount()) {

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -152,6 +152,14 @@ bool CjsonFormat::read(std::istream& file, Molecule& molecule)
     }
   }
 
+  // formal charges
+  json charges = atoms["charges"];
+  if (charges.is_array() && charges.size() == atomCount) {
+    for (size_t i = 0; i < atomCount; ++i) {
+      molecule.atom(i).setFormalCharge(charges[i]);
+    }
+  }
+
   // Check for coordinate sets, and read them in if found, e.g. trajectories.
   json coordSets = atoms["coords"]["3dSets"];
   if (coordSets.is_array() && coordSets.size()) {
@@ -753,6 +761,13 @@ bool CjsonFormat::write(std::ostream& file, const Molecule& molecule)
     labels.push_back(molecule.label(i));
   }
   root["atoms"]["labels"] = labels;
+
+  // formal charges
+  json charges;
+  for (size_t i = 0; i < molecule.atomCount(); ++i) {
+    charges.push_back(molecule.formalCharge(i));
+  }
+  root["atoms"]["charges"] = charges;
 
   auto layer = LayerManager::getMoleculeInfo(&molecule)->layer;
   if (layer.atomCount()) {

--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -237,6 +237,13 @@ public:
         }
       }
 
+      // Check formal charge.
+      attribute = node.attribute("formalCharge");
+      if (attribute) {
+        signed int formalCharge = lexicalCast<signed int>(attribute.value());
+        atom.setFormalCharge(formalCharge);
+      }
+
       // Move on to the next atom node (if there is one).
       node = node.next_sibling("atom");
     }

--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -445,6 +445,13 @@ std::string formatNumber(std::stringstream &s, double n)
   return s.str();
 }
 
+std::string formatNumber(std::stringstream &s, int n)
+{
+  s.str(""); // clear it
+  s << n;
+  return s.str();
+}
+
 bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
 {
   xml_document document;
@@ -456,8 +463,8 @@ bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
   out.imbue(numLocale);  // imbue modified locale
 
   // We also need to set the locale temporarily for XML string formatting
-  std::stringstream floatStream; // use this to format floats as C-format strings
-  floatStream.imbue(numLocale);
+  std::stringstream numberStream; // use this to format floats as C-format strings
+  numberStream.imbue(numLocale);
 
   // Add a custom declaration node.
   xml_node declaration = document.prepend_child(pugi::node_declaration);
@@ -514,12 +521,12 @@ bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
     crystalBetaNode.append_attribute("units") = "units:degree";
     crystalGammaNode.append_attribute("units") = "units:degree";
 
-    crystalANode.text() = formatNumber(floatStream, cell->a()).c_str();
-    crystalBNode.text() = formatNumber(floatStream, cell->b()).c_str();
-    crystalCNode.text() = formatNumber(floatStream, cell->c()).c_str();
-    crystalAlphaNode.text() = formatNumber(floatStream, cell->alpha() * RAD_TO_DEG).c_str();
-    crystalBetaNode.text() = formatNumber(floatStream, cell->beta() * RAD_TO_DEG).c_str();
-    crystalGammaNode.text() = formatNumber(floatStream, cell->gamma() * RAD_TO_DEG).c_str();
+    crystalANode.text() = formatNumber(numberStream, cell->a()).c_str();
+    crystalBNode.text() = formatNumber(numberStream, cell->b()).c_str();
+    crystalCNode.text() = formatNumber(numberStream, cell->c()).c_str();
+    crystalAlphaNode.text() = formatNumber(numberStream, cell->alpha() * RAD_TO_DEG).c_str();
+    crystalBetaNode.text() = formatNumber(numberStream, cell->beta() * RAD_TO_DEG).c_str();
+    crystalGammaNode.text() = formatNumber(numberStream, cell->gamma() * RAD_TO_DEG).c_str();
   }
 
   xml_node atomArrayNode = moleculeNode.append_child("atomArray");
@@ -533,13 +540,17 @@ bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
       Elements::symbol(a.atomicNumber());
     if (cell) {
       Vector3 fracPos = cell->toFractional(a.position3d());
-      atomNode.append_attribute("xFract") = formatNumber(floatStream,fracPos.x()).c_str();
-      atomNode.append_attribute("yFract") = formatNumber(floatStream,fracPos.y()).c_str();
-      atomNode.append_attribute("zFract") = formatNumber(floatStream,fracPos.z()).c_str();
+      atomNode.append_attribute("xFract") = formatNumber(numberStream,fracPos.x()).c_str();
+      atomNode.append_attribute("yFract") = formatNumber(numberStream,fracPos.y()).c_str();
+      atomNode.append_attribute("zFract") = formatNumber(numberStream,fracPos.z()).c_str();
     } else {
-      atomNode.append_attribute("x3") = formatNumber(floatStream,a.position3d().x()).c_str();
-      atomNode.append_attribute("y3") = formatNumber(floatStream,a.position3d().y()).c_str();
-      atomNode.append_attribute("z3") = formatNumber(floatStream,a.position3d().z()).c_str();
+      atomNode.append_attribute("x3") = formatNumber(numberStream,a.position3d().x()).c_str();
+      atomNode.append_attribute("y3") = formatNumber(numberStream,a.position3d().y()).c_str();
+      atomNode.append_attribute("z3") = formatNumber(numberStream,a.position3d().z()).c_str();
+    }
+    if(a.formalCharge() != 0) {
+      atomNode.append_attribute("formalCharge") =
+          formatNumber(numberStream, int(a.formalCharge())).c_str();
     }
   }
 

--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -550,7 +550,7 @@ bool CmlFormat::write(std::ostream& out, const Core::Molecule& mol)
     }
     if(a.formalCharge() != 0) {
       atomNode.append_attribute("formalCharge") =
-          formatNumber(numberStream, int(a.formalCharge())).c_str();
+          formatNumber(numberStream, a.formalCharge()).c_str();
     }
   }
 

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -275,7 +275,7 @@ bool MdlFormat::write(std::ostream& out, const Core::Molecule& mol)
   for (size_t i = 0; i < chargeList.size(); ++i) {
     Index atomIndex = chargeList[i].first;
     signed int atomCharge = chargeList[i].second;
-    out << "M  CHG " << setw(3) << std::right << atomIndex + 1 << " "
+    out << "M  CHG  1 " << setw(3) << std::right << atomIndex + 1 << " "
         << setw(3) << atomCharge << "\n";
   }
   out << "M  END\n";

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -252,16 +252,17 @@ bool MdlFormat::write(std::ostream& out, const Core::Molecule& mol)
   for (size_t i = 0; i < mol.atomCount(); ++i) {
     Atom atom = mol.atom(i);
     signed int charge = atom.formalCharge();
-    chargeList.push_back(std::pair(atom.index(), charge));
+    if (charge)
+      chargeList.push_back(std::pair(atom.index(), charge));
     unsigned int chargeField = (charge < 0)?
         ((charge >= -3)? 4 - charge : 0) :
         ((charge <= 3)? charge : 0);
     out << setw(10) << std::right << std::fixed << setprecision(4)
         << atom.position3d().x() << setw(10) << atom.position3d().y()
         << setw(10) << atom.position3d().z() << " " << setw(3) << std::left
-        << Elements::symbol(atom.atomicNumber()) << "0 "
+        << Elements::symbol(atom.atomicNumber()) << " 0"
         << setw(3) << std::right << chargeField /* for compatibility */
-        << "0  0  0  0  0  0  0  0  0  0  \n";
+        << "  0  0  0  0  0  0  0  0  0  0\n";
   }
   // Bond block.
   for (size_t i = 0; i < mol.bondCount(); ++i) {

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <iostream>
 
 using Avogadro::Core::Atom;
 using Avogadro::Core::Bond;
@@ -91,6 +92,7 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
   }
 
   // Parse the atom block.
+  std::vector<std::pair<size_t, signed int>> chargeList;
   for (int i = 0; i < numAtoms; ++i) {
     Vector3 pos;
     getline(in, buffer);
@@ -111,10 +113,17 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
     }
 
     string element(trimmed(buffer.substr(31, 3)));
+    signed int charge(lexicalCast<int>(trimmed(buffer.substr(36, 3))));
     if (!buffer.empty()) {
       unsigned char atomicNum = Elements::atomicNumberFromSymbol(element);
       Atom newAtom = mol.addAtom(atomicNum);
       newAtom.setPosition3d(pos);
+      // In case there's no CHG property
+      charge = (charge > 4)?
+        ((charge <= 7)? 4 - charge : 0) :
+        ((charge < 4)? charge : 0);
+      if (charge)
+        chargeList.push_back(std::pair(newAtom.index(), charge));
       continue;
     } else {
       appendError("Error parsing atom block: " + buffer);
@@ -149,17 +158,46 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
                 static_cast<unsigned char>(order));
   }
 
-  // Look for the end tag.
+  // Parse the properties block until the end of the file.
+  // Property lines count is not used, as it it now unsupported.
   bool foundEnd(false);
+  bool foundChgProperty(false);
   while (getline(in, buffer)) {
-    if (trimmed(buffer) == "M  END") {
+    string prefix = buffer.substr(0, 6);
+    if (prefix == "M  END") {
       foundEnd = true;
       break;
+    } else if (prefix == "M  CHG") {
+      if (!foundChgProperty)
+        chargeList.clear(); // Forget old-style charges
+      size_t entryCount(lexicalCast<int>(buffer.substr(6, 3), ok));
+      for(size_t i = 0; i < entryCount; i++) {
+        size_t index(lexicalCast<size_t>(buffer.substr(10+8*i, 3), ok) - 1);
+        if (!ok) {
+          appendError("Error parsing charged atom index:" + buffer.substr(10+8*i, 3));
+          return false;
+        }
+        signed int charge(lexicalCast<int>(buffer.substr(14+8*i, 3), ok));
+        if (!ok) {
+          appendError("Error parsing atom charge:" + buffer.substr(14+8*i, 3));
+          return false;
+        }
+        if (charge)
+          chargeList.push_back(std::pair(index, charge));
+      }
     }
   }
+
   if (!foundEnd) {
     appendError("Error, ending tag for file not found.");
     return false;
+  }
+
+  // Apply charges.
+  for (size_t i = 0; i < chargeList.size(); i++) {
+    size_t index = chargeList[i].first;
+    signed int charge = chargeList[i].second;
+    mol.setFormalCharge(index, charge);
   }
 
   // Check that all atoms were handled.
@@ -210,13 +248,20 @@ bool MdlFormat::write(std::ostream& out, const Core::Molecule& mol)
   out << setw(3) << std::right << mol.atomCount() << setw(3) << mol.bondCount()
       << "  0  0  0  0  0  0  0  0999 V2000\n";
   // Atom block.
+  std::vector<std::pair<size_t, signed int>> chargeList;
   for (size_t i = 0; i < mol.atomCount(); ++i) {
     Atom atom = mol.atom(i);
+    signed int charge = atom.formalCharge();
+    chargeList.push_back(std::pair(atom.index(), charge));
+    unsigned int chargeField = (charge < 0)?
+        ((charge >= -3)? 4 - charge : 0) :
+        ((charge <= 3)? charge : 0);
     out << setw(10) << std::right << std::fixed << setprecision(4)
         << atom.position3d().x() << setw(10) << atom.position3d().y()
         << setw(10) << atom.position3d().z() << " " << setw(3) << std::left
-        << Elements::symbol(atom.atomicNumber())
-        << "  0  0  0  0  0  0  0  0  0  0  0  0\n";
+        << Elements::symbol(atom.atomicNumber()) << "0 "
+        << setw(3) << std::right << chargeField /* for compatibility */
+        << "0  0  0  0  0  0  0  0  0  0  \n";
   }
   // Bond block.
   for (size_t i = 0; i < mol.bondCount(); ++i) {
@@ -225,6 +270,13 @@ bool MdlFormat::write(std::ostream& out, const Core::Molecule& mol)
     out << setw(3) << std::right << bond.atom1().index() + 1 << setw(3)
         << bond.atom2().index() + 1 << setw(3) << static_cast<int>(bond.order())
         << "  0  0  0  0\n";
+  }
+  // Properties block.
+  for (size_t i = 0; i < chargeList.size(); ++i) {
+    Index atomIndex = chargeList[i].first;
+    signed int atomCharge = chargeList[i].second;
+    out << "M  CHG " << setw(3) << std::right << atomIndex + 1 << " "
+        << setw(3) << atomCharge << "\n";
   }
   out << "M  END\n";
 

--- a/avogadro/io/mdlformat.h
+++ b/avogadro/io/mdlformat.h
@@ -51,8 +51,11 @@ public:
 
   std::string specificationUrl() const override
   {
-    return "http://download.accelrys.com/freeware/ctfile-formats/"
-           "ctfile-formats.zip";
+    return "http://help.accelrysonline.com/ulm/onelab/1.0/content/ulm_pdfs/direct/"
+           "reference/ctfileformats2016.pdf";
+    /* for previous (2011) version, see:
+    https://web.archive.org/web/20180329184712/http://download.accelrys.com/freeware/ctfile-formats/ctfile-formats.zip
+    */
   }
 
   std::vector<std::string> fileExtensions() const override;

--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -203,7 +203,7 @@ bool PdbFormat::read(std::istream& in, Core::Molecule& mol)
   } // End while loop
   mol.perceiveBondsSimple();
   mol.perceiveBondsFromResidueData();
-  mol.perceiveSubstitutedCations();
+  perceiveSubstitutedCations(mol);
   SecondaryStructureAssigner ssa;
   ssa.assign(&mol);
 
@@ -222,6 +222,52 @@ std::vector<std::string> PdbFormat::mimeTypes() const
   std::vector<std::string> mime;
   mime.push_back("chemical/x-pdb");
   return mime;
+}
+
+void PdbFormat::perceiveSubstitutedCations(Core::Molecule mol)
+{
+  for (Index i = 0; i < mol.atomCount(); i++) {
+    unsigned char requiredBondCount(0);
+    switch(mol.atomicNumber(i)) {
+      case 7:
+      case 15:
+      case 33:
+      case 51:
+        requiredBondCount = 4;
+        break;
+      case 8:
+      case 16:
+      case 34:
+      case 52:
+        requiredBondCount = 3;
+    }
+    if (!requiredBondCount)
+      continue;
+
+    unsigned char bondCount(0);
+    Index j = 0;
+    for (const auto &bond : mol.bonds(i)) {
+      unsigned char otherAtomicNumber(0);
+      Index index1(bond.atom1().index());
+      Index index2(bond.atom2().index());
+      if (index1 == i) {
+        otherAtomicNumber = mol.atomicNumber(index2);
+        bondCount += bond.order();
+      } else if (index2 == i) {
+        otherAtomicNumber = mol.atomicNumber(index1);
+        bondCount += bond.order();
+      }
+      if (otherAtomicNumber && otherAtomicNumber != 6) {
+        bondCount = 0;
+        break;
+      }
+      j++;
+    }
+
+    if (bondCount == requiredBondCount) {
+      mol.setFormalCharge(i, 1);
+    }
+  }
 }
 
 } // namespace Io

--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -224,11 +224,11 @@ std::vector<std::string> PdbFormat::mimeTypes() const
   return mime;
 }
 
-void PdbFormat::perceiveSubstitutedCations(Core::Molecule mol)
+void PdbFormat::perceiveSubstitutedCations(Core::Molecule& molecule)
 {
-  for (Index i = 0; i < mol.atomCount(); i++) {
+  for (Index i = 0; i < molecule.atomCount(); i++) {
     unsigned char requiredBondCount(0);
-    switch(mol.atomicNumber(i)) {
+    switch(molecule.atomicNumber(i)) {
       case 7:
       case 15:
       case 33:
@@ -246,15 +246,15 @@ void PdbFormat::perceiveSubstitutedCations(Core::Molecule mol)
 
     unsigned char bondCount(0);
     Index j = 0;
-    for (const auto &bond : mol.bonds(i)) {
+    for (const auto &bond : molecule.bonds(i)) {
       unsigned char otherAtomicNumber(0);
       Index index1(bond.atom1().index());
       Index index2(bond.atom2().index());
       if (index1 == i) {
-        otherAtomicNumber = mol.atomicNumber(index2);
+        otherAtomicNumber = molecule.atomicNumber(index2);
         bondCount += bond.order();
       } else if (index2 == i) {
-        otherAtomicNumber = mol.atomicNumber(index1);
+        otherAtomicNumber = molecule.atomicNumber(index1);
         bondCount += bond.order();
       }
       if (otherAtomicNumber && otherAtomicNumber != 6) {
@@ -265,7 +265,7 @@ void PdbFormat::perceiveSubstitutedCations(Core::Molecule mol)
     }
 
     if (bondCount == requiredBondCount) {
-      mol.setFormalCharge(i, 1);
+      molecule.setFormalCharge(i, 1);
     }
   }
 }

--- a/avogadro/io/pdbformat.cpp
+++ b/avogadro/io/pdbformat.cpp
@@ -203,6 +203,7 @@ bool PdbFormat::read(std::istream& in, Core::Molecule& mol)
   } // End while loop
   mol.perceiveBondsSimple();
   mol.perceiveBondsFromResidueData();
+  mol.perceiveSubstitutedCations();
   SecondaryStructureAssigner ssa;
   ssa.assign(&mol);
 

--- a/avogadro/io/pdbformat.h
+++ b/avogadro/io/pdbformat.h
@@ -53,7 +53,7 @@ public:
     return false;
   }
 
-  void perceiveSubstitutedCations(Core::Molecule);
+  void perceiveSubstitutedCations(Core::Molecule& molecule);
 };
 
 } // namespace Io

--- a/avogadro/io/pdbformat.h
+++ b/avogadro/io/pdbformat.h
@@ -52,6 +52,8 @@ public:
     // Writing a PDB file is not currently supported
     return false;
   }
+
+  void perceiveSubstitutedCations(Core::Molecule);
 };
 
 } // namespace Io

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -431,7 +431,9 @@ void RWMolecule::appendMolecule(const Molecule& mol, const QString& undoText)
   Index offset = atomCount();
   for (size_t i = 0; i < mol.atomCount(); ++i) {
     Core::Atom atom = mol.atom(i);
-    addAtom(atom.atomicNumber(), atom.position3d());
+    AtomType new_atom = addAtom(atom.atomicNumber(), atom.position3d());
+    new_atom.setFormalCharge(atom.formalCharge());
+
     setAtomSelected(atomCount() - 1, true);
   }
   // now loop through and add the bonds


### PR DESCRIPTION
This Pull Requests improves Avogadro's support for formal charges. First of all, it implements reading them from CML, which also extends to other formats (e.g. SMILES, which is internally converted to CML). Those charges are then passed down the class hierarchy. Secondly, since PDB files can contain quaternary ammonium (e.g. acetylcholine, various drug ligands) or tertiary sulfonium (S-adenosylmethionine), or even quaternary arsonium (https://www.rcsb.org/structure/5NXY) groups, and those cannot be eliminated by hydrogen adjustment, specific code was added to detect those.

Then, the code was made more convergent with other paths so as to allow the various optimization PRs to act on it.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
