### PR TITLE
Create new layer from selection

### DIFF
--- a/avogadro/qtgui/layermodel.cpp
+++ b/avogadro/qtgui/layermodel.cpp
@@ -158,6 +158,8 @@ void LayerModel::addMolecule(const Molecule* mol)
   RWLayerManager::addMolecule(mol);
   m_item = 0;
   updateRows();
+
+  connect(mol, &Molecule::changed, this, &LayerModel::updateRows);
 }
 
 void LayerModel::setActiveLayer(int index, RWMolecule* rwmolecule)

--- a/avogadro/qtgui/layermodel.cpp
+++ b/avogadro/qtgui/layermodel.cpp
@@ -75,7 +75,7 @@ QVariant LayerModel::data(const QModelIndex& idx, int role) const
     if (idx.column() == ColumnType::Name) {
       switch (role) {
         case Qt::DisplayRole: {
-          return QString("%1 %2").arg(name.c_str()).arg(layer + 1); // count starts at 0 internally
+          return QString("Layer %1").arg(layer + 1); // count starts at 0 internally
         }
         case Qt::ForegroundRole:
           if (layer == static_cast<int>(getMoleculeLayer().activeLayer()))

--- a/avogadro/qtgui/molecule.h
+++ b/avogadro/qtgui/molecule.h
@@ -72,7 +72,7 @@ public:
     Bonds = 0x02,
     UnitCell = 0x04,
     Selection = 0x08,
-    Layer = 0x16,
+    Layers = 0x16,
     /** Operations that can affect the above types. */
     Added = 0x1024,
     Removed = 0x2048,

--- a/avogadro/qtgui/molecule.h
+++ b/avogadro/qtgui/molecule.h
@@ -71,6 +71,8 @@ public:
     Atoms = 0x01,
     Bonds = 0x02,
     UnitCell = 0x04,
+    Selection = 0x08,
+    Layer = 0x16,
     /** Operations that can affect the above types. */
     Added = 0x1024,
     Removed = 0x2048,

--- a/avogadro/qtgui/rwlayermanager.cpp
+++ b/avogadro/qtgui/rwlayermanager.cpp
@@ -9,6 +9,7 @@
 #include <avogadro/core/molecule.h>
 
 #include <QtCore/QObject>
+#include <QtCore/QDebug>
 #include <QtWidgets/QUndoCommand>
 #include <QtWidgets/QUndoStack>
 #include <cassert>

--- a/avogadro/qtgui/rwlayermanager.cpp
+++ b/avogadro/qtgui/rwlayermanager.cpp
@@ -36,6 +36,19 @@ public:
   {
     m_visible = true;
     m_locked = false;
+
+    const auto activeLayer = m_moleculeInfo->layer.activeLayer();
+    // we loop through the layers to find enabled settings for the active layer
+    for (const auto& names : m_moleculeInfo->enable) {
+      bool value = names.second[activeLayer];
+      m_enable[names.first] = value;
+    }
+    // now we do the same thing for settings
+    for (const auto& names : m_moleculeInfo->settings) {
+      auto value = names.second[activeLayer];
+      m_settings[names.first] = value;
+    }
+
   }
 
   void redo() override
@@ -43,8 +56,13 @@ public:
     m_moleculeInfo->visible.push_back(m_visible);
     m_moleculeInfo->locked.push_back(m_locked);
 
-    for (auto& enable : m_enable) {
+    // it's confusing to create an empty layer
+    //  .. so we just create a layer that matches the active layer
+    for (const auto& enable : m_enable) {
       m_moleculeInfo->enable[enable.first].push_back(enable.second);
+    }
+    for (const auto& settings : m_settings) {
+      m_moleculeInfo->settings[settings.first].push_back(settings.second);
     }
 
     m_moleculeInfo->layer.addLayer();

--- a/avogadro/qtplugins/select/select.h
+++ b/avogadro/qtplugins/select/select.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2016 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SELECT_H
@@ -53,6 +42,8 @@ private slots:
   void selectAtomIndex();
   void selectElement(int element);
   void selectResidue();
+
+  void createLayerFromSelection();
 
 private:
   QList<QAction*> m_actions;

--- a/avogadro/qtplugins/selectiontool/selectiontool.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontool.cpp
@@ -267,8 +267,9 @@ void SelectionTool::applyLayer(int layer)
   }
   RWMolecule* rwmol = m_molecule->undoMolecule();
   rwmol->beginMergeMode(tr("Change Layer"));
+  Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Modified;
 
-  qDebug() << "SelectionTool::applyLayer" << layer << " layerCount " << m_layerManager.layerCount();
+  // qDebug() << "SelectionTool::applyLayer" << layer << " layerCount " << m_layerManager.layerCount();
   if (layer >= m_layerManager.layerCount()) {
     // add a new layer
     auto& layerInfo = Core::LayerManager::getMoleculeInfo(m_molecule)->layer;
@@ -278,7 +279,7 @@ void SelectionTool::applyLayer(int layer)
     layer = layerInfo.maxLayer();
 
     // check to enable the same rendering in this new layer
-    qDebug() << "SelectionTool::applyLayer: " << activeLayer << " " << layer;
+    // qDebug() << "SelectionTool::applyLayer: " << activeLayer << " " << layer;
     auto moleculeInfo = Core::LayerManager::getMoleculeInfo(m_molecule);
     for (const auto& names : moleculeInfo->enable) {
       auto values = names.second;
@@ -287,6 +288,10 @@ void SelectionTool::applyLayer(int layer)
 
       moleculeInfo->enable[names.first] = values;
     }
+
+    // update the menu too
+    m_toolWidget->setDropDown(layer, m_layerManager.layerCount());
+    changes |= Molecule::Layers | Molecule::Added;
   }
 
   for (Index i = 0; i < rwmol->atomCount(); ++i) {
@@ -296,7 +301,7 @@ void SelectionTool::applyLayer(int layer)
     }
   }
   rwmol->endMergeMode();
-  rwmol->emitChanged(Molecule::Atoms | Molecule::Modified);
+  rwmol->emitChanged(changes);
 }
 
 void SelectionTool::selectLinkedMolecule(QMouseEvent* e, Index atom)

--- a/avogadro/qtplugins/selectiontool/selectiontool.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontool.cpp
@@ -263,6 +263,13 @@ void SelectionTool::applyLayer(int layer)
   if (layer < 0) {
     return;
   }
+  if (layer > m_layerManager.layerCount()) {
+    // add a new layer
+    auto& layerInfo = Core::LayerManager::getMoleculeInfo(m_molecule)->layer;
+    layerInfo.addLayer();
+    layer = layerInfo.maxLayer();
+  }
+
   RWMolecule* rwmol = m_molecule->undoMolecule();
   rwmol->beginMergeMode(tr("Change Layer"));
   for (Index i = 0; i < rwmol->atomCount(); ++i) {

--- a/avogadro/qtplugins/selectiontool/selectiontool.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontool.cpp
@@ -259,23 +259,9 @@ void SelectionTool::applyLayer(int layer)
   if (layer >= m_layerManager.layerCount()) {
     // add a new layer
     auto& layerInfo = Core::LayerManager::getMoleculeInfo(m_molecule)->layer;
-    const auto activeLayer = layerInfo.activeLayer();
     QtGui::RWLayerManager rwLayerManager;
     rwLayerManager.addLayer(rwmol);
     layer = layerInfo.maxLayer();
-
-    // check to enable the same rendering in this new layer
-    // qDebug() << "SelectionTool::applyLayer: " << activeLayer << " " << layer;
-    /*
-    auto moleculeInfo = Core::LayerManager::getMoleculeInfo(m_molecule);
-    for (const auto& names : moleculeInfo->enable) {
-      auto values = names.second;
-      bool value = values[activeLayer];
-      values.push_back(value);
-
-      moleculeInfo->enable[names.first] = values;
-    }
-    */
 
     // update the menu too
     m_toolWidget->setDropDown(layer, m_layerManager.layerCount());

--- a/avogadro/qtplugins/selectiontool/selectiontool.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontool.cpp
@@ -1,21 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  Adapted from Avogadro 1.x with the following authors' permission:
-  Copyright 2007 Donald Ephraim Curtis
-  Copyright 2008 Marcus D. Hanwell
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "selectiontool.h"
@@ -262,14 +247,15 @@ void SelectionTool::applyColor(Vector3ub color)
 
 void SelectionTool::applyLayer(int layer)
 {
-  if (layer < 0) {
+  if (layer < 0 || m_molecule == nullptr) {
     return;
   }
   RWMolecule* rwmol = m_molecule->undoMolecule();
   rwmol->beginMergeMode(tr("Change Layer"));
   Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Modified;
 
-  // qDebug() << "SelectionTool::applyLayer" << layer << " layerCount " << m_layerManager.layerCount();
+  // qDebug() << "SelectionTool::applyLayer" << layer << " layerCount " <<
+  // m_layerManager.layerCount();
   if (layer >= m_layerManager.layerCount()) {
     // add a new layer
     auto& layerInfo = Core::LayerManager::getMoleculeInfo(m_molecule)->layer;
@@ -280,6 +266,7 @@ void SelectionTool::applyLayer(int layer)
 
     // check to enable the same rendering in this new layer
     // qDebug() << "SelectionTool::applyLayer: " << activeLayer << " " << layer;
+    /*
     auto moleculeInfo = Core::LayerManager::getMoleculeInfo(m_molecule);
     for (const auto& names : moleculeInfo->enable) {
       auto values = names.second;
@@ -288,6 +275,7 @@ void SelectionTool::applyLayer(int layer)
 
       moleculeInfo->enable[names.first] = values;
     }
+    */
 
     // update the menu too
     m_toolWidget->setDropDown(layer, m_layerManager.layerCount());
@@ -365,6 +353,30 @@ bool SelectionTool::selectAtom(QMouseEvent* e, const Index& index)
   else {
     return toggleAtom(index);
   }
+}
+
+void SelectionTool::setMolecule(QtGui::Molecule* mol)
+{
+  if (m_molecule != mol) {
+    m_molecule = mol;
+  }
+
+  size_t currentLayer = 0;
+  size_t maxLayers = 1;
+  if (m_molecule && !m_molecule->isSelectionEmpty()) {
+    // find a selected atom
+    Index selectedIndex = 0;
+    for (Index i = 0; i < m_molecule->atomCount(); ++i) {
+      auto a = m_molecule->atom(i);
+      if (a.selected())
+        selectedIndex = i;
+      break;
+    }
+    currentLayer = m_layerManager.getLayerID(selectedIndex);
+    maxLayers = m_layerManager.layerCount();
+  }
+
+  m_toolWidget->setDropDown(currentLayer, maxLayers);
 }
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/selectiontool/selectiontool.h
+++ b/avogadro/qtplugins/selectiontool/selectiontool.h
@@ -1,21 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  Adapted from Avogadro 1.x with the following authors' permission:
-  Copyright 2007 Donald Ephraim Curtis
-  Copyright 2008 Marcus D. Hanwell
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SelectionTool_H
@@ -84,13 +69,6 @@ private:
   Vector2 m_end;
   QtGui::PluginLayerManager m_layerManager;
 };
-
-inline void SelectionTool::setMolecule(QtGui::Molecule* mol)
-{
-  if (m_molecule != mol) {
-    m_molecule = mol;
-  }
-}
 
 inline void SelectionTool::setGLRenderer(Rendering::GLRenderer* renderer)
 {

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
@@ -43,6 +43,7 @@ void SelectionToolWidget::setDropDown(size_t current, size_t max)
   for (size_t i = 0; i < max; ++i) {
     m_ui->changeLayerDropDown->addItem(QString::number(i + 1));
   }
+  m_ui->changeLayerDropDown->addItem(tr("New Layer"));
   m_ui->changeLayerDropDown->setCurrentIndex(current);
 }
 

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.cpp
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #include "selectiontoolwidget.h"
@@ -26,6 +15,7 @@ SelectionToolWidget::SelectionToolWidget(QWidget* parent)
   : QWidget(parent), m_ui(new Ui::SelectionToolWidget)
 {
   m_ui->setupUi(this);
+  setDropDown(0, 1);
   connect(m_ui->applyColorButton, SIGNAL(clicked()), this,
           SLOT(userClickedColor()));
   connect(m_ui->changeLayerDropDown, SIGNAL(currentIndexChanged(int)), this,

--- a/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
+++ b/avogadro/qtplugins/selectiontool/selectiontoolwidget.h
@@ -1,17 +1,6 @@
 /******************************************************************************
-
   This source file is part of the Avogadro project.
-
-  Copyright 2013 Kitware, Inc.
-
-  This source code is released under the New BSD License, (the "License").
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
 #ifndef AVOGADRO_QTPLUGINS_SELECTIONTOOLWIDGET_H


### PR DESCRIPTION
Draft to create a new layer from a selection (e.g., select a bunch of water molecules, hide them)
- Creates a new layer
- Sets the render types in the new layer to the same set from the active layer
- Moves the selected atoms into the new layer

Still needs:
- [x] Update menu list after creating the new layer
- [x] Send a signal to update the LayerModel UI

This should probably move the code from `selectiontool.cpp` into the RWLayerManager for "cloneNewLayer()` or something similar.

It might also be worth just adding this to the default RWLayerManager `addLayer()` method to reduce surprise (e.g., create a new layer that defaults to the same render types as the active layer).

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
