### PR TITLE
Bond graph optimization

### DIFF
--- a/avogadro/core/connectedgroup.cpp
+++ b/avogadro/core/connectedgroup.cpp
@@ -196,6 +196,7 @@ std::vector<std::set<size_t>> ConnectedGroup::getAllGroups() const
 
 void ConnectedGroup::resetToSize(size_t n)
 {
+  m_groupToNode.resize(n);
   for (size_t i = 0; i < n; ++i) {
     m_nodeToGroup[i] = i;
     m_groupToNode[i].insert(i);

--- a/avogadro/core/graph.cpp
+++ b/avogadro/core/graph.cpp
@@ -19,6 +19,7 @@
 #include <avogadro/core/connectedgroup.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <set>
 #include <stack>

--- a/avogadro/core/graph.cpp
+++ b/avogadro/core/graph.cpp
@@ -232,6 +232,12 @@ const std::vector<size_t>& Graph::neighbors(size_t index) const
   return m_adjacencyList[index];
 }
 
+const std::vector<size_t>& Graph::edges(size_t index) const
+{
+  assert(index < size());
+  return m_edgeMap[index];
+}
+
 size_t Graph::degree(size_t index) const
 {
   return neighbors(index).size();

--- a/avogadro/core/graph.cpp
+++ b/avogadro/core/graph.cpp
@@ -86,7 +86,7 @@ void Graph::removeVertex(size_t index)
     size_t affectedIndex = m_adjacencyList.size() - 1;
     for (size_t i = 0; i < m_adjacencyList[index].size(); i++) {
       size_t otherIndex = m_adjacencyList[index][i];
-      for (size_t j = 0; i < m_adjacencyList[otherIndex].size(); i++) {
+      for (size_t j = 0; j < m_adjacencyList[otherIndex].size(); j++) {
         if (m_adjacencyList[otherIndex][j] == affectedIndex)
           m_adjacencyList[otherIndex][j] = index;
       }
@@ -231,8 +231,8 @@ void Graph::removeEdge(size_t a, size_t b)
   assert(a < size());
   assert(b < size());
 
-  std::vector<size_t>& neighborsA = m_adjacencyList[a];
-  std::vector<size_t>& neighborsB = m_adjacencyList[b];
+  std::vector<size_t> &neighborsA = m_adjacencyList[a];
+  std::vector<size_t> &neighborsB = m_adjacencyList[b];
 
   std::vector<size_t>::iterator iter =
     std::find(neighborsA.begin(), neighborsA.end(), b);
@@ -261,7 +261,8 @@ void Graph::removeEdge(size_t a, size_t b)
 
   for (size_t i = 0; i < m_edgeMap[b].size(); i++) {
     if (m_edgeMap[b][i] == edgeIndex) {
-      m_edgeMap[b].erase(m_edgeMap[b].begin() + i);
+      std::swap(m_edgeMap[b][i], m_edgeMap[b].back());
+      m_edgeMap[b].pop_back();
       break;
     }
   }
@@ -271,9 +272,9 @@ void Graph::removeEdge(size_t a, size_t b)
 
   size_t affectedIndex = m_edgePairs.size();
   if (affectedIndex != edgeIndex) {
-    auto edgeList1 = m_edgeMap[m_edgePairs[edgeIndex].first];
+    std::vector<size_t> &edgeList1 = m_edgeMap[m_edgePairs[edgeIndex].first];
     *std::find(edgeList1.begin(), edgeList1.end(), affectedIndex) = edgeIndex;
-    auto edgeList2 = m_edgeMap[m_edgePairs[edgeIndex].second];
+    std::vector<size_t> &edgeList2 = m_edgeMap[m_edgePairs[edgeIndex].second];
     *std::find(edgeList2.begin(), edgeList2.end(), affectedIndex) = edgeIndex;
   }
 

--- a/avogadro/core/graph.cpp
+++ b/avogadro/core/graph.cpp
@@ -28,7 +28,9 @@ namespace Core {
 
 Graph::Graph() : m_subgraphs() {}
 
-Graph::Graph(size_t n) : m_adjacencyList(n), m_subgraphs(n) {}
+Graph::Graph(size_t n) :
+    m_adjacencyList(n), m_edgeMap(n), m_edgePairs(), m_subgraphs(n)
+{}
 
 Graph::~Graph() {}
 
@@ -166,6 +168,8 @@ size_t Graph::addEdge(size_t a, size_t b)
 {
   assert(a < size());
   assert(b < size());
+  if (b < a)
+    std::swap(a, b);
   std::vector<size_t> &neighborsA = m_adjacencyList[a];
   std::vector<size_t> &neighborsB = m_adjacencyList[b];
 
@@ -345,7 +349,7 @@ void Graph::swapEdgeIndices(size_t edgeIndex1, size_t edgeIndex2)
   }
   for (size_t i = 0; i < m_edgeMap[pair1.second].size(); i++) {
     if (m_edgeMap[pair1.second][i] == edgeIndex1) {
-      changeTo2[0] = &m_edgeMap[pair1.second][i];
+      changeTo2[1] = &m_edgeMap[pair1.second][i];
     }
   }
   const std::pair<size_t, size_t> &pair2 = m_edgePairs[edgeIndex2];
@@ -357,7 +361,7 @@ void Graph::swapEdgeIndices(size_t edgeIndex1, size_t edgeIndex2)
   }
   for (size_t i = 0; i < m_edgeMap[pair2.second].size(); i++) {
     if (m_edgeMap[pair2.second][i] == edgeIndex2) {
-      changeTo1[0] = &m_edgeMap[pair2.second][i];
+      changeTo1[1] = &m_edgeMap[pair2.second][i];
     }
   }
 
@@ -365,9 +369,9 @@ void Graph::swapEdgeIndices(size_t edgeIndex1, size_t edgeIndex2)
   Swap m_edgeMap values only after reading everything, to avoid race condition.
   */
   *changeTo2[0] = edgeIndex2;
-  *changeTo2[0] = edgeIndex2;
+  *changeTo2[1] = edgeIndex2;
   *changeTo1[0] = edgeIndex1;
-  *changeTo1[0] = edgeIndex1;
+  *changeTo1[1] = edgeIndex1;
 
   std::swap(m_edgePairs[edgeIndex1], m_edgePairs[edgeIndex2]);
 }
@@ -377,22 +381,22 @@ size_t Graph::edgeCount() const
   return m_edgePairs.size();
 }
 
-const std::vector<size_t>& Graph::neighbors(size_t index) const
+const std::vector<size_t> Graph::neighbors(size_t index) const
 {
   assert(index < size());
-  return m_adjacencyList[index];
+  return std::vector<size_t>(m_adjacencyList[index]);
 }
 
-const std::vector<size_t>& Graph::edges(size_t index) const
+const std::vector<size_t> Graph::edges(size_t index) const
 {
   assert(index < size());
-  return m_edgeMap[index];
+  return std::vector<size_t>(m_edgeMap[index]);
 }
 
-const std::pair<size_t, size_t>& Graph::endpoints(size_t index) const
+const std::pair<size_t, size_t> Graph::endpoints(size_t index) const
 {
   assert(index < edgeCount());
-  return m_edgePairs[index];
+  return std::pair<size_t, size_t>(m_edgePairs[index]);
 }
 
 size_t Graph::degree(size_t index) const

--- a/avogadro/core/graph.h
+++ b/avogadro/core/graph.h
@@ -18,6 +18,7 @@
 #define AVOGADRO_CORE_GRAPH_H
 
 #include "avogadrocore.h"
+#include "array.h"
 #include "connectedgroup.h"
 
 #include <cstddef>
@@ -42,16 +43,16 @@ public:
   /** Destroys the graph. */
   ~Graph();
 
-  /** Sets the number of verticies in the graph to size @p n. */
+  /** Sets the number of vertices in the graph to size @p n. */
   void setSize(size_t n);
 
-  /** @return the number of verticies in the graph. */
+  /** @return the number of vertices in the graph. */
   size_t size() const;
 
   /** @return \c true if the graph is empty (i.e. size() == \c 0). */
   bool isEmpty() const;
 
-  /** Removes all verticies and edges from the graph. */
+  /** Removes all vertices and edges from the graph. */
   void clear();
 
   /** Adds a vertex to the graph and returns its index. */
@@ -60,13 +61,13 @@ public:
   /** Removes the vertex at @p index from the graph. */
   void removeVertex(size_t index);
 
-  /** @return the number of verticies in the graph. */
+  /** @return the number of vertices in the graph. */
   size_t vertexCount() const;
 
-  /** Adds an edge between verticies @p a and @p b. */
+  /** Adds an edge between vertices @p a and @p b. */
   void addEdge(size_t a, size_t b);
 
-  /** Removes the edge between veritices @p a and @p b. */
+  /** Removes the edge between vertices @p a and @p b. */
   void removeEdge(size_t a, size_t b);
 
   /** Removes all of the edges from the graph. */
@@ -82,28 +83,34 @@ public:
   size_t edgeCount() const;
 
   /**
-   * @return a vector containing the indicies of each vertex that the vertex at
+   * @return a vector containing the indices of each vertex that the vertex at
    * index shares an edge with.
    */
   const std::vector<size_t>& neighbors(size_t index) const;
+
+  /**
+   * @return a vector containing the indices of each edge that the vertex at
+   * index is an endpoint of.
+   */
+  //const std::vector<size_t>& incidentEdges(size_t index) const;
 
   /** @return the degree of the vertex at @p index. */
   size_t degree(size_t index) const;
 
   /**
-   * @return \c true if the graph contains an edge between verticies @p a and
+   * @return \c true if the graph contains an edge between vertices @p a and
    * @p b.
    */
   bool containsEdge(size_t a, size_t b) const;
 
   /**
-   * @return a vector of vector containing the indicies of each vertex in each
+   * @return a vector of vector containing the indices of each vertex in each
    * connected component in the graph.
    */
   std::vector<std::set<size_t>> connectedComponents() const;
 
   /**
-   * @return a set containing the indicies of each vertex connected with @p
+   * @return a set containing the indices of each vertex connected with @p
    * index.
    */
   std::set<size_t> connectedComponent(size_t index) const;
@@ -125,6 +132,8 @@ public:
 private:
   std::set<size_t> checkConectivity(size_t a, size_t b) const;
   std::vector<std::vector<size_t>> m_adjacencyList;
+  std::vector<std::vector<size_t>> m_edgeMap;
+  Array<std::pair<size_t, size_t>> m_edgePairs;
   ConnectedGroup m_subgraphs;
 };
 

--- a/avogadro/core/graph.h
+++ b/avogadro/core/graph.h
@@ -90,9 +90,9 @@ public:
 
   /**
    * @return a vector containing the indices of each edge that the vertex at
-   * index is an endpoint of.
+   * @p index is an endpoint of; that is, the edges incident at it.
    */
-  //const std::vector<size_t>& incidentEdges(size_t index) const;
+  const std::vector<size_t>& edges(size_t index) const;
 
   /** @return the degree of the vertex at @p index. */
   size_t degree(size_t index) const;

--- a/avogadro/core/graph.h
+++ b/avogadro/core/graph.h
@@ -146,19 +146,19 @@ public:
    * @return a vector containing the indices of each vertex that the vertex at
    * index shares an edge with.
    */
-  const std::vector<size_t>& neighbors(size_t index) const;
+  const std::vector<size_t> neighbors(size_t index) const;
 
   /**
    * @return a vector containing the indices of each edge that the vertex at
    * @p index is an endpoint of; that is, the edges incident at it.
    */
-  const std::vector<size_t>& edges(size_t index) const;
+  const std::vector<size_t> edges(size_t index) const;
 
   /**
    * @return the indices of the two vertices that the edge at @p index connects;
    * that is, its endpoints.
    */
-  const std::pair<size_t, size_t>& endpoints(size_t edgeIndex) const;
+  const std::pair<size_t, size_t> endpoints(size_t edgeIndex) const;
 
   /** @return the degree of the vertex at @p index. */
   size_t degree(size_t index) const;

--- a/avogadro/core/graph.h
+++ b/avogadro/core/graph.h
@@ -30,6 +30,10 @@ namespace Core {
 /**
  * @class Graph graph.h <avogadro/core/graph.h>
  * @brief The Graph class represents a graph data structure.
+ *
+ * A graph consists of vertices and edges, wherein every edge connects two
+ * vertices. Each vertex is assigned an index, starting from 0 up to size() - 1.
+ * Each edge is also assigned an index, from 0 to edgeCount() - 1.
  */
 class AVOGADROCORE_EXPORT Graph
 {
@@ -43,7 +47,18 @@ public:
   /** Destroys the graph. */
   ~Graph();
 
-  /** Sets the number of vertices in the graph to size @p n. */
+  /**
+   * Sets the number of vertices in the graph to size @p n.
+   *
+   * If @p n is smaller than \c size(), this removes all vertices with index
+   * @p n or higher, as well as any edges connected to them, while preserving
+   * all other vertices and edges. These vertices keep their existing indices,
+   * while no guarantee is made regarding preserved edge indices.
+   *
+   * If @p n is larger than \c size(), a number of unconnected vertices are
+   * added, up to the requested size. All existing vertices and edges are
+   * preserved in their current form.
+   */
   void setSize(size_t n);
 
   /** @return the number of vertices in the graph. */
@@ -55,25 +70,54 @@ public:
   /** Removes all vertices and edges from the graph. */
   void clear();
 
-  /** Adds a vertex to the graph and returns its index. */
+  /**
+   * Adds a vertex to the graph and returns its index.
+   * The new vertex is initially not connected. All existing vertices and edges
+   * are preserved and their indices unchanged.
+   */
   size_t addVertex();
 
-  /** Removes the vertex at @p index from the graph. */
+  /**
+   * Removes the vertex at @p index from the graph, as well as all edges to it.
+   * If @p index is not the highest vertex index in the graph, the vertex with
+   * highest index will be assigned the index of the removed vertex. All other
+   * vertices will keep their indices. No guarantees are made regarding edge
+   * indices.
+   */
   void removeVertex(size_t index);
 
-  /** Swaps two vertices' indices, without affecting connectivity */
+  /**
+   * Swaps two vertices' indices, without affecting connectivity.
+   * All other vertices and all edges keep their existing indices.
+   */
   void swapVertexIndices(size_t a, size_t b);
 
   /** @return the number of vertices in the graph. */
   size_t vertexCount() const;
 
-  /** Adds an edge between vertices @p a and @p b. */
-  void addEdge(size_t a, size_t b);
+  /**
+   * Adds an edge between vertices @p a and @p b and returns its index.
+   * All existing vertices and edges are preserved unchanged.
+   */
+  size_t addEdge(size_t a, size_t b);
 
-  /** Removes the edge between vertices @p a and @p b. */
+  /**
+   * Removes the edge between vertices @p a and @p b.
+   * All vertices keep their indices. If the removed edge has an index lower
+   * than the highest edge index in the graph, the edge with the highest index
+   * is given the index of the removed edge. All other edges remain unchanged.
+   */
   void removeEdge(size_t a, size_t b);
 
-  /** Removes all of the edges from the graph. */
+  /**
+   * Removes edge with index @p edgeIndex.
+   * All vertices keep their indices. If @p edgeIndex is lower than the highest
+   * edge index in the graph, the edge with the highest index is given the index
+   * of the removed edge. All other edges remain unchanged.
+   */
+  void removeEdge(size_t edgeIndex);
+
+  /** Removes all of the edges from the graph, without affecting vertices. */
   void removeEdges();
 
   /**
@@ -84,11 +128,15 @@ public:
 
   /**
    * Removes the edge at @p edgeIndex, and creates a new one between vertices
-   * @p a and @p b, with the same index as the removed edge.
+   * @p a and @p b, with the same index as the removed edge. All other edges and
+   * vertices keep their current indices.
    */
   void editEdgeInPlace(size_t edgeIndex, size_t a, size_t b);
 
-  /** Swaps two edges' indices, without affecting connectivity */
+  /**
+   * Swaps two edges' indices, without affecting connectivity.
+   * All other edges and all vertices keep their current indices.
+   */
   void swapEdgeIndices(size_t edgeIndex1, size_t edgeIndex2);
 
   /** @return the number of edges in the graph. */

--- a/avogadro/core/graph.h
+++ b/avogadro/core/graph.h
@@ -61,6 +61,9 @@ public:
   /** Removes the vertex at @p index from the graph. */
   void removeVertex(size_t index);
 
+  /** Swaps two vertices' indices, without affecting connectivity */
+  void swapVertexIndices(size_t a, size_t b);
+
   /** @return the number of vertices in the graph. */
   size_t vertexCount() const;
 
@@ -79,6 +82,15 @@ public:
    */
   void removeEdges(size_t index);
 
+  /**
+   * Removes the edge at @p edgeIndex, and creates a new one between vertices
+   * @p a and @p b, with the same index as the removed edge.
+   */
+  void editEdgeInPlace(size_t edgeIndex, size_t a, size_t b);
+
+  /** Swaps two edges' indices, without affecting connectivity */
+  void swapEdgeIndices(size_t edgeIndex1, size_t edgeIndex2);
+
   /** @return the number of edges in the graph. */
   size_t edgeCount() const;
 
@@ -94,6 +106,12 @@ public:
    */
   const std::vector<size_t>& edges(size_t index) const;
 
+  /**
+   * @return the indices of the two vertices that the edge at @p index connects;
+   * that is, its endpoints.
+   */
+  const std::pair<size_t, size_t>& endpoints(size_t edgeIndex) const;
+
   /** @return the degree of the vertex at @p index. */
   size_t degree(size_t index) const;
 
@@ -102,6 +120,12 @@ public:
    * @p b.
    */
   bool containsEdge(size_t a, size_t b) const;
+
+  /**
+   * @return an array with all edges, where every element contains the indices
+   * of both endpoints of the edge with index equal to the element's array index.
+   */
+  const Array<std::pair<size_t, size_t>>& edgePairs() const;
 
   /**
    * @return a vector of vector containing the indices of each vertex in each

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -434,9 +434,7 @@ bool Molecule::removeBond(Index index)
 {
   if (index >= bondCount())
     return false;
-  auto first = m_graph.endpoints(index).first;
-  auto second = m_graph.endpoints(index).second;
-  m_graph.removeEdge(first, second);
+  m_graph.removeEdge(index);
   m_bondOrders.swapAndPop(index);
   return true;
 }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -530,9 +530,8 @@ void Molecule::clearBonds()
   m_bondPairs.clear();
   m_graph.removeEdges();
   m_graph.setSize(atomCount());
-  for (Index i = 0; i < m_bondMap.size(); i++) {
+  for (Index i = 0; i < m_bondMap.size(); i++)
     m_bondMap[i].clear();
-  }
   m_bondMap.resize(atomCount());
   m_graphDirty = false;
 }
@@ -564,7 +563,7 @@ Molecule::BondType Molecule::bond(Index atomId1, Index atomId2) const
     Index index = m_bondMap[atomId1][i];
     auto &pair = m_bondPairs[index];
     if (pair.first == atomId2 || pair.second == atomId2)
-      return BondType(const_cast<Molecule*>(this), index);
+      return BondType(const_cast<Molecule *>(this), index);
   }
   return BondType();
 }
@@ -577,15 +576,15 @@ Array<Molecule::BondType> Molecule::bonds(const AtomType& a)
   return bonds(a.index());
 }
 
-Array<const Molecule::BondType*> Molecule::bonds(Index a) const
+Array<const Molecule::BondType *> Molecule::bonds(Index a) const
 {
-  Array<const BondType*> atomBonds;
+  Array<const BondType *> atomBonds;
   if (a < atomCount()) {
     for (Index i = 0; i < m_bondMap[a].size(); ++i) {
       Index index = m_bondMap[a][i];
       if (m_bondPairs[index].first == a || m_bondPairs[index].second == a) {
         // work arround to consult bonds without breaking constantness
-        atomBonds.push_back(new BondType(const_cast<Molecule*>(this), index));
+        atomBonds.push_back(new BondType(const_cast<Molecule *>(this), index));
       }
     }
   }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -557,15 +557,14 @@ Molecule::BondType Molecule::bond(Index atomId1, Index atomId2) const
   assert(atomId1 < atomCount());
   assert(atomId2 < atomCount());
 
-  std::pair<Index, Index> pair = Molecule::makeBondPair(atomId1, atomId2);
-  Array<std::pair<Index, Index>>::const_iterator iter =
-    std::find(m_bondPairs.begin(), m_bondPairs.end(), pair);
-
-  Index index = static_cast<Index>(std::distance(m_bondPairs.begin(), iter));
-
-  if (index >= bondCount())
-    return BondType();
-  return BondType(const_cast<Molecule*>(this), index);
+  Index index;
+  for (Index i = 0; i < m_bondMap[atomId1].size(); i++) {
+    Index index = m_bondMap[atomId1][i];
+    auto& pair = m_bondPairs[index];
+    if (pair.first == atomId2 || pair.second == atomId2)
+      return BondType(const_cast<Molecule*>(this), index);
+  }
+  return BondType();
 }
 
 Array<Molecule::BondType> Molecule::bonds(const AtomType& a)

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -975,9 +975,12 @@ bool Molecule::removeBonds(Index atom)
   if (atom >= atomCount())
     return false;
 
-  const std::vector<size_t> &bondList = m_graph.edges(atom);
-  for (Index i = 0; i < bondList.size(); i++) {
-    removeBond(bondList[i]);
+  while(true) {
+    const std::vector<size_t> &bondList = m_graph.edges(atom);
+    if (!bondList.size())
+      break;
+    size_t bond = bondList[0];
+    removeBond(bond);
   }
   return true;
 }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -514,7 +514,7 @@ Array<const Molecule::BondType *> Molecule::bonds(Index a) const
     }
   }
 
-  std::sort(atomBonds.begin(), atomBonds.end(), [](auto a, auto b) {
+  std::sort(atomBonds.begin(), atomBonds.end(), [](const BondType *&a, const BondType *&b) {
     return a->index() < b->index();
   });
   return atomBonds;
@@ -533,7 +533,7 @@ Array<Molecule::BondType> Molecule::bonds(Index a)
     }
   }
 
-  std::sort(atomBonds.begin(), atomBonds.end(), [](auto a, auto b) {
+  std::sort(atomBonds.begin(), atomBonds.end(), [](BondType &a, BondType &b) {
     return a.index() < b.index();
   });
   return atomBonds;

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -361,7 +361,6 @@ bool Molecule::removeAtom(Index index)
   }
 
   removeBonds(index);
-  Index affectedIndex = static_cast<Index>(m_atomicNumbers.size() - 1);
   m_atomicNumbers.swapAndPop(index);
   m_graph.removeVertex(index);
 
@@ -481,7 +480,6 @@ Molecule::BondType Molecule::bond(Index atomId1, Index atomId2) const
   assert(atomId1 < atomCount());
   assert(atomId2 < atomCount());
 
-  Index index;
   const std::vector<Index> &edgeIndices = m_graph.edges(atomId1);
   for (Index i = 0; i < edgeIndices.size(); i++) {
     Index index = edgeIndices[i];
@@ -515,6 +513,10 @@ Array<const Molecule::BondType *> Molecule::bonds(Index a) const
       }
     }
   }
+
+  std::sort(atomBonds.begin(), atomBonds.end(), [](auto a, auto b) {
+    return a->index() < b->index();
+  });
   return atomBonds;
 }
 
@@ -530,6 +532,10 @@ Array<Molecule::BondType> Molecule::bonds(Index a)
         atomBonds.push_back(BondType(this, index));
     }
   }
+
+  std::sort(atomBonds.begin(), atomBonds.end(), [](auto a, auto b) {
+    return a.index() < b.index();
+  });
   return atomBonds;
 }
 

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -398,7 +398,9 @@ bool Molecule::removeAtom(Index index)
   removeBonds(index);
   Index affectedIndex = static_cast<Index>(m_atomicNumbers.size() - 1);
   m_atomicNumbers.swapAndPop(index);
+  std::cout << "Removing atom...\n";
   if (!m_graphDirty) {
+    std::cout << "Removing graph vertex...\n";
     m_graph.removeVertex(index);
     m_bondMap[index] = m_bondMap.back();
     m_bondMap.pop_back();

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -485,7 +485,7 @@ Molecule::BondType Molecule::bond(Index atomId1, Index atomId2) const
   const std::vector<Index> &edgeIndices = m_graph.edges(atomId1);
   for (Index i = 0; i < edgeIndices.size(); i++) {
     Index index = edgeIndices[i];
-    auto &pair = m_graph.endpoints(index);
+    const std::pair<Index, Index> &pair = m_graph.endpoints(index);
     if (pair.first == atomId2 || pair.second == atomId2)
       return BondType(const_cast<Molecule *>(this), index);
   }
@@ -972,16 +972,12 @@ std::map<unsigned char, size_t> Molecule::composition() const
 
 bool Molecule::removeBonds(Index atom)
 {
-  if (atom >= bondCount())
+  if (atom >= atomCount())
     return false;
-  Index i = 0;
-  while (i < m_graph.edgeCount()) {
-    auto& bond = m_graph.endpoints(i);
-    if (bond.first == atom || bond.second == atom) {
-      removeBond(i);
-    } else {
-      ++i;
-    }
+
+  const std::vector<size_t> &bondList = m_graph.edges(atom);
+  for (Index i = 0; i < bondList.size(); i++) {
+    removeBond(bondList[i]);
   }
   return true;
 }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -579,11 +579,13 @@ Array<const Molecule::BondType*> Molecule::bonds(Index a) const
 {
   Array<const BondType*> atomBonds;
   if (a < atomCount()) {
-    for (Index i = 0; i < m_bondPairs.size(); ++i)
-      if (m_bondPairs[i].first == a || m_bondPairs[i].second == a) {
+    for (Index i = 0; i < m_bondMap[a].size(); ++i) {
+      Index index = m_bondMap[a][i];
+      if (m_bondPairs[index].first == a || m_bondPairs[index].second == a) {
         // work arround to consult bonds without breaking constantness
-        atomBonds.push_back(new BondType(const_cast<Molecule*>(this), i));
+        atomBonds.push_back(new BondType(const_cast<Molecule*>(this), index));
       }
+    }
   }
   return atomBonds;
 }
@@ -592,10 +594,11 @@ Array<Molecule::BondType> Molecule::bonds(Index a)
 {
   Array<BondType> atomBonds;
   if (a < atomCount()) {
-    for (Index i = 0; i < bondCount(); ++i) {
-      auto bond = bondPair(i);
+    for (Index i = 0; i < m_bondMap[a].size(); ++i) {
+      Index index = m_bondMap[a][i];
+      auto bond = bondPair(index);
       if (bond.first == a || bond.second == a)
-        atomBonds.push_back(BondType(this, i));
+        atomBonds.push_back(BondType(this, index));
     }
   }
   return atomBonds;
@@ -1076,12 +1079,8 @@ bool Molecule::removeBonds(Index atom)
 Array<std::pair<Index, Index>> Molecule::getAtomBonds(Index index) const
 {
   Array<std::pair<Index, Index>> result;
-  for (auto& pair : m_bondPairs) {
-    if (pair.first == index) {
-      result.push_back(pair);
-    } else if (pair.second == index) {
-      result.push_back(pair);
-    }
+  for (Index i = 0; i < m_bondMap[index].size(); i++) {
+    result.push_back(m_bondPairs[m_bondMap[index][i]]);
   }
   return result;
 }
@@ -1089,14 +1088,8 @@ Array<std::pair<Index, Index>> Molecule::getAtomBonds(Index index) const
 Array<unsigned char> Molecule::getAtomOrders(Index index) const
 {
   Array<unsigned char> result;
-  Index i = 0;
-  for (auto& pair : m_bondPairs) {
-    if (pair.first == index) {
-      result.push_back(m_bondOrders[i]);
-    } else if (pair.second == index) {
-      result.push_back(m_bondOrders[i]);
-    }
-    ++i;
+  for (Index i = 0; i < m_bondMap[index].size(); i++) {
+    result.push_back(m_bondOrders[m_bondMap[index][i]]);
   }
   return result;
 }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -446,6 +446,7 @@ Molecule::BondType Molecule::addBond(Index atom1, Index atom2,
     if (!m_graphDirty) {
       m_graph.addEdge(atom1, atom2);
       m_bondMap[atom1].push_back(m_bondPairs.size());
+      m_bondMap[atom2].push_back(m_bondPairs.size());
     }
     m_bondPairs.push_back(Molecule::makeBondPair(atom1, atom2));
     m_bondOrders.push_back(order);

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -557,10 +557,12 @@ Molecule::BondType Molecule::bond(Index atomId1, Index atomId2) const
   assert(atomId1 < atomCount());
   assert(atomId2 < atomCount());
 
+  updateGraph(); // Because we are reading m_bondMap
+
   Index index;
   for (Index i = 0; i < m_bondMap[atomId1].size(); i++) {
     Index index = m_bondMap[atomId1][i];
-    auto& pair = m_bondPairs[index];
+    auto &pair = m_bondPairs[index];
     if (pair.first == atomId2 || pair.second == atomId2)
       return BondType(const_cast<Molecule*>(this), index);
   }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -395,17 +395,19 @@ bool Molecule::removeAtom(Index index)
     m_selectedAtoms.pop_back();
   }
 
+  removeBonds(index);
   Index affectedIndex = static_cast<Index>(m_atomicNumbers.size() - 1);
   m_atomicNumbers.swapAndPop(index);
-  removeBonds(index);
   if (!m_graphDirty) {
     m_graph.removeVertex(index);
-    m_bondMap.erase(m_bondMap.begin() + index);
+    m_bondMap[index] = m_bondMap.back();
+    m_bondMap.pop_back();
   }
+
   // the bonds from back() now are in index, so we need to rebond it
   rebondBond(index, affectedIndex);
   m_layers.removeAtom(index);
-  return true;
+
   return true;
 }
 

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -697,13 +697,7 @@ protected:
   unsigned short m_hallNumber = 0;
 
 private:
-  /** Update the graph to correspond to the current molecule. */
-  void updateGraph() const;
-
   mutable Graph m_graph;     // A transformation of the molecule to a graph.
-  mutable bool m_graphDirty; // Should the graph be rebuilt?
-  // Bond indices connected to each atom index.
-  mutable std::vector<std::vector<Index>> m_bondMap;
   // edge information
   Array<unsigned char> m_bondOrders;
   // vertex information
@@ -961,7 +955,6 @@ std::pair<Index, Index> Molecule::makeBondPair(const Index& a, const Index& b)
 
 inline Index Molecule::bondCount() const
 {
-  updateGraph();
   assert(m_graph.edgeCount() == m_bondOrders.size());
   return m_graph.edgeCount();
 }
@@ -978,7 +971,6 @@ inline const Array<unsigned char>& Molecule::bondOrders() const
 
 inline const Graph& Molecule::graph() const
 {
-  updateGraph();
   return m_graph;
 }
 

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -699,15 +699,12 @@ protected:
 private:
   /** Update the graph to correspond to the current molecule. */
   void updateGraph() const;
-  // the old atom is dirty and needs a update
-  void rebondBond(Index newIndex, Index oldIndex);
 
   mutable Graph m_graph;     // A transformation of the molecule to a graph.
   mutable bool m_graphDirty; // Should the graph be rebuilt?
   // Bond indices connected to each atom index.
   mutable std::vector<std::vector<Index>> m_bondMap;
   // edge information
-  Array<std::pair<Index, Index>> m_bondPairs;
   Array<unsigned char> m_bondOrders;
   // vertex information
   Array<unsigned char> m_atomicNumbers;
@@ -964,13 +961,14 @@ std::pair<Index, Index> Molecule::makeBondPair(const Index& a, const Index& b)
 
 inline Index Molecule::bondCount() const
 {
-  assert(m_bondPairs.size() == m_bondOrders.size());
-  return m_bondPairs.size();
+  updateGraph();
+  assert(m_graph.edgeCount() == m_bondOrders.size());
+  return m_graph.edgeCount();
 }
 
 inline const Array<std::pair<Index, Index>>& Molecule::bondPairs() const
 {
-  return m_bondPairs;
+  return m_graph.edgePairs();
 }
 
 inline const Array<unsigned char>& Molecule::bondOrders() const
@@ -991,7 +989,7 @@ inline const Array<unsigned char>& Molecule::atomicNumbers() const
 
 inline std::pair<Index, Index> Molecule::bondPair(Index bondId) const
 {
-  return bondId < bondCount() ? m_bondPairs[bondId]
+  return bondId < bondCount() ? m_graph.endpoints(bondId)
                               : std::make_pair(MaxIndex, MaxIndex);
 }
 

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -704,6 +704,8 @@ private:
 
   mutable Graph m_graph;     // A transformation of the molecule to a graph.
   mutable bool m_graphDirty; // Should the graph be rebuilt?
+  // Bond indices connected to each atom index.
+  mutable std::vector<std::vector<Index>> m_bondMap;
   // edge information
   Array<std::pair<Index, Index>> m_bondPairs;
   Array<unsigned char> m_bondOrders;

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -842,11 +842,13 @@ inline Core::Array<RWMolecule::BondType> RWMolecule::bonds(
 inline Core::Array<RWMolecule::BondType> RWMolecule::bonds(
   const Index& atomId) const
 {
+  auto atomBonds = m_molecule.bonds(atomId);
   Core::Array<RWMolecule::BondType> result;
-  for (Index i = 0; i < m_molecule.bondCount(); ++i)
-    if (m_molecule.bondPair(i).first == atomId ||
-        m_molecule.bondPair(i).second == atomId)
-      result.push_back(BondType(const_cast<RWMolecule*>(this), i));
+  for (Index i = 0; i < atomBonds.size(); ++i) {
+    result.push_back(BondType(
+      const_cast<RWMolecule*>(this), atomBonds[i].index()
+    ));
+  }
   return result;
 }
 

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -846,7 +846,7 @@ inline Core::Array<RWMolecule::BondType> RWMolecule::bonds(
   Core::Array<RWMolecule::BondType> result;
   for (Index i = 0; i < atomBonds.size(); ++i) {
     result.push_back(BondType(
-      const_cast<RWMolecule*>(this), atomBonds[i].index()
+      const_cast<RWMolecule *>(this), atomBonds[i].index()
     ));
   }
   return result;


### PR DESCRIPTION
This Pull Request gives a big boost to many Molecule operations. It should make PDB import almost twice as fast (relative to #829), and hydrogen adjustment 15 times faster for macromolecules.

It adds a new member to `Core::Molecule`, a vector of vectors containing the bond indices associated with each particular atom in the molecule. This information could only be obtained in O8n) time, while now it should be O(1). This data is updated in parallel with `m_graph`.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
