### PR TITLE
GAMESS-US and NWChem output reader sanity check

### DIFF
--- a/avogadro/quantumio/gamessus.cpp
+++ b/avogadro/quantumio/gamessus.cpp
@@ -60,7 +60,7 @@ std::vector<std::string> GAMESSUSOutput::mimeTypes() const
   return std::vector<std::string>();
 }
 
-bool GAMESSUSOutput::read(std::istream& in, Core::Molecule& molecule)
+[[nodiscard]] bool GAMESSUSOutput::read(std::istream& in, Core::Molecule& molecule)
 {
   // Read the log file line by line, most sections are terminated by an empty
   // line, so they should be retained.
@@ -99,7 +99,11 @@ bool GAMESSUSOutput::read(std::istream& in, Core::Molecule& molecule)
       readEigenvectors(in);
     }
   }
-
+  if (!atomsRead){
+    appendError("Could not find any atomic coordinates! Are you sure this is a GAMESS-US output file?");
+    return false;
+  }
+  
   // f functions and beyond need to be reordered
   reorderMOs();
 

--- a/avogadro/quantumio/gamessus.cpp
+++ b/avogadro/quantumio/gamessus.cpp
@@ -60,7 +60,7 @@ std::vector<std::string> GAMESSUSOutput::mimeTypes() const
   return std::vector<std::string>();
 }
 
-[[nodiscard]] bool GAMESSUSOutput::read(std::istream& in, Core::Molecule& molecule)
+bool GAMESSUSOutput::read(std::istream& in, Core::Molecule& molecule)
 {
   // Read the log file line by line, most sections are terminated by an empty
   // line, so they should be retained.

--- a/avogadro/quantumio/nwchemlog.cpp
+++ b/avogadro/quantumio/nwchemlog.cpp
@@ -56,12 +56,16 @@ std::vector<std::string> NWChemLog::mimeTypes() const
   return std::vector<std::string>();
 }
 
-bool NWChemLog::read(std::istream& in, Core::Molecule& molecule)
+[[nodiscard]] bool NWChemLog::read(std::istream& in, Core::Molecule& molecule)
 {
   // Read the log file line by line, most sections are terminated by an empty
   // line, so they should be retained.
   while (!in.eof())
     processLine(in, molecule);
+  if (0 == molecule.atomCount()){
+    appendError("Could not find any atomic coordinates! Are you sure this is an NWChem output file?");
+    return false;
+  }
 
   if (m_frequencies.size() > 0 && m_frequencies.size() == m_Lx.size() &&
       m_frequencies.size() == m_intensities.size()) {

--- a/avogadro/quantumio/nwchemlog.cpp
+++ b/avogadro/quantumio/nwchemlog.cpp
@@ -56,7 +56,7 @@ std::vector<std::string> NWChemLog::mimeTypes() const
   return std::vector<std::string>();
 }
 
-[[nodiscard]] bool NWChemLog::read(std::istream& in, Core::Molecule& molecule)
+bool NWChemLog::read(std::istream& in, Core::Molecule& molecule)
 {
   // Read the log file line by line, most sections are terminated by an empty
   // line, so they should be retained.


### PR DESCRIPTION
The GAMESS-US and NWChem-log output readers now raise an error if they could not read any atomic coordinates from the output. Also make the return value nodiscard to force callers to check if the read actually succeeded, as these functions also alter the state of a Molecule object if the read succeeds differently than in case of a failure.

Partially resolves issue 2. in https://discuss.avogadro.cc/t/molpro-import-is-still-regressed-in-avogadro2-1-96-0-compared-to-avogadro1/3855

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
