### PR TITLE
Add electron pair angle check for hydrogen bonds

### DIFF
--- a/avogadro/core/atomutilities.cpp
+++ b/avogadro/core/atomutilities.cpp
@@ -5,7 +5,7 @@
 
 #include "atomutilities.h"
 
-#include "../core/mdlvalence_p.h"
+#include "mdlvalence_p.h"
 
 #include <algorithm>
 #include <cmath>
@@ -13,14 +13,8 @@
 
 #define M_TETRAHED 109.47122063449069389
 
-using Avogadro::Vector3;
-using Avogadro::Core::Array;
-using Avogadro::Core::atomValence;
-using Avogadro::Core::Atom;
-using Avogadro::Core::Bond;
-using Avogadro::Core::Molecule;
-
-namespace {
+namespace Avogadro {
+namespace Core {
 
 typedef Array<Bond> NeighborListType;
 
@@ -34,12 +28,7 @@ inline unsigned int countExistingBonds(const NeighborListType& bonds)
   return result;
 }
 
-} // end anon namespace
-
-namespace Avogadro {
-namespace Core {
-
-Avogadro::Core::AtomHybridization AtomUtilities::perceiveHybridization(const Atom& atom)
+AtomHybridization AtomUtilities::perceiveHybridization(const Atom& atom)
 {
   const NeighborListType bonds(atom.molecule()->bonds(atom));
   const unsigned int numberOfBonds(countExistingBonds(bonds)); // bond order sum
@@ -66,9 +55,9 @@ Avogadro::Core::AtomHybridization AtomUtilities::perceiveHybridization(const Ato
     }
 
     if (numTripleBonds > 0 || numDoubleBonds > 1)
-      hybridization = Core::SP; // sp
+      hybridization = SP; // sp
     else if (numDoubleBonds > 0)
-      hybridization = Core::SP2; // sp2
+      hybridization = SP2; // sp2
   }
 
   return hybridization;
@@ -79,8 +68,8 @@ Avogadro::Core::AtomHybridization AtomUtilities::perceiveHybridization(const Ato
 // Also applies when you have a linear geometry and just need one new vector
 // (it doesn't matter where it goes).
 Vector3 AtomUtilities::generateNewBondVector(
-  const Atom& atom, std::vector<Vector3>& allVectors,
-  Core::AtomHybridization hybridization)
+  const Atom& atom, const std::vector<Vector3>& allVectors,
+  AtomHybridization hybridization)
 {
   Vector3 newPos;
   bool success = false;
@@ -149,18 +138,18 @@ Vector3 AtomUtilities::generateNewBondVector(
     v2.normalize();
 
     switch (hybridization) {
-      case Core::SP:
-      case Core::SquarePlanar:
-      case Core::TrigonalBipyramidal:
+      case SP:
+      case SquarePlanar:
+      case TrigonalBipyramidal:
         newPos = bond1; // 180 degrees away from the current neighbor
         break;
-      case Core::SP2: // sp2
+      case SP2: // sp2
         newPos = bond1 - v2 * tan(DEG_TO_RAD * 120.0);
         break;
-      case Core::Octahedral: // octahedral
+      case Octahedral: // octahedral
         newPos = bond1 - v2 * tan(DEG_TO_RAD * 90.0);
         break;
-      case Core::SP3:
+      case SP3:
       default:
         newPos = (bond1 - v2 * tan(DEG_TO_RAD * M_TETRAHED));
         break;
@@ -177,11 +166,11 @@ Vector3 AtomUtilities::generateNewBondVector(
     v1.normalize();
 
     switch (hybridization) {
-      case Core::SP: // shouldn't happen, but maybe with metal atoms?
-      case Core::SP2:
+      case SP: // shouldn't happen, but maybe with metal atoms?
+      case SP2:
         newPos = v1; // point away from the two existing bonds
         break;
-      case Core::SP3:
+      case SP3:
       default:
         Vector3 v2 = bond1.cross(bond2); // find the perpendicular
         v2.normalize();

--- a/avogadro/core/atomutilities.h
+++ b/avogadro/core/atomutilities.h
@@ -30,7 +30,7 @@ public:
    * Generate a new bond vector (unit length)
    */
   static Vector3 generateNewBondVector(const Atom& atom,
-                                       std::vector<Vector3>& currentVectors,
+                                       const std::vector<Vector3>& currentVectors,
                                        AtomHybridization hybridization);
 
 private:

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -137,12 +137,11 @@ static bool checkPairVector(
   AtomHybridization hybridization = AtomUtilities::perceiveHybridization(molecule.atom(n));
   Array<const Bond *> bonds = molecule.bonds(n);
   size_t bondCount = bonds.size();
-  std::vector<Vector3> bondVectors(bondCount);
+  std::vector<Vector3> bondVectors;
   Vector3 pos = molecule.atomPosition3d(n);
   /* Compute all bond vectors around atom n */
-  std::transform(bonds.begin(), bonds.end(), bondVectors.begin(), [molecule, n, pos](const Bond *b) {
-    return molecule.atomPosition3d(b->getOtherAtom(n).index()) - pos;
-  });
+  for (const Bond *b: bonds)
+    bondVectors.push_back(molecule.atomPosition3d(b->getOtherAtom(n).index()) - pos);
   float pairAngle;
   switch (hybridization) {
     case Core::SP3:

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -181,7 +181,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1:
-          pairAngle = fabs(computeAngle(bondVectors[0], -in) - M_TRIGONAL);
+          pairAngle = fabs(computeAngle(bondVectors[0], in) - M_TRIGONAL);
           break;
         case 2: {
           Vector3 pairVector = AtomUtilities::generateNewBondVector(

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -137,7 +137,8 @@ static bool checkPairVector(
   Array<const Bond *> bonds = molecule.bonds(n);
   size_t bondCount = bonds.size();
   std::vector<Vector3> bondVectors(bondCount);
-  std::transform(bonds.begin(), bonds.end(), bondVectors.begin(), [molecule, n](const Bond *b) {
+  Vector3 pos = molecule.atomPosition3d(n);
+  std::transform(bonds.begin(), bonds.end(), bondVectors.begin(), [molecule, n, pos](const Bond *b) {
     return molecule.atomPosition3d(b->getOtherAtom(n).index());
   });
   float pairAngle;
@@ -179,7 +180,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1:
-          pairAngle = abs(computeAngle(bondVectors[0], in) - M_TRI);
+          pairAngle = abs(computeAngle(bondVectors[0], -in) - M_TRI);
           break;
         case 2: {
           Vector3 pairVector = AtomUtilities::generateNewBondVector(
@@ -198,10 +199,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1: {
-          Vector3 pairVector = AtomUtilities::generateNewBondVector(
-            molecule.atom(n), bondVectors, hybridization
-          );
-          pairAngle = computeAngle(pairVector, in);
+          pairAngle = abs(computeAngle(bondVectors[0], in) - M_PI);
           break;
         }
         default:
@@ -255,7 +253,7 @@ void NonCovalent::process(const Molecule &molecule, Rendering::GroupNode &node)
       float angleTolerance = m_angleToleranceDegrees * M_PI / 180.0;
       if (!checkHoleVector(molecule, i, distance_vector, angleTolerance))
         continue;
-      if (!checkPairVector(molecule, n, distance_vector, angleTolerance))
+      if (!checkPairVector(molecule, n, -distance_vector, angleTolerance))
         continue;
 
       lines->addDashedLine(pos.cast<float>(), npos.cast<float>(), color, 8);

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -136,10 +136,11 @@ static bool checkPairVector(
   AtomHybridization hybridization = AtomUtilities::perceiveHybridization(molecule.atom(n));
   Array<const Bond *> bonds = molecule.bonds(n);
   size_t bondCount = bonds.size();
-  std::vector<Vector3> bondVectors;
-  for (const Bond *b: bonds)
-    bondVectors.push_back(molecule.atomPosition3d(b->getOtherAtom(n).index()));
-  float pairAngle = 0.0f;
+  std::vector<Vector3> bondVectors(bondCount);
+  std::transform(bonds.begin(), bonds.end(), bondVectors.begin(), [molecule, n](const Bond *b) {
+    return molecule.atomPosition3d(b->getOtherAtom(n).index());
+  });
+  float pairAngle;
   switch (hybridization) {
     case Core::SP3:
       switch (bondCount) {
@@ -206,6 +207,8 @@ static bool checkPairVector(
         default:
           return false;
       }
+    default:
+      return true;
   }
   return pairAngle <= angleTolerance;
 }

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -25,8 +25,9 @@
 
 #include <cmath>
 
-#define M_TETRAHED 1.910633236
-#define M_TRI 2.094395102
+// bond angles
+#define M_TETRAHEDRAL (acosf(-1.0f / 3.0f))
+#define M_TRIGONAL (2.0f * M_PI / 3.0f)
 
 namespace Avogadro {
 namespace QtPlugins {
@@ -138,8 +139,9 @@ static bool checkPairVector(
   size_t bondCount = bonds.size();
   std::vector<Vector3> bondVectors(bondCount);
   Vector3 pos = molecule.atomPosition3d(n);
+  /* Compute all bond vectors around atom n */
   std::transform(bonds.begin(), bonds.end(), bondVectors.begin(), [molecule, n, pos](const Bond *b) {
-    return molecule.atomPosition3d(b->getOtherAtom(n).index());
+    return molecule.atomPosition3d(b->getOtherAtom(n).index()) - pos;
   });
   float pairAngle;
   switch (hybridization) {
@@ -149,7 +151,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1:
-          pairAngle = abs(computeAngle(bondVectors[0], in) - M_TETRAHED);
+          pairAngle = fabs(computeAngle(bondVectors[0], in) - M_TETRAHEDRAL);
           break;
         case 2: {
           Vector3 pairVector = AtomUtilities::generateNewBondVector(
@@ -180,7 +182,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1:
-          pairAngle = abs(computeAngle(bondVectors[0], -in) - M_TRI);
+          pairAngle = fabs(computeAngle(bondVectors[0], -in) - M_TRIGONAL);
           break;
         case 2: {
           Vector3 pairVector = AtomUtilities::generateNewBondVector(
@@ -199,7 +201,7 @@ static bool checkPairVector(
           pairAngle = 0.0f;
           break;
         case 1: {
-          pairAngle = abs(computeAngle(bondVectors[0], in) - M_PI);
+          pairAngle = fabs(computeAngle(bondVectors[0], in) - M_PI);
           break;
         }
         default:


### PR DESCRIPTION
This works well with sp, sp2 and sp3 hybridization, and any number of bonds, on the acceptor atom. If a different hybridization is present, the bond will be accepted.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
