### PR TITLE
Make close contact perception respect visible layers

### DIFF
--- a/avogadro/qtplugins/closecontacts/closecontacts.cpp
+++ b/avogadro/qtplugins/closecontacts/closecontacts.cpp
@@ -73,6 +73,9 @@ void CloseContacts::process(const Molecule &molecule, Rendering::GroupNode &node
   Vector3ub color(128, 255, 64);
 
   NeighborPerceiver perceiver(molecule.atomPositions3d(), m_maximumDistance);
+  std::vector<bool> isAtomEnabled(molecule.atomCount());
+  for (Index i = 0; i < molecule.atomCount(); ++i)
+    isAtomEnabled[i] = m_layerManager.atomEnabled(i);
 
   GeometryNode *geometry = new GeometryNode;
   node.addChild(geometry);
@@ -83,10 +86,14 @@ void CloseContacts::process(const Molecule &molecule, Rendering::GroupNode &node
   geometry->addDrawable(lines);
   Array<Index> neighbors;
   for (Index i = 0; i < molecule.atomCount(); ++i) {
+    if (!isAtomEnabled[i])
+      continue;
     Vector3 pos = molecule.atomPosition3d(i);
     perceiver.getNeighborsInclusiveInPlace(neighbors, pos);
     for (Index n : neighbors) {
       if (n <= i) // check each pair only once
+        continue;
+      if (!isAtomEnabled[n])
         continue;
       if (!checkPairNot1213(molecule, i, n))
         continue;


### PR DESCRIPTION
Don't show a close contact when either atom is not enabled. Should be as fast as before.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
