### PR TITLE
Update NeighborPerceiver (better naming, optimization)

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -793,9 +793,10 @@ void Molecule::perceiveBondsSimple(const double tolerance, const double min)
   // check for bonds
   // O(n) average-case, O(n^2) worst-case
   // note that the "worst case" here would need to be an invalid molecule
+  Array<Index> neighbors;
   for (Index i = 0; i < atomCount(); i++) {
     Vector3 ipos = m_positions3d[i];
-    Array<Index> neighbors = neighborPerceiver.getNeighbors(ipos);
+    neighborPerceiver.getNeighborsInclusiveInPlace(neighbors, ipos);
     for (Index nj = 0; nj < neighbors.size(); ++nj) {
       Index j = neighbors[nj];
       double cutoff = radii[i] + radii[j] + tolerance;

--- a/avogadro/core/neighborperceiver.cpp
+++ b/avogadro/core/neighborperceiver.cpp
@@ -42,9 +42,10 @@ NeighborPerceiver::NeighborPerceiver(const Array<Vector3> points, float maxDista
   }
 }
 
-const Array<Index> NeighborPerceiver::getNeighbors(const Vector3 point) const
-{
-  Array<Index> r;
+void NeighborPerceiver::getNeighborsInclusiveInPlace(
+    Array<Index> &out, const Vector3 &point
+) const {
+  out.clear();
   const std::array<int, 3> bin_index = getBinIndex(point);
   for (int xi = std::max(int(1), bin_index[0]) - 1;
       xi < std::min(m_binCount[0], bin_index[0] + 2); xi++) {
@@ -52,15 +53,21 @@ const Array<Index> NeighborPerceiver::getNeighbors(const Vector3 point) const
         yi < std::min(m_binCount[1], bin_index[1] + 2); yi++) {
       for (int zi = std::max(int(1), bin_index[2]) - 1;
           zi < std::min(m_binCount[2], bin_index[2] + 2); zi++) {
-        std::vector<Index> bin = m_bins[xi][yi][zi];
-        r.insert(r.end(), bin.begin(), bin.end());
+        const std::vector<Index> &bin = m_bins[xi][yi][zi];
+        out.insert(out.end(), bin.begin(), bin.end());
       }
     }
   }
+}
+
+const Array<Index> NeighborPerceiver::getNeighborsInclusive(const Vector3 &point) const
+{
+  Array<Index> r;
+  getNeighborsInclusiveInPlace(r, point);
   return r;
 }
 
-const std::array<int, 3> NeighborPerceiver::getBinIndex(const Vector3 point) const
+const std::array<int, 3> NeighborPerceiver::getBinIndex(const Vector3 &point) const
 {
   std::array<int, 3> r;
   for (size_t c = 0; c < 3; c++) {

--- a/avogadro/core/neighborperceiver.h
+++ b/avogadro/core/neighborperceiver.h
@@ -35,15 +35,17 @@ public:
   
   /**
    * Returns a list of neighboring points. Linear time to number of neighbors.
-   * Can return some neighbors up to 2*sqrt(3) times the maximum distance.
+   * Can include some neighbors up to 2*sqrt(3) times the maximum distance.
+   * The list is newly allocated on every call; if performance/fragmentation
+   * is a concern, prefer NeighborPerceiver::getNeighborsInclusiveInPlace().
    *
    * @param point Position to return neighbors of, can be located anywhere.
    */
   const Array<Index> getNeighborsInclusive(const Vector3 &point) const;
   
   /**
-   * Updates a list of neighboring points. Linear time to number of neighbors.
-   * Can return some neighbors up to 2*sqrt(3) times the maximum distance.
+   * Fills an array with all neighboring points. Linear time to number of neighbors.
+   * Can include some neighbors up to 2*sqrt(3) times the maximum distance.
    *
    * @param out Array to output neighbor indices in.
    * @param point Position to return neighbors of, can be located anywhere.

--- a/avogadro/core/neighborperceiver.h
+++ b/avogadro/core/neighborperceiver.h
@@ -29,21 +29,29 @@ public:
    *
    * @param points Positions in 3D space to detect neighbors among.
    * @param maxDistance All neighbors strictly within this distance will be detected.
-   *                    Between 1 and 2*sqrt(3) times this distance, some could be included.
-   *                    Beyond 2*sqrt(3) times this distance, none will be included.
    *                    Should be as low as possible for best performance.
    */
   NeighborPerceiver(const Array<Vector3> points, float maxDistance);
   
   /**
    * Returns a list of neighboring points. Linear time to number of neighbors.
+   * Can return some neighbors up to 2*sqrt(3) times the maximum distance.
    *
    * @param point Position to return neighbors of, can be located anywhere.
    */
-  const Array<Index> getNeighbors(const Vector3 point) const;
+  const Array<Index> getNeighborsInclusive(const Vector3 &point) const;
+  
+  /**
+   * Updates a list of neighboring points. Linear time to number of neighbors.
+   * Can return some neighbors up to 2*sqrt(3) times the maximum distance.
+   *
+   * @param out Array to output neighbor indices in.
+   * @param point Position to return neighbors of, can be located anywhere.
+   */
+  void getNeighborsInclusiveInPlace(Array<Index> &out, const Vector3 &point) const;
   
 private:
-  const std::array<int, 3> getBinIndex(const Vector3 point) const;
+  const std::array<int, 3> getBinIndex(const Vector3 &point) const;
 protected:
   float m_maxDistance;
   std::array<int, 3> m_binCount;

--- a/tests/core/neighborperceivertest.cpp
+++ b/tests/core/neighborperceivertest.cpp
@@ -23,7 +23,7 @@ TEST(NeighborPerceiverTest, positive)
   
   NeighborPerceiver perceiver(points, 1.0f);
   
-  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  auto neighbors = perceiver.getNeighborsInclusive(Vector3(0.0, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(3));
 }
 
@@ -37,7 +37,7 @@ TEST(NeighborPerceiverTest, negative)
   
   NeighborPerceiver perceiver(points, 1.0f);
   
-  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  auto neighbors = perceiver.getNeighborsInclusive(Vector3(0.0, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(3));
 }
 
@@ -48,14 +48,14 @@ TEST(NeighborPerceiverTest, bounds)
   
   NeighborPerceiver perceiver(points, 1.0f);
   
-  auto neighbors = perceiver.getNeighbors(Vector3(0.0, 0.0, 0.0));
+  auto neighbors = perceiver.getNeighborsInclusive(Vector3(0.0, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
-  neighbors = perceiver.getNeighbors(Vector3(1.5, 0.0, 0.0));
+  perceiver.getNeighborsInclusiveInPlace(neighbors, Vector3(1.5, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
-  neighbors = perceiver.getNeighbors(Vector3(2.5, 0.0, 0.0));
+  perceiver.getNeighborsInclusiveInPlace(neighbors, Vector3(2.5, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(0));
-  neighbors = perceiver.getNeighbors(Vector3(-0.5, 0.0, 0.0));
+  perceiver.getNeighborsInclusiveInPlace(neighbors, Vector3(-0.5, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(1));
-  neighbors = perceiver.getNeighbors(Vector3(-1.5, 0.0, 0.0));
+  perceiver.getNeighborsInclusiveInPlace(neighbors, Vector3(-1.5, 0.0, 0.0));
   EXPECT_EQ(neighbors.size(), static_cast<size_t>(0));
 }


### PR DESCRIPTION
`getNeighbors` has been renamed to `getNeighborsInclusive`. I'm wondering if a `getNeighbors` (exclusive) would be welcome, as it would simply need to keep a copy of the input array and use it to decide what neighbors to actually return. The functions have also been made somewhat faster (at least 30%) and a new `getNeighborsInclusiveInPlace` has been added, which returns neighbors in an array passed as parameter rather than returning a newly allocated array, which could amount to many thousands of allocations.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
