### PR TITLE
Add line widths to the non-covalent / h-bond rendering

### DIFF
--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -45,7 +45,7 @@ NonCovalent::NonCovalent(QObject *p) : ScenePlugin(p)
     Vector3ub(hydrogenBColor.red(), hydrogenBColor.green(), hydrogenBColor.blue())
   };
   m_lineWidths = {
-    settings.value("nonCovalent/lineWidth0", 2).toInt()
+    settings.value("nonCovalent/lineWidth0", 2.0).toFloat()
   };
 }
 
@@ -164,9 +164,18 @@ QWidget *NonCovalent::setupWidget()
   distance_spin->setValue(m_angleToleranceDegrees);
   QObject::connect(distance_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setMaximumDistance);
   
+  // line width
+  QDoubleSpinBox* lineWidth_spin = new QDoubleSpinBox;
+  lineWidth_spin->setRange(1.0, 10.0);
+  lineWidth_spin->setSingleStep(0.5);
+  lineWidth_spin->setDecimals(1);
+  lineWidth_spin->setValue(m_lineWidths[0]);
+  QObject::connect(lineWidth_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setLineWidth);
+
   QFormLayout *form = new QFormLayout;
   form->addRow(QObject::tr("Angle tolerance:"), angle_spin);
   form->addRow(QObject::tr("Maximum distance:"), distance_spin);
+  form->addRow(QObject::tr("Line width:"), lineWidth_spin);
   v->addLayout(form);
 
   v->addStretch(1);
@@ -190,6 +199,15 @@ void NonCovalent::setMaximumDistance(float maximumDistance)
 
   QSettings settings;
   settings.setValue("nonCovalent/maximumDistance", m_maximumDistance);
+}
+
+void NonCovalent::setLineWidth(float width)
+{
+  m_lineWidths[0] = width;
+  emit drawablesChanged();
+
+  QSettings settings;
+  settings.setValue("nonCovalent/lineWidth0", width);
 }
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/noncovalent/noncovalent.h
+++ b/avogadro/qtplugins/noncovalent/noncovalent.h
@@ -41,9 +41,10 @@ public:
     return DefaultBehavior::False;
   }
 
-public:
+public slots:
   void setAngleTolerance(float angleTolerance);
   void setMaximumDistance(float maximumDistance);
+  void setLineWidth(float width);
 
 private:
   std::string m_name = "Non-Covalent";
@@ -51,7 +52,7 @@ private:
   double m_angleToleranceDegrees;
   double m_maximumDistance;
   std::array<Vector3ub, 1> m_lineColors;
-  std::array<int, 1> m_lineWidths;
+  std::array<float, 1> m_lineWidths;
 };
 
 } // end namespace QtPlugins


### PR DESCRIPTION
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
