### PR TITLE
Make Navigator transformations relative to center + translation (v2)

### DIFF
--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -133,8 +133,7 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
     case Translation: {
       Vector2f fromScreen(m_lastMousePosition.x(), m_lastMousePosition.y());
       Vector2f toScreen(e->localPos().x(), e->localPos().y());
-      Vector3f ref = m_renderer->scene().center() - m_translation;
-      translate(ref, fromScreen, toScreen);
+      translate(m_renderer->scene().center(), fromScreen, toScreen);
       e->accept();
       break;
     }

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -126,8 +126,7 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
   switch (m_currentAction) {
     case Rotation: {
       QPoint delta = e->pos() - m_lastMousePosition;
-      Vector3f ref = m_renderer->scene().center() - m_translation;
-      rotate(ref, delta.y(), delta.x(), 0);
+      rotate(m_renderer->scene().center(), delta.y(), delta.x(), 0);
       e->accept();
       break;
     }
@@ -141,11 +140,10 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
     }
     case ZoomTilt: {
       QPoint delta = e->pos() - m_lastMousePosition;
-      Vector3f ref = m_renderer->scene().center() - m_translation;
       // Tilt
-      rotate(ref, 0, 0, delta.x());
+      rotate(m_renderer->scene().center(), 0, 0, delta.x());
       // Zoom
-      zoom(ref, delta.y());
+      zoom(m_renderer->scene().center(), delta.y());
       e->accept();
       break;
     }
@@ -197,7 +195,7 @@ QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
 
 QUndoCommand* Navigator::keyPressEvent(QKeyEvent* e)
 {
-  Vector3f ref = m_renderer->scene().center() + m_translation;
+  Vector3f ref = m_renderer->scene().center();
   switch (e->key()) {
     case Qt::Key_Left:
     case Qt::Key_H:

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -185,7 +185,8 @@ QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
   else if (!numDegrees.isNull())
     d = numDegrees.y();
 
-  zoom(m_renderer->scene().center(), m_zoomDirection * d);
+  Vector3f ref = m_renderer->scene().center() - m_translation;
+  zoom(ref, m_zoomDirection * d);
 
   e->accept();
   emit updateRequested();

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -197,7 +197,7 @@ QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
 
 QUndoCommand* Navigator::keyPressEvent(QKeyEvent* e)
 {
-  Vector3f ref = m_renderer->scene().center();
+  Vector3f ref = m_renderer->scene().center() + m_translation;
   switch (e->key()) {
     case Qt::Key_Left:
     case Qt::Key_H:

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -141,10 +141,11 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
     }
     case ZoomTilt: {
       QPoint delta = e->pos() - m_lastMousePosition;
+      Vector3f ref = m_renderer->scene().center() - m_translation;
       // Tilt
-      rotate(m_renderer->scene().center(), 0, 0, delta.x());
+      rotate(ref, 0, 0, delta.x());
       // Zoom
-      zoom(m_renderer->scene().center(), delta.y());
+      zoom(ref, delta.y());
       e->accept();
       break;
     }

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -279,6 +279,11 @@ inline void Navigator::rotate(const Vector3f& ref, float x, float y, float z)
   m_renderer->camera().rotate(y * ROTATION_SPEED, yAxis);
   m_renderer->camera().rotate(z * ROTATION_SPEED, zAxis);
   m_renderer->camera().translate(-ref);
+  m_translation = (
+    Eigen::AngleAxisf(-x * ROTATION_SPEED, xAxis) *
+    Eigen::AngleAxisf(-y * ROTATION_SPEED, yAxis) *
+    Eigen::AngleAxisf(-z * ROTATION_SPEED, zAxis)
+  ) * m_translation;
 }
 
 inline void Navigator::zoom(const Vector3f& ref, float d)

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -134,7 +134,8 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
     case Translation: {
       Vector2f fromScreen(m_lastMousePosition.x(), m_lastMousePosition.y());
       Vector2f toScreen(e->localPos().x(), e->localPos().y());
-      translate(m_renderer->scene().center()/* + m_renderer->camera().translation()*/, fromScreen, toScreen);
+      Vector3f ref = m_renderer->scene().center() - m_translation;
+      translate(ref, fromScreen, toScreen);
       e->accept();
       break;
     }

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -83,6 +83,7 @@ private:
   Qt::MouseButtons m_pressedButtons;
   QPoint m_lastMousePosition;
   int m_zoomDirection;
+  Vector3f m_translation;
 
   enum ToolAction
   {


### PR DESCRIPTION
Prior to this PR, transformations are done relative to the center of the scene. This gives the expected behavior, save for translation: if the user pans the camera away from the starting position, rotation, zoom, etc. will act in a way that doesn't match mouse movements in any meaningful way.

This PR keeps track of the total translation vector and performs all operations relative to the center of the scene minus this vector, which effectively results in a reference point that follows the user, always placing itself in front of the camera. Behavior without panning is preserved, while in other cases it more closely matches user expectation.

The change is small but split into per-transformation changes. Please tell me if any of the transformations should not be given this treatment. Feel free to squash the remaining commits into a single one.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
