### PR TITLE
Import and retain space group information

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -45,6 +45,7 @@ Molecule::Molecule(const Molecule& other)
     m_residues(other.m_residues), m_graph(other.m_graph),
     m_bondOrders(other.m_bondOrders),
     m_atomicNumbers(other.m_atomicNumbers),
+    m_hallNumber(other.m_hallNumber),
     m_layers(LayerManager::getMoleculeLayer(this))
 {
   // Copy the layers, if they exist
@@ -83,6 +84,7 @@ Molecule::Molecule(Molecule&& other) noexcept
     m_residues(std::move(other.m_residues)), m_graph(std::move(other.m_graph)),
     m_bondOrders(std::move(other.m_bondOrders)),
     m_atomicNumbers(std::move(other.m_atomicNumbers)),
+    m_hallNumber(other.m_hallNumber),
     m_layers(LayerManager::getMoleculeLayer(this))
 {
   // Copy the layers, if they exist
@@ -117,6 +119,7 @@ Molecule& Molecule::operator=(const Molecule& other)
     m_graph = other.m_graph;
     m_bondOrders = other.m_bondOrders;
     m_atomicNumbers = other.m_atomicNumbers;
+    m_hallNumber = other.m_hallNumber;
 
     clearMeshes();
 
@@ -168,6 +171,7 @@ Molecule& Molecule::operator=(Molecule&& other) noexcept
     m_graph = std::move(other.m_graph);
     m_bondOrders = std::move(other.m_bondOrders);
     m_atomicNumbers = std::move(other.m_atomicNumbers);
+    m_hallNumber = std::move(other.m_hallNumber);
 
     clearMeshes();
     m_meshes = std::move(other.m_meshes);

--- a/avogadro/core/spacegroups.cpp
+++ b/avogadro/core/spacegroups.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2016 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include <algorithm> // for std::count()
@@ -39,6 +28,43 @@ SpaceGroups::SpaceGroups()
 SpaceGroups::~SpaceGroups()
 {
 }
+
+unsigned short SpaceGroups::hallNumber(const std::string& spaceGroup)
+{
+  unsigned short hall = 0; // can't find anything
+  const unsigned short hall_count = 530;
+
+  // space_group_hall_symbol
+  for (unsigned short i = 0; i < hall_count; ++i) {
+    if (spaceGroup == space_group_hall_symbol[i]) {
+      return i; // found a match
+    }
+  }
+
+  // space_group_international
+  for (unsigned short i = 0; i < hall_count; ++i) {
+    if (spaceGroup == space_group_international[i]) {
+      return i; // found a match
+    }
+  }
+
+  // space_group_international_short
+  for (unsigned short i = 0; i < hall_count; ++i) {
+    if (spaceGroup == space_group_international_short[i]) {
+      return i; // found a match
+    }
+  }
+
+  // space_group_international_full
+  for (unsigned short i = 0; i < hall_count; ++i) {
+    if (spaceGroup == space_group_international_full[i]) {
+      return i; // found a match
+    }
+  }
+
+  return hall; // can't find anything
+}
+
 
 CrystalSystem SpaceGroups::crystalSystem(unsigned short hallNumber)
 {

--- a/avogadro/core/spacegroups.h
+++ b/avogadro/core/spacegroups.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2016 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_CORE_SPACE_GROUPS_H
@@ -53,49 +42,54 @@ public:
   ~SpaceGroups();
 
   /**
-   * Get an enum representing the crystal system for a given hall number.
+   * @return The hall number of the matching space group string or 0 if not found
+   */
+  static unsigned short hallNumber(const std::string& spaceGroup);
+
+  /**
+   * @return an enum representing the crystal system for a given hall number.
    * If an invalid hall number is given, None will be returned.
    */
   static CrystalSystem crystalSystem(unsigned short hallNumber);
 
   /**
-   * Get the international number for a given hall number.
+   * @return the international number for a given hall number.
    * If an invalid hall number is given, 0 will be returned.
    */
   static unsigned short internationalNumber(unsigned short hallNumber);
 
   /**
-   * Get the Schoenflies symbol for a given hall number.
+   * @return the Schoenflies symbol for a given hall number.
    * If an invalid hall number is given, an empty string will be returned.
    */
   static const char* schoenflies(unsigned short hallNumber);
 
   /**
-   * Get the Hall symbol for a given hall number. '=' is used instead of '"'.
+   * @return the Hall symbol for a given hall number. '=' is used instead of '"'.
    * If an invalid hall number is given, an empty string will be returned.
    */
   static const char* hallSymbol(unsigned short hallNumber);
 
   /**
-   * Get the international symbol for a given hall number.
+   * @return the international symbol for a given hall number.
    * If an invalid hall number is given, an empty string will be returned.
    */
   static const char* international(unsigned short hallNumber);
 
   /**
-   * Get the full international symbol for a given hall number.
+   * @return the full international symbol for a given hall number.
    * If an invalid hall number is given, an empty string will be returned.
    */
   static const char* internationalFull(unsigned short hallNumber);
 
   /**
-   * Get the short international symbol for a given hall number.
+   * @return the short international symbol for a given hall number.
    * If an invalid hall number is given, an empty string will be returned.
    */
   static const char* internationalShort(unsigned short hallNumber);
 
   /**
-   * Get the setting for a given hall number.
+   * @return the setting for a given hall number.
    * If an invalid hall number is given, an empty string will be returned.
    * An empty string may also be returned if there are no settings for this
    * space group.
@@ -103,13 +97,13 @@ public:
   static const char* setting(unsigned short hallNumber);
 
   /**
-   * Get the number of transforms for a given hall number.
+   * @return the number of transforms for a given hall number.
    * If an invalid hall number is given, 0 will be returned.
    */
   static unsigned short transformsCount(unsigned short hallNumber);
 
   /**
-   * Get an array of transforms for a given hall number and a vector v.
+   * @return an array of transforms for a given hall number and a vector v.
    * The vector should be in fractional coordinates.
    * If an invalid hall number is given, an empty array will be returned.
    */

--- a/avogadro/io/cmlformat.h
+++ b/avogadro/io/cmlformat.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2012 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_IO_CMLFORMAT_H

--- a/avogadro/io/mmtfformat.cpp
+++ b/avogadro/io/mmtfformat.cpp
@@ -10,6 +10,7 @@
 #include <avogadro/core/gaussianset.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/residue.h>
+#include <avogadro/core/spacegroups.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/core/utilities.h>
 

--- a/avogadro/io/mmtfformat.cpp
+++ b/avogadro/io/mmtfformat.cpp
@@ -86,6 +86,14 @@ bool MMTFFormat::read(std::istream& file, Molecule& molecule)
     molecule.setUnitCell(unitCellObject);
   }
   // spaceGroup
+  if (structure.spaceGroup.size() > 0) {
+    unsigned short hall = 0;
+    hall = Core::SpaceGroups::hallNumber(structure.spaceGroup);
+
+    if (hall != 0) {
+      molecule.setHallNumber(hall);
+    }
+  }
 
   Index modelChainCount =
     static_cast<Index>(structure.chainsPerModel[modelIndex]);

--- a/avogadro/qtplugins/spacegroup/spacegroup.cpp
+++ b/avogadro/qtplugins/spacegroup/spacegroup.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2016 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "spacegroup.h"
@@ -277,8 +266,11 @@ void SpaceGroup::symmetrize()
 
 void SpaceGroup::fillUnitCell()
 {
-  // Ask the user to select a space group
-  unsigned short hallNumber = selectSpaceGroup();
+  unsigned short hallNumber = m_molecule->hallNumber();
+
+  // If it's not set, ask the user to select a space group
+  if (hallNumber == 0)
+    hallNumber = selectSpaceGroup();
   // If the hall number is zero, the user canceled
   if (hallNumber == 0)
     return;

--- a/avogadro/qtplugins/spacegroup/spacegroup.h
+++ b/avogadro/qtplugins/spacegroup/spacegroup.h
@@ -1,18 +1,7 @@
-/*******************************************************************************
-
+/******************************************************************************
   This source file is part of the Avogadro project.
-
-  Copyright 2016 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-*******************************************************************************/
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SPACEGROUP_H
 #define AVOGADRO_QTPLUGINS_SPACEGROUP_H


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
