### PR TITLE
Fix Valgrind uninitialized errors

### DIFF
--- a/avogadro/qtplugins/overlayaxes/overlayaxes.cpp
+++ b/avogadro/qtplugins/overlayaxes/overlayaxes.cpp
@@ -234,7 +234,8 @@ void OverlayAxes::RenderImpl::addAxis(const Vector3f& axis,
 
 OverlayAxes::OverlayAxes(QObject* parent_)
   : Avogadro::QtGui::ExtensionPlugin(parent_), m_render(new RenderImpl),
-    m_axesAction(new QAction(tr("Reference Axes"), this)), m_initialized(false)
+    m_axesAction(new QAction(tr("Reference Axes"), this)), m_initialized(false),
+    m_glWidget(nullptr)
 {
   connect(m_axesAction, SIGNAL(triggered()), SLOT(processAxes()));
 

--- a/avogadro/rendering/camera.cpp
+++ b/avogadro/rendering/camera.cpp
@@ -25,7 +25,8 @@ namespace Rendering {
 
 Camera::Camera()
   : m_width(0), m_height(0), m_projectionType(Perspective),
-    m_orthographicScale(1.0), m_data(new EigenData)
+    m_orthographicScale(1.0), m_data(new EigenData),
+    m_focus(NAN, NAN, NAN)
 {
   m_data->projection.setIdentity();
   m_data->modelView.setIdentity();

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -129,7 +129,7 @@ void GLRenderer::resetCamera()
 void GLRenderer::resetGeometry()
 {
   m_scene.setDirty(true);
-  if (m_camera.focus() == m_center)
+  if (m_camera.focus()(0) != m_camera.focus()(0) || m_camera.focus() == m_center)
     m_camera.setFocus(m_scene.center());
   m_center = m_scene.center();
   m_radius = m_scene.radius();

--- a/avogadro/rendering/shaderprogram.cpp
+++ b/avogadro/rendering/shaderprogram.cpp
@@ -441,7 +441,7 @@ bool ShaderProgram::setAttributeArrayInternal(
 
 void ShaderProgram::initializeTextureUnits()
 {
-  GLint numTextureUnits;
+  GLint numTextureUnits = 0;
   glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &numTextureUnits);
 
   // We'll impose a hard limit of 32 texture units for symbolic lookups.


### PR DESCRIPTION
A small change, but it's necessary if a Valgrind CI test is eventually put in place. Now something like `valgrind --tool=memcheck --error-exitcode=1 ./avogadrolibs/bin/AvogadroTests` should work as expected (e.g. right now all tests exit with zero status, except `AvogadroQtGuiTests`, which detects 2 unitialized value errors).

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
