### PR TITLE
Move some HydrogenTools code into AtomUtilities

### DIFF
--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS
   atom.h
   atomtyper.h
   atomtyper-inline.h
+  atomutilities.h
   avogadrocore.h
   basisset.h
   bond.h
@@ -59,6 +60,7 @@ set(HEADERS
 
 set(SOURCES
   angleiterator.cpp
+  atomutilities.cpp
   coordinateblockgenerator.cpp
   crystaltools.cpp
   cube.cpp

--- a/avogadro/core/atomutilities.cpp
+++ b/avogadro/core/atomutilities.cpp
@@ -1,0 +1,238 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "atomutilities.h"
+
+#include "../core/mdlvalence_p.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#define M_TETRAHED 109.47122063449069389
+
+using Avogadro::Vector3;
+using Avogadro::Core::Array;
+using Avogadro::Core::atomValence;
+using Avogadro::Core::Atom;
+using Avogadro::Core::Bond;
+using Avogadro::Core::Molecule;
+
+namespace {
+
+typedef Array<Bond> NeighborListType;
+
+// Return the other atom in the bond.
+inline Atom getOtherAtom(const Atom& atom, const Bond& bond)
+{
+  return bond.atom1().index() != atom.index() ? bond.atom1() : bond.atom2();
+}
+
+inline unsigned int countExistingBonds(const NeighborListType& bonds)
+{
+  unsigned int result(0);
+  for (NeighborListType::const_iterator it = bonds.begin(), itEnd = bonds.end();
+       it != itEnd; ++it) {
+    result += static_cast<unsigned int>(it->order());
+  }
+  return result;
+}
+
+} // end anon namespace
+
+namespace Avogadro {
+namespace Core {
+
+Avogadro::Core::AtomHybridization AtomUtilities::perceiveHybridization(const Atom& atom)
+{
+  const NeighborListType bonds(atom.molecule()->bonds(atom));
+  const unsigned int numberOfBonds(countExistingBonds(bonds)); // bond order sum
+
+  AtomHybridization hybridization = SP3; // default to sp3
+
+  // TODO: Handle hypervalent species, SO3, SO4, lone pairs, etc.
+
+  if (numberOfBonds > 4) {
+    //      hybridization = numberOfBonds; // e.g., octahedral, trig. bipyr.,
+    //      etc.
+  } else {
+    // Count multiple bonds
+    unsigned int numTripleBonds = 0;
+    unsigned int numDoubleBonds = 0;
+
+    for (NeighborListType::const_iterator it = bonds.begin(),
+                                          itEnd = bonds.end();
+         it != itEnd; ++it) {
+      if (it->order() == 2)
+        numDoubleBonds++;
+      else if (it->order() == 3)
+        numTripleBonds++;
+    }
+
+    if (numTripleBonds > 0 || numDoubleBonds > 1)
+      hybridization = Core::SP; // sp
+    else if (numDoubleBonds > 0)
+      hybridization = Core::SP2; // sp2
+  }
+
+  return hybridization;
+}
+
+// Generate bond geometries
+// First, the default fallback (random vectors)
+// Also applies when you have a linear geometry and just need one new vector
+// (it doesn't matter where it goes).
+Vector3 AtomUtilities::generateNewBondVector(
+  const Atom& atom, std::vector<Vector3>& allVectors,
+  Core::AtomHybridization hybridization)
+{
+  Vector3 newPos;
+  bool success = false;
+  int currentValence = allVectors.size();
+
+  // No bonded atoms, just pick a random vector
+  if (currentValence == 0) {
+    newPos = Vector3::Random().normalized();
+    return newPos;
+  } else if (currentValence == 1) {
+    // One bonded atom
+    Vector3 bond1 = allVectors[0];
+
+    // Check what's attached to our neighbor -- we want to set trans to the
+    // neighbor
+    Vector3 bond2(0.0, 0.0, 0.0);
+
+    const NeighborListType bonds(atom.molecule()->bonds(atom));
+    for (NeighborListType::const_iterator it = bonds.begin(),
+                                          itEnd = bonds.end();
+         it != itEnd; ++it) {
+      Atom a1 = getOtherAtom(atom, *it);
+      const NeighborListType nbrBonds(atom.molecule()->bonds(a1));
+      for (NeighborListType::const_iterator nbIt = nbrBonds.begin(),
+                                            nbItEnd = nbrBonds.end();
+           nbIt != nbItEnd; ++nbIt) {
+        Atom a2 = getOtherAtom(a1, *nbIt);
+        if (a2.index() == atom.index())
+          continue; // we want a *new* atom
+
+        Vector3 delta = a2.position3d() - a1.position3d();
+        if (!delta.isZero(1e-5))
+          bond2 = delta.normalized();
+
+        // Check for carboxylate (CO2)
+        if ((atom.atomicNumber() == 8)  // atom for H is O
+            && (a1.atomicNumber() == 6) // central atom is C
+            && (nbIt->order() == 2) && (a2.atomicNumber() == 8))
+          break; // make sure the H will be trans to the C=O
+      }
+    }
+
+    Vector3 v1, v2;
+    v1 = bond1.cross(bond2);
+    bool noA2 = false;
+    if (bond2.norm() < 1.0e-5 || v1.norm() < 1.0e-5) {
+      //        std::cout << " creating a random paired atom " << std::endl;
+
+      // there is no a-2 atom
+      noA2 = true;
+      v2 = Vector3::Random().normalized();
+
+      double angle = fabs(acos(bond1.dot(v2)));
+      while (angle < 45.0 * DEG_TO_RAD || angle > 135.0 * DEG_TO_RAD) {
+        v2 = Vector3::Random().normalized();
+        angle = fabs(acos(bond1.dot(v2)));
+        //          std::cout << "angle = " << angle*RAD_TO_DEG << std::endl;
+      }
+      v1 = bond1.cross(v2); // so find a perpendicular, given the random vector
+      v2 = bond1.cross(v1);
+    } else {
+      //        std::cout << " found a neighbor for trans " << std::endl;
+      v1 = bond1.cross(bond2);
+      v2 = -1.0 * bond1.cross(v1);
+    }
+    v2.normalize();
+
+    switch (hybridization) {
+      case Core::SP:
+      case Core::SquarePlanar:
+      case Core::TrigonalBipyramidal:
+        newPos = bond1; // 180 degrees away from the current neighbor
+        break;
+      case Core::SP2: // sp2
+        newPos = bond1 - v2 * tan(DEG_TO_RAD * 120.0);
+        break;
+      case Core::Octahedral: // octahedral
+        newPos = bond1 - v2 * tan(DEG_TO_RAD * 90.0);
+        break;
+      case Core::SP3:
+      default:
+        newPos = (bond1 - v2 * tan(DEG_TO_RAD * M_TETRAHED));
+        break;
+    }
+
+    //      std::cout << " one bond " << newPos.normalized() << std::endl;
+    return -1.0 * newPos.normalized();
+  } // end one bond
+  else if (currentValence == 2) {
+    Vector3 bond1 = allVectors[0];
+    Vector3 bond2 = allVectors[1];
+
+    Vector3 v1 = bond1 + bond2;
+    v1.normalize();
+
+    switch (hybridization) {
+      case Core::SP: // shouldn't happen, but maybe with metal atoms?
+      case Core::SP2:
+        newPos = v1; // point away from the two existing bonds
+        break;
+      case Core::SP3:
+      default:
+        Vector3 v2 = bond1.cross(bond2); // find the perpendicular
+        v2.normalize();
+        newPos = bond1 - v2 * tan(DEG_TO_RAD * (M_TETRAHED));
+        newPos = v2 + v1 * (sqrt(2.0) / 2.0);
+    }
+
+    //      std::cout << " two bonds " << newPos.normalized() << std::endl;
+    return -1.0 * newPos.normalized();
+  } // end two bonds
+  else if (currentValence == 3) {
+    Vector3 bond1 = allVectors[0];
+    Vector3 bond2 = allVectors[1];
+    Vector3 bond3 = allVectors[2];
+
+    // need to handle different hybridizations here
+
+    // since the base of the tetrahedron should be symmetric
+    // the sum of the three bond vectors should cancel the angular parts
+    // and point in the new direction.. just need to normalize and rescale
+    newPos = -1.0 * (bond1 + bond2 + bond3);
+
+    //      std::cout << " three bonds " << newPos.normalized() << std::endl;
+    return newPos.normalized();
+  }
+
+  // Fallback:
+  // Try 10 times to generate a random vector that doesn't overlap with
+  // an existing bond. If we can't, just give up and let the overlap occur.
+
+  // Tolerance for two vectors being "too close" in radians (pi/8).
+  const Avogadro::Real cosRadTol =
+    cos(static_cast<Avogadro::Real>(M_PI) / static_cast<Avogadro::Real>(8.));
+
+  for (int attempt = 0; !success && attempt < 10; ++attempt) {
+    newPos = Vector3::Random().normalized();
+    success = true;
+    for (std::vector<Vector3>::const_iterator it = allVectors.begin(),
+                                              itEnd = allVectors.end();
+         success && it != itEnd; ++it) {
+      success = newPos.dot(*it) < cosRadTol;
+    }
+  }
+  return newPos;
+}
+
+} // namespace Core
+} // namespace Avogadro

--- a/avogadro/core/atomutilities.cpp
+++ b/avogadro/core/atomutilities.cpp
@@ -191,7 +191,7 @@ Vector3 AtomUtilities::generateNewBondVector(
       default:
         Vector3 v2 = bond1.cross(bond2); // find the perpendicular
         v2.normalize();
-        newPos = bond1 - v2 * tan(DEG_TO_RAD * (M_TETRAHED));
+        //newPos = bond1 - v2 * tan(DEG_TO_RAD * (M_TETRAHED));
         newPos = v2 + v1 * (sqrt(2.0) / 2.0);
     }
 

--- a/avogadro/core/atomutilities.h
+++ b/avogadro/core/atomutilities.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_QTGUI_ATOMUTILITIES_H
+#define AVOGADRO_QTGUI_ATOMUTILITIES_H
+
+#include <avogadro/core/vector.h>
+#include <avogadro/core/molecule.h>
+
+#include <vector>
+
+namespace Avogadro {
+namespace Core {
+class Atom;
+class Molecule;
+
+class AVOGADROCORE_EXPORT AtomUtilities
+{
+public:
+  /**
+   * Perceive the geometry / hybridization bonded to @a atom.
+   * Ideally, the client should cache the hybridization number
+   * by calling setHybridization() later
+   */
+  static AtomHybridization perceiveHybridization(const Atom& atom);
+
+  /**
+   * Generate a new bond vector (unit length)
+   */
+  static Vector3 generateNewBondVector(const Atom& atom,
+                                       std::vector<Vector3>& currentVectors,
+                                       AtomHybridization hybridization);
+
+private:
+  AtomUtilities();  // Not implemented
+  ~AtomUtilities(); // Not implemented
+};
+
+} // namespace Core
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTGUI_ATOMUTILITIES_H

--- a/avogadro/qtgui/hydrogentools.cpp
+++ b/avogadro/qtgui/hydrogentools.cpp
@@ -17,8 +17,7 @@
 #include "hydrogentools.h"
 
 #include "../core/mdlvalence_p.h"
-#include <avogadro/core/array.h>
-#include <avogadro/core/elements.h>
+#include <avogadro/core/atomutilities.h>
 
 #include <QtCore/QDebug>
 
@@ -233,41 +232,6 @@ int HydrogenTools::extraHydrogenIndices(const RWAtom& atom,
   return result;
 }
 
-Core::AtomHybridization HydrogenTools::perceiveHybridization(const RWAtom& atom)
-{
-  const NeighborListType bonds(atom.molecule()->bonds(atom));
-  const unsigned int numberOfBonds(countExistingBonds(bonds)); // bond order sum
-
-  Core::AtomHybridization hybridization = Core::SP3; // default to sp3
-
-  // TODO: Handle hypervalent species, SO3, SO4, lone pairs, etc.
-
-  if (numberOfBonds > 4) {
-    //      hybridization = numberOfBonds; // e.g., octahedral, trig. bipyr.,
-    //      etc.
-  } else {
-    // Count multiple bonds
-    unsigned int numTripleBonds = 0;
-    unsigned int numDoubleBonds = 0;
-
-    for (NeighborListType::const_iterator it = bonds.begin(),
-                                          itEnd = bonds.end();
-         it != itEnd; ++it) {
-      if (it->order() == 2)
-        numDoubleBonds++;
-      else if (it->order() == 3)
-        numTripleBonds++;
-    }
-
-    if (numTripleBonds > 0 || numDoubleBonds > 1)
-      hybridization = Core::SP; // sp
-    else if (numDoubleBonds > 0)
-      hybridization = Core::SP2; // sp2
-  }
-
-  return hybridization;
-}
-
 void HydrogenTools::generateNewHydrogenPositions(
   const RWAtom& atom, int numberOfHydrogens, std::vector<Vector3>& positions)
 {
@@ -278,7 +242,9 @@ void HydrogenTools::generateNewHydrogenPositions(
   Core::AtomHybridization hybridization = atom.hybridization();
   if (hybridization == Core::HybridizationUnknown) {
     // Perceive it
-    hybridization = perceiveHybridization(atom);
+    hybridization = Core::AtomUtilities::perceiveHybridization(
+        Core::Atom(dynamic_cast<Core::Molecule*>(atom.molecule()), atom.index())
+    );
   }
 
   const Avogadro::Real bondLength = hydrogenBondDistance(atom.atomicNumber());
@@ -300,164 +266,13 @@ void HydrogenTools::generateNewHydrogenPositions(
   for (int impHIndex = 0; impHIndex < numberOfHydrogens; ++impHIndex) {
     // First try to derive the bond vector based on the hybridization
     // Fallback will be to a random vector
-    Vector3 newPos = generateNewBondVector(atom, allVectors, hybridization);
+    Vector3 newPos = Core::AtomUtilities::generateNewBondVector(
+        Core::Atom(dynamic_cast<Core::Molecule*>(atom.molecule()), atom.index()),
+        allVectors, hybridization
+    );
     allVectors.push_back(newPos);
     positions.push_back(atom.position3d() + (newPos * bondLength));
   }
-}
-
-// Generate bond geometries
-// First, the default fallback (random vectors)
-// Also applies when you have a linear geometry and just need one new vector
-// (it doesn't matter where it goes).
-Vector3 HydrogenTools::generateNewBondVector(
-  const RWAtom& atom, std::vector<Vector3>& allVectors,
-  Core::AtomHybridization hybridization)
-{
-  Vector3 newPos;
-  bool success = false;
-  int currentValence = allVectors.size();
-
-  // No bonded atoms, just pick a random vector
-  if (currentValence == 0) {
-    newPos = Vector3::Random().normalized();
-    return newPos;
-  } else if (currentValence == 1) {
-    // One bonded atom
-    Vector3 bond1 = allVectors[0];
-
-    // Check what's attached to our neighbor -- we want to set trans to the
-    // neighbor
-    Vector3 bond2(0.0, 0.0, 0.0);
-
-    const NeighborListType bonds(atom.molecule()->bonds(atom));
-    for (NeighborListType::const_iterator it = bonds.begin(),
-                                          itEnd = bonds.end();
-         it != itEnd; ++it) {
-      RWAtom a1 = getOtherAtom(atom, *it);
-      const NeighborListType nbrBonds(atom.molecule()->bonds(a1));
-      for (NeighborListType::const_iterator nbIt = nbrBonds.begin(),
-                                            nbItEnd = nbrBonds.end();
-           nbIt != nbItEnd; ++nbIt) {
-        RWAtom a2 = getOtherAtom(a1, *nbIt);
-        if (a2.index() == atom.index())
-          continue; // we want a *new* atom
-
-        Vector3 delta = a2.position3d() - a1.position3d();
-        if (!delta.isZero(1e-5))
-          bond2 = delta.normalized();
-
-        // Check for carboxylate (CO2)
-        if ((atom.atomicNumber() == 8)  // atom for H is O
-            && (a1.atomicNumber() == 6) // central atom is C
-            && (nbIt->order() == 2) && (a2.atomicNumber() == 8))
-          break; // make sure the H will be trans to the C=O
-      }
-    }
-
-    Vector3 v1, v2;
-    v1 = bond1.cross(bond2);
-    bool noA2 = false;
-    if (bond2.norm() < 1.0e-5 || v1.norm() < 1.0e-5) {
-      //        std::cout << " creating a random paired atom " << std::endl;
-
-      // there is no a-2 atom
-      noA2 = true;
-      v2 = Vector3::Random().normalized();
-
-      double angle = fabs(acos(bond1.dot(v2)));
-      while (angle < 45.0 * DEG_TO_RAD || angle > 135.0 * DEG_TO_RAD) {
-        v2 = Vector3::Random().normalized();
-        angle = fabs(acos(bond1.dot(v2)));
-        //          std::cout << "angle = " << angle*RAD_TO_DEG << std::endl;
-      }
-      v1 = bond1.cross(v2); // so find a perpendicular, given the random vector
-      v2 = bond1.cross(v1);
-    } else {
-      //        std::cout << " found a neighbor for trans " << std::endl;
-      v1 = bond1.cross(bond2);
-      v2 = -1.0 * bond1.cross(v1);
-    }
-    v2.normalize();
-
-    switch (hybridization) {
-      case Core::SP:
-      case Core::SquarePlanar:
-      case Core::TrigonalBipyramidal:
-        newPos = bond1; // 180 degrees away from the current neighbor
-        break;
-      case Core::SP2: // sp2
-        newPos = bond1 - v2 * tan(DEG_TO_RAD * 120.0);
-        break;
-      case Core::Octahedral: // octahedral
-        newPos = bond1 - v2 * tan(DEG_TO_RAD * 90.0);
-        break;
-      case Core::SP3:
-      default:
-        newPos = (bond1 - v2 * tan(DEG_TO_RAD * M_TETRAHED));
-        break;
-    }
-
-    //      std::cout << " one bond " << newPos.normalized() << std::endl;
-    return -1.0 * newPos.normalized();
-  } // end one bond
-  else if (currentValence == 2) {
-    Vector3 bond1 = allVectors[0];
-    Vector3 bond2 = allVectors[1];
-
-    Vector3 v1 = bond1 + bond2;
-    v1.normalize();
-
-    switch (hybridization) {
-      case Core::SP: // shouldn't happen, but maybe with metal atoms?
-      case Core::SP2:
-        newPos = v1; // point away from the two existing bonds
-        break;
-      case Core::SP3:
-      default:
-        Vector3 v2 = bond1.cross(bond2); // find the perpendicular
-        v2.normalize();
-        newPos = bond1 - v2 * tan(DEG_TO_RAD * (M_TETRAHED));
-        newPos = v2 + v1 * (sqrt(2.0) / 2.0);
-    }
-
-    //      std::cout << " two bonds " << newPos.normalized() << std::endl;
-    return -1.0 * newPos.normalized();
-  } // end two bonds
-  else if (currentValence == 3) {
-    Vector3 bond1 = allVectors[0];
-    Vector3 bond2 = allVectors[1];
-    Vector3 bond3 = allVectors[2];
-
-    // need to handle different hybridizations here
-
-    // since the base of the tetrahedron should be symmetric
-    // the sum of the three bond vectors should cancel the angular parts
-    // and point in the new direction.. just need to normalize and rescale
-    newPos = -1.0 * (bond1 + bond2 + bond3);
-
-    //      std::cout << " three bonds " << newPos.normalized() << std::endl;
-    return newPos.normalized();
-  }
-
-  // Fallback:
-  // Try 10 times to generate a random vector that doesn't overlap with
-  // an existing bond. If we can't, just give up and let the overlap occur.
-
-  // Tolerance for two vectors being "too close" in radians (pi/8).
-  const Avogadro::Real cosRadTol =
-    cos(static_cast<Avogadro::Real>(M_PI) / static_cast<Avogadro::Real>(8.));
-
-  for (int attempt = 0; !success && attempt < 10; ++attempt) {
-    newPos = Vector3::Random().normalized();
-    success = true;
-    for (std::vector<Vector3>::const_iterator it = allVectors.begin(),
-                                              itEnd = allVectors.end();
-         success && it != itEnd; ++it) {
-      success = newPos.dot(*it) < cosRadTol;
-    }
-  }
-  return newPos;
 }
 
 } // namespace QtGui

--- a/avogadro/qtgui/hydrogentools.h
+++ b/avogadro/qtgui/hydrogentools.h
@@ -97,20 +97,6 @@ public:
                                            int numberOfHydrogens,
                                            std::vector<Vector3>& positions);
 
-  /**
-   * Perceive the geometry / hybridization bonded to @a atom.
-   * Ideally, the client should cache the hybridization number
-   * by calling setHybridization() later
-   */
-  static Core::AtomHybridization perceiveHybridization(const RWAtom& atom);
-
-  /**
-   * Generate a new bond vector (unit length)
-   */
-  static Vector3 generateNewBondVector(const RWAtom& atom,
-                                       std::vector<Vector3>& currentVectors,
-                                       Core::AtomHybridization hybridization);
-
 private:
   HydrogenTools();  // Not implemented
   ~HydrogenTools(); // Not implemented


### PR DESCRIPTION
This moves `perceiveHybridization` and `generateNewBondVector` into a new class named `AtomUtilities`. The new interface accepts a `Core::Molecule` rather than the original `QtGui::RWMolecule`.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
