### PR TITLE
WIP: Buggy implementation of decompressing single files

### DIFF
--- a/avogadro/qtplugins/plugindownloader/zipextracter.h
+++ b/avogadro/qtplugins/plugindownloader/zipextracter.h
@@ -32,6 +32,9 @@ public:
   int copyData(struct archive* ar, struct archive* aw);
   QList<QString> extract(std::string extractdir, std::string absolutepath);
   QList<QString> listFiles(const std::string absolutepath);
+
+  static QByteArray decompress(const std::string &absolutepath);
+
 };
 }
 }


### PR DESCRIPTION
Should be useful for transparent reading from gz/bz2/xz files
(e.g., cubes, MO files, etc.)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
