### PR TITLE
Revert "Use signed mac package"

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -201,44 +201,6 @@ jobs:
           message(FATAL_ERROR "Running tests failed!")
         endif()
 
-    - name: Install the Apple certificate
-      # From GitHub docs: https://docs.github.com/en/actions/guides/installing-an-apple-certificate-on-macos-runners-for-xcode-development
-      if: runner.os == 'macOS'
-      working-directory: ${{ runner.workspace }}/build
-      env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        NOTARIZE_USERNAME: ${{ secrets.AC_USERNAME }}
-        NOTARIZE_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        PRODUCT_BUNDLE_IDENTIFIER: cc.avogadro
-      run: |
-        # create variables
-        if [ -n "${P12_PASSWORD}" ]; then
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          # check that it was created properly
-          ls -l $CERTIFICATE_PATH
-          md5 $CERTIFICATE_PATH
-
-          # create temporary keychain if the cert is non-zero
-          if [ -s $CERTIFICATE_PATH ]; then
-            security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-            security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-            security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-            # import certificate to keychain
-            security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-            security list-keychain -d user -s $KEYCHAIN_PATH
-
-            # code-sign app
-            codesign --deep -s "Developer ID Application: Geoffrey Hutchison" -v prefix/Avogadro2.app
-          fi # certificate exists
-        fi # password exists
-
     - name: Pack
       if: matrix.config.artifact != 0
       run: cpack ${{ matrix.config.cpack_flags }}
@@ -263,18 +225,6 @@ jobs:
         # remove the cpack files
         rm avogadroapp/Avogadro2*Linux.*
       working-directory: ${{ runner.workspace }}/build
-
-    - name: Notarize Mac DMG
-      if: runner.os == 'macOS'
-      run: |
-        # check if we have the password and the username
-        if [ -n "${NOTARIZE_PASSWORD}" ] && [ -n "${NOTARIZE_USERNAME}" ]; then
-          npx notarize-cli --file "build/avogadroapp/Avogadro2*.dmg"
-        fi
-      env:
-        NOTARIZE_USERNAME: ${{ secrets.AC_USERNAME }}
-        NOTARIZE_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        PRODUCT_BUNDLE_IDENTIFIER: cc.avogadro
 
     - name: Setup tmate session
       if: ${{ failure() }}


### PR DESCRIPTION
Reverts OpenChemistry/avogadrolibs#885

We need to use the CPACK_PRE_BUILD_SCRIPTS in `avogadroapp` to sign. Right now, the signature is broken, which is worse than no signature.