### PR TITLE
Optimize secondary structure

### DIFF
--- a/avogadro/core/secondarystructure.cpp
+++ b/avogadro/core/secondarystructure.cpp
@@ -217,11 +217,11 @@ void SecondaryStructureAssigner::assignBackboneHydrogenBonds()
   int n = m_hBonds.size();
   for (unsigned int i = 0; i < n; ++i) {
     auto recordI = m_hBonds[i];
-    auto residueI = m_molecule->residue(recordI->residue);
+    const Residue& residueI = m_molecule->residue(recordI->residue);
 
     for (unsigned int j = i + 1; j < n; ++j) {
       auto recordJ = m_hBonds[j];
-      auto residueJ = m_molecule->residue(recordJ->residue);
+      const Residue& residueJ = m_molecule->residue(recordJ->residue);
 
       // skip if we're not on the same chain
       if (residueI.chainId() != residueJ.chainId())

--- a/avogadro/core/secondarystructure.cpp
+++ b/avogadro/core/secondarystructure.cpp
@@ -217,11 +217,11 @@ void SecondaryStructureAssigner::assignBackboneHydrogenBonds()
   int n = m_hBonds.size();
   for (unsigned int i = 0; i < n; ++i) {
     auto recordI = m_hBonds[i];
-    const Residue& residueI = m_molecule->residue(recordI->residue);
+    const Residue &residueI = m_molecule->residue(recordI->residue);
 
     for (unsigned int j = i + 1; j < n; ++j) {
       auto recordJ = m_hBonds[j];
-      const Residue& residueJ = m_molecule->residue(recordJ->residue);
+      const Residue &residueJ = m_molecule->residue(recordJ->residue);
 
       // skip if we're not on the same chain
       if (residueI.chainId() != residueJ.chainId())


### PR DESCRIPTION
This relatively small change makes secondary structure perception much faster, and thus PDB import up to a further 2x on top of #832 and #829, resulting in a 35 - 50 times faster load time with all three applied.

Since `residueJ` was not declared `const`, the compiler was emitting constructors and destructors that were being run on every iteration of the inner loop, taking up a large part of the total processing time according to `callgrind`.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
