### PR TITLE
Minor cleanups using clang-tidy nullptr, override

### DIFF
--- a/avogadro/qtplugins/ballandstick/ballandstick.cpp
+++ b/avogadro/qtplugins/ballandstick/ballandstick.cpp
@@ -49,19 +49,19 @@ struct LayerBallAndStick : Core::LayerData
     showHydrogens = settings.value("ballandstick/showHydrogens", true).toBool();
   }
 
-  ~LayerBallAndStick()
+  ~LayerBallAndStick() override
   {
     if (widget)
       widget->deleteLater();
   }
 
-  std::string serialize() override final
+  std::string serialize() final
   {
     return boolToString(multiBonds) + " " + boolToString(showHydrogens) + " " +
            std::to_string(atomScale) + " " + std::to_string(bondRadius);
   }
 
-  void deserialize(std::string text) override final
+  void deserialize(std::string text) final
   {
     std::stringstream ss(text);
     std::string aux;

--- a/avogadro/qtplugins/cartoons/cartoons.cpp
+++ b/avogadro/qtplugins/cartoons/cartoons.cpp
@@ -60,14 +60,14 @@ struct LayerCartoon : Core::LayerData
   typedef void (Cartoons::*JumpTable)(bool);
   JumpTable jumpTable[7];
 
-  std::string serialize() override final
+  std::string serialize() final
   {
     return boolToString(showBackbone) + " " + boolToString(showTrace) + " " +
            boolToString(showTube) + " " + boolToString(showRibbon) + " " +
            boolToString(showSimpleCartoon) + " " + boolToString(showCartoon) +
            " " + boolToString(showRope);
   }
-  void deserialize(std::string text) override final
+  void deserialize(std::string text) final
   {
     std::stringstream ss(text);
     std::string aux;
@@ -136,7 +136,7 @@ struct LayerCartoon : Core::LayerData
     showSimpleCartoon = settings.value("cartoon/simplecartoon", true).toBool();
   }
 
-  ~LayerCartoon()
+  ~LayerCartoon() override
   {
     if (widget)
       widget->deleteLater();

--- a/avogadro/qtplugins/label/label.cpp
+++ b/avogadro/qtplugins/label/label.cpp
@@ -88,13 +88,13 @@ struct LayerLabel : Core::LayerData
     color[2] = static_cast<unsigned char>(q_color.blue());
   }
 
-  ~LayerLabel()
+  ~LayerLabel() override
   {
     if (widget)
       widget->deleteLater();
   }
 
-  std::string serialize() override final
+  std::string serialize() final
   {
     std::string aux = (const char*)atomOptions;
     std::string aux2 = (const char*)residueOptions;
@@ -102,7 +102,7 @@ struct LayerLabel : Core::LayerData
            std::to_string(color[0]) + " " + std::to_string(color[1]) + " " +
            std::to_string(color[2]);
   }
-  void deserialize(std::string text) override final
+  void deserialize(std::string text) final
   {
     std::stringstream ss(text);
     std::string aux;

--- a/avogadro/qtplugins/qtaim/qtaimlsodaintegrator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimlsodaintegrator.cpp
@@ -1374,7 +1374,7 @@ void QTAIMLSODAIntegrator::lsoda(int neq, double* y, double* t, double tout,
    start of problem).  Check for too much accuracy being requested, and
    check for h below the roundoff level in *t.
 */
-  while (1) {
+  while (true) {
     if (*istate != 1 || nst != 0) {
       if ((nst - nslast) >= mxstep) {
         //              qDebug( "lsoda -- %d steps taken before reaching tout",
@@ -1696,8 +1696,8 @@ void QTAIMLSODAIntegrator::stoda(int neq, double* y)
    In any case, prja is called at least every msbp steps.
 */
 
-  while (1) {
-    while (1) {
+  while (true) {
+    while (true) {
       if (fabs(rc - 1.) > ccmax)
         ipup = miter;
       if (nst >= nslp + msbp)
@@ -2319,7 +2319,7 @@ void QTAIMLSODAIntegrator::correction(int neq, double* y, int* corflag,
    preprocessed before starting the corrector iteration.  ipup is set
    to 0 as an indicator that this has been done.
 */
-  while (1) {
+  while (true) {
     if (*m == 0) {
       if (ipup > 0) {
         prja(neq, y);

--- a/avogadro/qtplugins/wireframe/wireframe.cpp
+++ b/avogadro/qtplugins/wireframe/wireframe.cpp
@@ -48,18 +48,18 @@ struct LayerWireframe : Core::LayerData
     lineWidth = settings.value("wireframe/lineWidth", 1.0).toDouble();
   }
 
-  ~LayerWireframe()
+  ~LayerWireframe() override
   {
     if (widget)
       widget->deleteLater();
   }
 
-  std::string serialize() override final
+  std::string serialize() final
   {
     return boolToString(multiBonds) + " " + boolToString(showHydrogens) + " " +
            std::to_string(lineWidth);
   }
-  void deserialize(std::string text) override final
+  void deserialize(std::string text) final
   {
     std::stringstream ss(text);
     std::string aux;


### PR DESCRIPTION
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
