### PR TITLE
Fix NeighborPerceiver not handling coordinates below the minimum

### DIFF
--- a/avogadro/core/neighborperceiver.cpp
+++ b/avogadro/core/neighborperceiver.cpp
@@ -37,7 +37,7 @@ NeighborPerceiver::NeighborPerceiver(const Array<Vector3> points, float maxDista
   );
   m_bins = bins;
   for (Index i = 0; i < points.size(); i++) {
-    std::array<size_t, 3> bin_index = getBinIndex(points[i]);
+    std::array<int, 3> bin_index = getBinIndex(points[i]);
     m_bins.at(bin_index[0]).at(bin_index[1]).at(bin_index[2]).push_back(i);
   }
 }
@@ -45,12 +45,12 @@ NeighborPerceiver::NeighborPerceiver(const Array<Vector3> points, float maxDista
 const Array<Index> NeighborPerceiver::getNeighbors(const Vector3 point) const
 {
   Array<Index> r;
-  const std::array<size_t, 3> bin_index = getBinIndex(point);
-  for (size_t xi = std::max(size_t(1), bin_index[0]) - 1;
+  const std::array<int, 3> bin_index = getBinIndex(point);
+  for (int xi = std::max(int(1), bin_index[0]) - 1;
       xi < std::min(m_binCount[0], bin_index[0] + 2); xi++) {
-    for (size_t yi = std::max(size_t(1), bin_index[1]) - 1;
+    for (int yi = std::max(int(1), bin_index[1]) - 1;
         yi < std::min(m_binCount[1], bin_index[1] + 2); yi++) {
-      for (size_t zi = std::max(size_t(1), bin_index[2]) - 1;
+      for (int zi = std::max(int(1), bin_index[2]) - 1;
           zi < std::min(m_binCount[2], bin_index[2] + 2); zi++) {
         std::vector<Index> bin = m_bins[xi][yi][zi];
         r.insert(r.end(), bin.begin(), bin.end());
@@ -60,9 +60,9 @@ const Array<Index> NeighborPerceiver::getNeighbors(const Vector3 point) const
   return r;
 }
 
-const std::array<size_t, 3> NeighborPerceiver::getBinIndex(const Vector3 point) const
+const std::array<int, 3> NeighborPerceiver::getBinIndex(const Vector3 point) const
 {
-  std::array<size_t, 3> r;
+  std::array<int, 3> r;
   for (size_t c = 0; c < 3; c++) {
     r[c] = std::floor((point(c) - m_minPos(c)) / m_maxDistance);
   }

--- a/avogadro/core/neighborperceiver.h
+++ b/avogadro/core/neighborperceiver.h
@@ -43,10 +43,10 @@ public:
   const Array<Index> getNeighbors(const Vector3 point) const;
   
 private:
-  const std::array<size_t, 3> getBinIndex(const Vector3 point) const;
+  const std::array<int, 3> getBinIndex(const Vector3 point) const;
 protected:
   float m_maxDistance;
-  std::array<size_t, 3> m_binCount;
+  std::array<int, 3> m_binCount;
   std::vector<std::vector<std::vector<std::vector<Index>>>> m_bins;
   Vector3 m_minPos;
   Vector3 m_maxPos;

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -14,6 +14,7 @@ set(tests
   Mesh
   Molecule
   Mutex
+  NeighborPerceiver
   RingPerceiver
   Spacegroup
   Utilities

--- a/tests/core/neighborperceivertest.cpp
+++ b/tests/core/neighborperceivertest.cpp
@@ -1,0 +1,61 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/array.h>
+#include <avogadro/core/neighborperceiver.h>
+#include <avogadro/core/vector.h>
+
+using Avogadro::Core::Array;
+using Avogadro::Core::NeighborPerceiver;
+using Avogadro::Vector3;
+
+TEST(NeighborPerceiverTest, positive)
+{
+  Array<Vector3> points;
+  points.push_back(Vector3(0.0, 0.0, 0.0));
+  points.push_back(Vector3(1.0, 0.0, 0.0));
+  points.push_back(Vector3(0.0, 1.5, 1.5));
+  points.push_back(Vector3(2.1, 0.0, 0.0));
+  
+  NeighborPerceiver perceiver(points, 1.0f);
+  
+  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(3));
+}
+
+TEST(NeighborPerceiverTest, negative)
+{
+  Array<Vector3> points;
+  points.push_back(Vector3(0.0, 0.0, 0.0));
+  points.push_back(Vector3(-1.0, 0.0, 0.0));
+  points.push_back(Vector3(0.0, -1.5, -1.5));
+  points.push_back(Vector3(-2.1, 0.0, 0.0));
+  
+  NeighborPerceiver perceiver(points, 1.0f);
+  
+  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(3));
+}
+
+TEST(NeighborPerceiverTest, bounds)
+{
+  Array<Vector3> points;
+  points.push_back(Vector3(0.0, 0.0, 0.0));
+  
+  NeighborPerceiver perceiver(points, 1.0f);
+  
+  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
+  neighbors = perceiver.getNeighbors(Vector3(1.5, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
+  neighbors = perceiver.getNeighbors(Vector3(2.5, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(0));
+  neighbors = perceiver.getNeighbors(Vector3(-0.5, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
+  neighbors = perceiver.getNeighbors(Vector3(-1.5, 0.0, 0.0));
+  EXPECT_EQ(neighbors.size(), static_cast<size_t>(0));
+}


### PR DESCRIPTION
This is a bug I found while working on the still in-progress surface code. It prevents calculating part of the surface, but is generally an issue for any consumer of the `NeighborPerceiver` API.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
