### PR TITLE
Remove call for Core::Molecule rendering to eliminate casting

### DIFF
--- a/avogadro/qtgui/sceneplugin.cpp
+++ b/avogadro/qtgui/sceneplugin.cpp
@@ -23,10 +23,6 @@ ScenePlugin::ScenePlugin(QObject* parent_) : QObject(parent_) {}
 
 ScenePlugin::~ScenePlugin() {}
 
-void ScenePlugin::process(const Core::Molecule& molecule,
-                          Rendering::GroupNode& node)
-{}
-
 void ScenePlugin::process(const QtGui::Molecule& molecule,
                           Rendering::GroupNode& node)
 {}

--- a/avogadro/qtgui/sceneplugin.h
+++ b/avogadro/qtgui/sceneplugin.h
@@ -56,9 +56,6 @@ public:
   /**
    * Process the supplied atom, and add the necessary primitives to the scene.
    */
-  virtual void process(const Core::Molecule& molecule,
-                       Rendering::GroupNode& node);
-
   virtual void process(const QtGui::Molecule& molecule,
                        Rendering::GroupNode& node);
 

--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012-13 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "glwidget.h"
@@ -81,12 +70,11 @@ void GLWidget::updateScene()
     Rendering::GroupNode& node = m_renderer.scene().rootNode();
     node.clear();
     Rendering::GroupNode* moleculeNode = new Rendering::GroupNode(&node);
-    QtGui::RWMolecule* rwmol = new QtGui::RWMolecule(*mol, this);
+    QtGui::RWMolecule* rwmol = mol->undoMolecule();
 
     foreach (QtGui::ScenePlugin* scenePlugin,
              m_scenePlugins.activeScenePlugins()) {
       Rendering::GroupNode* engineNode = new Rendering::GroupNode(moleculeNode);
-      scenePlugin->process(static_cast<Core::Molecule>(*mol), *engineNode);
       scenePlugin->process(*mol, *engineNode);
       scenePlugin->processEditable(*rwmol, *engineNode);
     }

--- a/avogadro/qtopengl/glwidget.h
+++ b/avogadro/qtopengl/glwidget.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012-13 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTOPENGL_GLWIDGET_H

--- a/avogadro/qtplugins/crystal/crystalscene.cpp
+++ b/avogadro/qtplugins/crystal/crystalscene.cpp
@@ -6,9 +6,9 @@
 #include "crystalscene.h"
 
 #include <avogadro/core/array.h>
-#include <avogadro/core/molecule.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/qtgui/colorbutton.h>
+#include <avogadro/qtgui/molecule.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/groupnode.h>
 #include <avogadro/rendering/linestripgeometry.h>
@@ -17,6 +17,8 @@
 #include <QtWidgets/QDoubleSpinBox>
 #include <QtWidgets/QFormLayout>
 #include <QtWidgets/QVBoxLayout>
+
+#include <QDebug>
 
 namespace Avogadro {
 namespace QtPlugins {
@@ -43,7 +45,7 @@ CrystalScene::CrystalScene(QObject* p)
 
 CrystalScene::~CrystalScene() {}
 
-void CrystalScene::process(const Molecule& molecule, GroupNode& node)
+void CrystalScene::process(const QtGui::Molecule& molecule, GroupNode& node)
 {
   if (const UnitCell* cell = molecule.unitCell()) {
     GeometryNode* geometry = new GeometryNode;

--- a/avogadro/qtplugins/crystal/crystalscene.h
+++ b/avogadro/qtplugins/crystal/crystalscene.h
@@ -10,6 +10,7 @@
 #include <avogadro/qtgui/sceneplugin.h>
 
 #include <QtGui/QColor> 
+
 namespace Avogadro {
 namespace QtPlugins {
 
@@ -24,7 +25,7 @@ public:
   explicit CrystalScene(QObject* parent = nullptr);
   ~CrystalScene() override;
 
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
   QString name() const override { return tr("Crystal Lattice"); }

--- a/avogadro/qtplugins/force/force.cpp
+++ b/avogadro/qtplugins/force/force.cpp
@@ -1,23 +1,12 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2018 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "force.h"
 
 #include <avogadro/core/elements.h>
-#include <avogadro/core/molecule.h>
+#include <avogadro/qtgui/molecule.h>
 #include <avogadro/rendering/arrowgeometry.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/groupnode.h>
@@ -34,7 +23,7 @@ namespace QtPlugins {
 
 using Core::Array;
 using Core::Elements;
-using Core::Molecule;
+using QtGui::Molecule;
 using Rendering::ArrowGeometry;
 using Rendering::GeometryNode;
 using Rendering::GroupNode;
@@ -43,7 +32,7 @@ Force::Force(QObject* p) : ScenePlugin(p), m_enabled(false) {}
 
 Force::~Force() {}
 
-void Force::process(const Molecule& molecule, Rendering::GroupNode& node)
+void Force::process(const QtGui::Molecule& molecule, Rendering::GroupNode& node)
 {
   GeometryNode* geometry = new GeometryNode;
   node.addChild(geometry);

--- a/avogadro/qtplugins/force/force.h
+++ b/avogadro/qtplugins/force/force.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_WIREFRAME_H
@@ -33,7 +22,7 @@ public:
   explicit Force(QObject* parent = nullptr);
   ~Force() override;
 
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
   QString name() const override { return tr("Force"); }

--- a/avogadro/qtplugins/label/label.cpp
+++ b/avogadro/qtplugins/label/label.cpp
@@ -6,9 +6,9 @@
 #include "label.h"
 
 #include <avogadro/core/elements.h>
-#include <avogadro/core/molecule.h>
 #include <avogadro/core/residue.h>
 #include <avogadro/qtgui/colorbutton.h>
+#include <avogadro/qtgui/molecule.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/scene.h>
 #include <avogadro/rendering/textlabel3d.h>
@@ -230,7 +230,7 @@ Label::Label(QObject* parent_) : QtGui::ScenePlugin(parent_)
 
 Label::~Label() {}
 
-void Label::process(const Core::Molecule& molecule, Rendering::GroupNode& node)
+void Label::process(const QtGui::Molecule& molecule, Rendering::GroupNode& node)
 {
   m_layerManager.load<LayerLabel>();
   for (size_t layer = 0; layer < m_layerManager.layerCount(); ++layer) {

--- a/avogadro/qtplugins/label/label.h
+++ b/avogadro/qtplugins/label/label.h
@@ -30,7 +30,7 @@ public:
   }
 
   QWidget* setupWidget() override;
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
   DefaultBehavior defaultBehavior() const override

--- a/avogadro/qtplugins/meshes/meshes.cpp
+++ b/avogadro/qtplugins/meshes/meshes.cpp
@@ -1,29 +1,16 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "meshes.h"
 
 #include <avogadro/core/array.h>
 #include <avogadro/core/mesh.h>
-#include <avogadro/core/molecule.h>
+#include <avogadro/qtgui/molecule.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/groupnode.h>
 #include <avogadro/rendering/meshgeometry.h>
-
-#include <QtCore/QDebug>
 
 #include <algorithm>
 
@@ -51,14 +38,14 @@ struct Sequence
 };
 } // namespace
 
-void Meshes::process(const Molecule& mol, GroupNode& node)
+void Meshes::process(const QtGui::Molecule& mol, GroupNode& node)
 {
-  GeometryNode* geometry = new GeometryNode;
-  node.addChild(geometry);
-
   unsigned char opacity = 150;
 
   if (mol.meshCount()) {
+    GeometryNode* geometry = new GeometryNode;
+    node.addChild(geometry);
+ 
     const Mesh* mesh = mol.mesh(0);
 
     /// @todo Allow use of MeshGeometry without an index array when all vertices

--- a/avogadro/qtplugins/meshes/meshes.h
+++ b/avogadro/qtplugins/meshes/meshes.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_MESHES_H
@@ -34,7 +23,7 @@ public:
   explicit Meshes(QObject* parent = nullptr);
   ~Meshes() override;
 
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& mol,
                Rendering::GroupNode& node) override;
 
   QString name() const override { return tr("Meshes"); }

--- a/avogadro/qtplugins/qtaim/qtaimengine.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimengine.cpp
@@ -43,14 +43,9 @@ QTAIMEngine::~QTAIMEngine()
 {
 }
 
-void QTAIMEngine::process(const Core::Molecule& coreMolecule,
+void QTAIMEngine::process(const QtGui::Molecule& molecule,
                           Rendering::GroupNode& node)
 {
-  const QtGui::Molecule* molecule =
-    dynamic_cast<const QtGui::Molecule*>(&coreMolecule);
-  if (!molecule)
-    return;
-
   // Create sphere/cylinder nodes.
   GeometryNode* geometry = new GeometryNode;
   node.addChild(geometry);
@@ -60,30 +55,30 @@ void QTAIMEngine::process(const Core::Molecule& coreMolecule,
   geometry->addDrawable(cylinders);
 
   // Render the bond paths
-  if (molecule->property("QTAIMFirstNCPIndexVariantList").isValid() &&
-      molecule->property("QTAIMSecondNCPIndexVariantList").isValid() &&
-      molecule->property("QTAIMLaplacianAtBondCriticalPoints").isValid() &&
-      molecule->property("QTAIMEllipticityAtBondCriticalPoints").isValid() &&
-      molecule->property("QTAIMBondPathSegmentStartIndex").isValid() &&
-      molecule->property("QTAIMBondPathSegmentEndIndex").isValid() &&
-      molecule->property("QTAIMXBondPaths").isValid() &&
-      molecule->property("QTAIMYBondPaths").isValid() &&
-      molecule->property("QTAIMZBondPaths").isValid()) {
+  if (molecule.property("QTAIMFirstNCPIndexVariantList").isValid() &&
+      molecule.property("QTAIMSecondNCPIndexVariantList").isValid() &&
+      molecule.property("QTAIMLaplacianAtBondCriticalPoints").isValid() &&
+      molecule.property("QTAIMEllipticityAtBondCriticalPoints").isValid() &&
+      molecule.property("QTAIMBondPathSegmentStartIndex").isValid() &&
+      molecule.property("QTAIMBondPathSegmentEndIndex").isValid() &&
+      molecule.property("QTAIMXBondPaths").isValid() &&
+      molecule.property("QTAIMYBondPaths").isValid() &&
+      molecule.property("QTAIMZBondPaths").isValid()) {
     QVariant firstNCPIndexVariant =
-      molecule->property("QTAIMFirstNCPIndexVariantList");
+      molecule.property("QTAIMFirstNCPIndexVariantList");
     QVariant secondNCPIndexVariant =
-      molecule->property("QTAIMSecondNCPIndexVariantList");
+      molecule.property("QTAIMSecondNCPIndexVariantList");
     QVariant laplacianAtBondCriticalPointsVariant =
-      molecule->property("QTAIMLaplacianAtBondCriticalPoints");
+      molecule.property("QTAIMLaplacianAtBondCriticalPoints");
     QVariant ellipticityAtBondCriticalPointsVariant =
-      molecule->property("QTAIMEllipticityAtBondCriticalPoints");
+      molecule.property("QTAIMEllipticityAtBondCriticalPoints");
     QVariant bondPathSegmentStartIndexVariant =
-      molecule->property("QTAIMBondPathSegmentStartIndex");
+      molecule.property("QTAIMBondPathSegmentStartIndex");
     QVariant bondPathSegmentEndIndexVariant =
-      molecule->property("QTAIMBondPathSegmentEndIndex");
-    QVariant xBondPathsVariant = molecule->property("QTAIMXBondPaths");
-    QVariant yBondPathsVariant = molecule->property("QTAIMYBondPaths");
-    QVariant zBondPathsVariant = molecule->property("QTAIMZBondPaths");
+      molecule.property("QTAIMBondPathSegmentEndIndex");
+    QVariant xBondPathsVariant = molecule.property("QTAIMXBondPaths");
+    QVariant yBondPathsVariant = molecule.property("QTAIMYBondPaths");
+    QVariant zBondPathsVariant = molecule.property("QTAIMZBondPaths");
 
     QVariantList firstNCPIndexVariantList = firstNCPIndexVariant.toList();
     QVariantList secondNCPIndexVariantList = secondNCPIndexVariant.toList();
@@ -145,15 +140,15 @@ void QTAIMEngine::process(const Core::Molecule& coreMolecule,
     } // bond path
   }
 
-  if (molecule->property("QTAIMXNuclearCriticalPoints").isValid() &&
-      molecule->property("QTAIMYNuclearCriticalPoints").isValid() &&
-      molecule->property("QTAIMZNuclearCriticalPoints").isValid()) {
+  if (molecule.property("QTAIMXNuclearCriticalPoints").isValid() &&
+      molecule.property("QTAIMYNuclearCriticalPoints").isValid() &&
+      molecule.property("QTAIMZNuclearCriticalPoints").isValid()) {
     QVariant xNuclearCriticalPointsVariant =
-      molecule->property("QTAIMXNuclearCriticalPoints");
+      molecule.property("QTAIMXNuclearCriticalPoints");
     QVariant yNuclearCriticalPointsVariant =
-      molecule->property("QTAIMYNuclearCriticalPoints");
+      molecule.property("QTAIMYNuclearCriticalPoints");
     QVariant zNuclearCriticalPointsVariant =
-      molecule->property("QTAIMZNuclearCriticalPoints");
+      molecule.property("QTAIMZNuclearCriticalPoints");
     QVariantList xNuclearCriticalPointsVariantList =
       xNuclearCriticalPointsVariant.toList();
     QVariantList yNuclearCriticalPointsVariantList =
@@ -178,15 +173,15 @@ void QTAIMEngine::process(const Core::Molecule& coreMolecule,
     }
   }
 
-  if (molecule->property("QTAIMXBondCriticalPoints").isValid() &&
-      molecule->property("QTAIMYBondCriticalPoints").isValid() &&
-      molecule->property("QTAIMZBondCriticalPoints").isValid()) {
+  if (molecule.property("QTAIMXBondCriticalPoints").isValid() &&
+      molecule.property("QTAIMYBondCriticalPoints").isValid() &&
+      molecule.property("QTAIMZBondCriticalPoints").isValid()) {
     QVariant xBondCriticalPointsVariant =
-      molecule->property("QTAIMXBondCriticalPoints");
+      molecule.property("QTAIMXBondCriticalPoints");
     QVariant yBondCriticalPointsVariant =
-      molecule->property("QTAIMYBondCriticalPoints");
+      molecule.property("QTAIMYBondCriticalPoints");
     QVariant zBondCriticalPointsVariant =
-      molecule->property("QTAIMZBondCriticalPoints");
+      molecule.property("QTAIMZBondCriticalPoints");
     QVariantList xBondCriticalPointsVariantList =
       xBondCriticalPointsVariant.toList();
     QVariantList yBondCriticalPointsVariantList =
@@ -211,15 +206,15 @@ void QTAIMEngine::process(const Core::Molecule& coreMolecule,
     }
   }
 
-  if (molecule->property("QTAIMXElectronDensitySources").isValid() &&
-      molecule->property("QTAIMYElectronDensitySources").isValid() &&
-      molecule->property("QTAIMZElectronDensitySources").isValid()) {
+  if (molecule.property("QTAIMXElectronDensitySources").isValid() &&
+      molecule.property("QTAIMYElectronDensitySources").isValid() &&
+      molecule.property("QTAIMZElectronDensitySources").isValid()) {
     QVariant xElectronDensitySourcesVariant =
-      molecule->property("QTAIMXElectronDensitySources");
+      molecule.property("QTAIMXElectronDensitySources");
     QVariant yElectronDensitySourcesVariant =
-      molecule->property("QTAIMYElectronDensitySources");
+      molecule.property("QTAIMYElectronDensitySources");
     QVariant zElectronDensitySourcesVariant =
-      molecule->property("QTAIMZElectronDensitySources");
+      molecule.property("QTAIMZElectronDensitySources");
     QVariantList xElectronDensitySourcesVariantList =
       xElectronDensitySourcesVariant.toList();
     QVariantList yElectronDensitySourcesVariantList =

--- a/avogadro/qtplugins/qtaim/qtaimengine.h
+++ b/avogadro/qtplugins/qtaim/qtaimengine.h
@@ -33,7 +33,7 @@ public:
   explicit QTAIMEngine(QObject* parent = nullptr);
   virtual ~QTAIMEngine() override;
 
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
   QString name() const override { return tr("QTAIM"); }

--- a/avogadro/qtplugins/surfaces/surfaces.cpp
+++ b/avogadro/qtplugins/surfaces/surfaces.cpp
@@ -330,6 +330,8 @@ void Surfaces::displayMesh()
   if (!m_cube)
     return;
 
+  qDebug() << " running displayMesh";
+
   if (!m_mesh1)
     m_mesh1 = m_molecule->addMesh();
   if (!m_meshGenerator1) {
@@ -370,6 +372,9 @@ void Surfaces::meshFinished()
       movieFrame();
     } else {
       m_dialog->reenableCalculateButton();
+
+      qDebug() << " mesh finished";
+
       m_molecule->emitChanged(QtGui::Molecule::Added);
     }
   }

--- a/avogadro/qtplugins/symmetry/symmetryscene.cpp
+++ b/avogadro/qtplugins/symmetry/symmetryscene.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "symmetryscene.h"
@@ -119,22 +108,17 @@ SymmetryScene::SymmetryScene(QObject* p)
 
 SymmetryScene::~SymmetryScene() {}
 
-void SymmetryScene::process(const Core::Molecule& coreMolecule,
+void SymmetryScene::process(const QtGui::Molecule& molecule,
                             Rendering::GroupNode& node)
 {
-  const QtGui::Molecule* molecule =
-    dynamic_cast<const QtGui::Molecule*>(&coreMolecule);
-  if (!molecule)
-    return;
-
-  QVariant origo = molecule->property("SymmetryOrigo");
-  QVariant radius = molecule->property("SymmetryRadius");
-  QVariant inversion = molecule->property("SymmetryInversion");
+  QVariant origo = molecule.property("SymmetryOrigo");
+  QVariant radius = molecule.property("SymmetryRadius");
+  QVariant inversion = molecule.property("SymmetryInversion");
   QVariant properRotation =
-    molecule->property("SymmetryProperRotationVariantList");
+    molecule.property("SymmetryProperRotationVariantList");
   QVariant improperRotation =
-    molecule->property("SymmetryImproperRotationVariantList");
-  QVariant reflection = molecule->property("SymmetryReflectionVariantList");
+    molecule.property("SymmetryImproperRotationVariantList");
+  QVariant reflection = molecule.property("SymmetryReflectionVariantList");
   if (!origo.isValid() || !radius.isValid()) {
     return;
   }

--- a/avogadro/qtplugins/symmetry/symmetryscene.h
+++ b/avogadro/qtplugins/symmetry/symmetryscene.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2015 Marcus Johansson <mcodev31@gmail.com>
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SYMMETRYSCENE_H
@@ -35,7 +24,7 @@ public:
   explicit SymmetryScene(QObject* parent = nullptr);
   ~SymmetryScene() override;
 
-  void process(const Core::Molecule& molecule,
+  void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
   void processEditable(const QtGui::RWMolecule& molecule,


### PR DESCRIPTION
Fixes crashes after generating surface meshes (on Mac at least)
.. the Core::Molecule cast would get deleted and a race occurred

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
