### PR TITLE
OpenGL: Detaching and deleting shaders/programs on updates

### DIFF
--- a/avogadro/rendering/cylindergeometry.cpp
+++ b/avogadro/rendering/cylindergeometry.cpp
@@ -169,6 +169,11 @@ void CylinderGeometry::update()
     d->program.attachShader(d->fragmentShader);
     if (!d->program.link())
       cout << d->program.error() << endl;
+
+    d->program.detachShader(d->vertexShader);
+    d->program.detachShader(d->fragmentShader);
+    d->vertexShader.cleanup();
+    d->fragmentShader.cleanup();
   }
 }
 

--- a/avogadro/rendering/linestripgeometry.cpp
+++ b/avogadro/rendering/linestripgeometry.cpp
@@ -109,6 +109,11 @@ void LineStripGeometry::update()
     d->program.attachShader(d->fragmentShader);
     if (!d->program.link())
       cout << d->program.error() << endl;
+
+    d->program.detachShader(d->vertexShader);
+    d->program.detachShader(d->fragmentShader);
+    d->vertexShader.cleanup();
+    d->fragmentShader.cleanup();
   }
 }
 

--- a/avogadro/rendering/shaderprogram.cpp
+++ b/avogadro/rendering/shaderprogram.cpp
@@ -103,6 +103,9 @@ ShaderProgram::ShaderProgram()
 
 ShaderProgram::~ShaderProgram()
 {
+  if (m_handle != 0) {
+    glDeleteProgram(static_cast<GLuint>(m_handle));
+  }
 }
 
 bool ShaderProgram::attachShader(const Shader& shader)
@@ -172,7 +175,6 @@ bool ShaderProgram::detachShader(const Shader& shader)
         glDetachShader(static_cast<GLuint>(m_handle),
                        static_cast<GLuint>(shader.handle()));
         m_vertexShader = 0;
-        m_linked = false;
         return true;
       }
     case Shader::Fragment:
@@ -183,7 +185,6 @@ bool ShaderProgram::detachShader(const Shader& shader)
         glDetachShader(static_cast<GLuint>(m_handle),
                        static_cast<GLuint>(shader.handle()));
         m_fragmentShader = 0;
-        m_linked = false;
         return true;
       }
     default:

--- a/avogadro/rendering/spheregeometry.cpp
+++ b/avogadro/rendering/spheregeometry.cpp
@@ -144,6 +144,11 @@ void SphereGeometry::update()
     d->program.attachShader(d->fragmentShader);
     if (!d->program.link())
       cout << d->program.error() << endl;
+
+    d->program.detachShader(d->vertexShader);
+    d->program.detachShader(d->fragmentShader);
+    d->vertexShader.cleanup();
+    d->fragmentShader.cleanup();
   }
 }
 

--- a/avogadro/rendering/textlabelbase.cpp
+++ b/avogadro/rendering/textlabelbase.cpp
@@ -245,6 +245,10 @@ void TextLabelBase::RenderImpl::compileShaders()
     std::cerr << shaderProgram.error() << std::endl;
     return;
   }
+  shaderProgram.detachShader(vertexShader);
+  shaderProgram.detachShader(fragmentShader);
+  vertexShader.cleanup();
+  fragmentShader.cleanup();
 
   shadersInvalid = false;
 }


### PR DESCRIPTION
Background:  
I had issues with Avogadro crashing after some minutes when I was viewing vibrational modes, and I quickly realized it was because Avogadro continually allocated more memory until my RAM+swap was full.

From what I understand, this is because each geometry update (for each animation frame) will trigger `GLWidget::updateScene()`, which clears the rendering `GroupNode` (https://github.com/OpenChemistry/avogadrolibs/blob/master/avogadro/qtopengl/glwidget.cpp#L82) and then rebuilds. During that clearing, the `ShaderProgram` objects get destroyed, however they are not being deleted from OpenGL.

Changing this alone however doesn't fix the issue, so I also added code to detach and delete the shader as soon as `glLinkProgram()` was called (Following [this reference](https://stackoverflow.com/a/43294730)). To avoid relinking the program, I needed to remove the `m_linked = false`. Until now, only `SphereAmbientOcclusionRenderer` has been using `ShaderProgram::detachShader()`, so I hope this change is safe. I only did this for `CylinderGeometry`, `SphereGeometry`, `LineStripGeometry` and `TextLabelBase`, because there I observed the issue to be significant and I could test it.

Doing this greatly reduces the continuous memory allocation, and I could not find any unexpected behaviour. However since I don't know the code well, there might be a different and better solution. Feel free to modify this PR.

I'v attached a NWChem log to test viewing molecular vibrations:
[mode.log](https://github.com/OpenChemistry/avogadrolibs/files/8500207/mode.log)

---

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
