### PR TITLE
Solve problems writing files with no extension

### DIFF
--- a/avogadro/qtgui/fileformatdialog.cpp
+++ b/avogadro/qtgui/fileformatdialog.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "fileformatdialog.h"
@@ -33,9 +22,7 @@ using std::vector;
 namespace Avogadro {
 namespace QtGui {
 
-FileFormatDialog::FileFormatDialog(QWidget* parentW)
-  : QFileDialog(parentW)
-{}
+FileFormatDialog::FileFormatDialog(QWidget* parentW) : QFileDialog(parentW) {}
 
 FileFormatDialog::~FileFormatDialog() {}
 
@@ -90,8 +77,8 @@ FileFormatDialog::FormatFilePair FileFormatDialog::fileToWrite(
   FormatFilePair result(nullptr, QString());
   // Use the default read filter if none specified:
   const QString realFilter = filter.isEmpty() ? writeFileFilter() : filter;
-  
-QString fileName;
+
+  QString fileName;
   do { // jump point for continue statements on retry
     fileName =
       QFileDialog::getSaveFileName(parentWidget, caption, dir, realFilter);
@@ -104,6 +91,24 @@ QString fileName;
 
     // If none found, give user the option to retry.
     if (!format) {
+      QString extension = QFileInfo(fileName).suffix().toLower();
+
+      if (extension.isEmpty()) {
+        QMessageBox::StandardButton reply = QMessageBox::question(
+          parentWidget, caption,
+          tr(
+            "The file extension is missing, so the format cannot be determined."
+            "Do you want to add it?"),
+          QMessageBox::Abort | QMessageBox::Retry, QMessageBox::Retry);
+        switch (reply) {
+          default:
+          case QMessageBox::Retry:
+            continue;
+          case QMessageBox::Abort:
+            return result;
+        }
+      }
+
       QMessageBox::StandardButton reply = QMessageBox::question(
         parentWidget, caption,
         tr("Unable to find a suitable file writer for "
@@ -149,7 +154,7 @@ const Io::FileFormat* FileFormatDialog::findFileFormat(
   QString verb;
   QString key;
 
-  // TODO: This does not work for translation... 
+  // TODO: This does not work for translation...
   //  particularly since len(matches) is known
   if ((formatFlags & FileFormat::Read && formatFlags & FileFormat::Write) ||
       ((formatFlags & FileFormat::Read) == 0 &&
@@ -202,7 +207,7 @@ const QString FileFormatDialog::writeFileFilter()
       FileFormatManager::instance().fileFormats(FileFormat::Write |
                                                 FileFormat::File);
 
-    writeFilter = generateFilterString(formats, AllFiles);
+    writeFilter = generateFilterString(formats, WriteFormats | AllFiles);
   }
 
   return writeFilter;
@@ -246,7 +251,24 @@ QString FileFormatDialog::generateFilterString(
 
   foreach (const QString& desc, formatMap.uniqueKeys()) {
     QStringList extensions;
-    foreach (QString extension, formatMap.values(desc)) {
+    QStringList formatExtensions = formatMap.values(desc);
+
+    // When writing formats, only list one common extension
+    // .. to ensure the OS appends the extension to the filename
+    if (options & WriteFormats) {
+      if (formatExtensions.contains(QStringLiteral("cml")))
+        formatExtensions = QStringList("cml");
+      else if (formatExtensions.contains(QStringLiteral("mol2")))
+        formatExtensions = QStringList("mol2");
+      else if (formatExtensions.contains(QStringLiteral("pdb")))
+        formatExtensions = QStringList("pdb");
+      else if (formatExtensions.contains(QStringLiteral("sdf")))
+        formatExtensions = QStringList("sdf");
+      else if (formatExtensions.contains(QStringLiteral("xyz")))
+        formatExtensions = QStringList("xyz");
+    }
+
+    foreach (QString extension, formatExtensions) {
       if (!nonExtensions.contains(extension))
         extension.prepend("*.");
       extensions << extension;

--- a/avogadro/qtgui/fileformatdialog.h
+++ b/avogadro/qtgui/fileformatdialog.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTGUI_FILEFORMATDIALOG_H
@@ -141,7 +130,8 @@ public: // Must be public for operator declarations
   {
     NoFilterStringOption = 0x0,
     AllFormats = 0x1,
-    AllFiles = 0x2
+    AllFiles = 0x2,
+    WriteFormats = 0x4,
   };
   Q_DECLARE_FLAGS(FilterStringOptions, FilterStringOption)
 


### PR DESCRIPTION
- For common extensions, use only one extension in the filter
- Add better error message if an extension is missing

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
