### PR TITLE
Add halogen and chalcogen bonds, tune parameters

### DIFF
--- a/avogadro/qtplugins/closecontacts/closecontacts.cpp
+++ b/avogadro/qtplugins/closecontacts/closecontacts.cpp
@@ -69,7 +69,7 @@ static bool checkPairNot1213(const Molecule &molecule, Index i, Index n)
 
 void CloseContacts::process(const Molecule &molecule, Rendering::GroupNode &node)
 {
-  Vector3ub color(128, 255, 64);
+  Vector3ub color(128, 128, 128);
 
   NeighborPerceiver perceiver(molecule.atomPositions3d(), m_maximumDistance);
   std::vector<bool> isAtomEnabled(molecule.atomCount());

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -99,7 +99,7 @@ static enum InteractionTypes getInteractionType(const Molecule &molecule, Index 
         }
       }
       break;
-    case 8: case 16: // chalcogen bond
+    case 8: case 16: case 34: case 52: // chalcogen bond
       for (const Bond *b : molecule.bonds(i)) {
         Index j = (b->atom1().index() == i ? b->atom2() : b->atom1()).index();
         unsigned char jnum = molecule.atomicNumber(j);

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -48,14 +48,20 @@ NonCovalent::NonCovalent(QObject *p) : ScenePlugin(p)
   m_layerManager = PluginLayerManager(m_name);
   
   QSettings settings;
-  m_angleToleranceDegrees = settings.value("nonCovalent/angleTolerance", 30.0).toDouble();
-  m_maximumDistance = settings.value("nonCovalent/maximumDistance", 2.0).toDouble();
+  m_angleToleranceDegrees = settings.value("nonCovalent/angleTolerance", 40.0).toDouble();
+  m_maximumDistance = settings.value("nonCovalent/maximumDistance", 3.0).toDouble();
   QColor hydrogenBColor = settings.value("nonCovalent/lineColor0", QColor(64, 192, 255)).value<QColor>();
+  QColor halogenBColor = settings.value("nonCovalent/lineColor1", QColor(128, 255, 64)).value<QColor>();
+  QColor chalcogenBColor = settings.value("nonCovalent/lineColor2", QColor(255, 192, 64)).value<QColor>();
   m_lineColors = {
-    Vector3ub(hydrogenBColor.red(), hydrogenBColor.green(), hydrogenBColor.blue())
+    Vector3ub(hydrogenBColor.red(), hydrogenBColor.green(), hydrogenBColor.blue()),
+    Vector3ub(halogenBColor.red(), halogenBColor.green(), halogenBColor.blue()),
+    Vector3ub(chalcogenBColor.red(), chalcogenBColor.green(), chalcogenBColor.blue())
   };
   m_lineWidths = {
-    settings.value("nonCovalent/lineWidth0", 2.0).toFloat()
+    settings.value("nonCovalent/lineWidth0", 2.0).toFloat(),
+    settings.value("nonCovalent/lineWidth1", 2.0).toFloat(),
+    settings.value("nonCovalent/lineWidth2", 2.0).toFloat()
   };
 }
 
@@ -63,7 +69,9 @@ NonCovalent::~NonCovalent() {}
 
 enum InteractionTypes {
   NONE = -1,
-  HYDROGEN_BOND = 0
+  HYDROGEN_BOND = 0,
+  HALOGEN_BOND = 1,
+  CHALCOGEN_BOND = 2
 };
 
 static enum InteractionTypes getInteractionType(const Molecule &molecule, Index i)
@@ -80,6 +88,27 @@ static enum InteractionTypes getInteractionType(const Molecule &molecule, Index 
         }
       }
       break;
+    case 9: case 17: case 35: case 53: // halogen bond
+      for (const Bond *b : molecule.bonds(i)) {
+        Index j = (b->atom1().index() == i ? b->atom2() : b->atom1()).index();
+        unsigned char jnum = molecule.atomicNumber(j);
+        switch (jnum) {
+          case 6: case 7: case 8: case 9:
+          case 16: case 17: case 35: case 53: // F, O, N, Cl, Br, C, I, S
+            return HALOGEN_BOND;
+        }
+      }
+      break;
+    case 8: case 16: // chalcogen bond
+      for (const Bond *b : molecule.bonds(i)) {
+        Index j = (b->atom1().index() == i ? b->atom2() : b->atom1()).index();
+        unsigned char jnum = molecule.atomicNumber(j);
+        switch (jnum) {
+          case 6: // C
+            return CHALCOGEN_BOND;
+        }
+      }
+      break;
   }
   return NONE;
 }
@@ -90,7 +119,19 @@ static bool checkPairDonorIsValid(const Molecule &molecule, Index n, int interac
   switch (interactionType) {
     case HYDROGEN_BOND:
       switch (nnum) {
-        case 7: case 8: case 9: // F, O, N
+        case 7: case 8: case 9: case 17: // F, O, N, Cl
+          return true;
+      }
+      break;
+    case HALOGEN_BOND:
+      switch (nnum) {
+        case 7: case 8: case 9: case 17: // F, O, N, Cl
+          return true;
+      }
+      break;
+    case CHALCOGEN_BOND:
+      switch (nnum) {
+        case 7: case 8: case 9: case 17: // F, O, N, Cl
           return true;
       }
       break;
@@ -257,7 +298,7 @@ void NonCovalent::process(const Molecule &molecule, Rendering::GroupNode &node)
       if (!checkPairVector(molecule, n, -distance_vector, angleTolerance))
         continue;
 
-      lines->addDashedLine(pos.cast<float>(), npos.cast<float>(), color, 8);
+      lines->addDashedLine(pos.cast<float>(), npos.cast<float>(), m_lineColors[interactionType], 8);
     }
   }
 }

--- a/avogadro/qtplugins/noncovalent/noncovalent.h
+++ b/avogadro/qtplugins/noncovalent/noncovalent.h
@@ -51,8 +51,8 @@ private:
   
   double m_angleToleranceDegrees;
   double m_maximumDistance;
-  std::array<Vector3ub, 1> m_lineColors;
-  std::array<float, 1> m_lineWidths;
+  std::array<Vector3ub, 3> m_lineColors;
+  std::array<float, 3> m_lineWidths;
 };
 
 } // end namespace QtPlugins


### PR DESCRIPTION
It adds both halogen and chalcogen bonds, which are displayed under some pretty arbitrary conditions (must have look at it eventually). I also increased the default angle tolerance to 40 degrees, and distance to 3.0 Å, and changed close contacts' color to a shade of gray so it contrasts more easily with the new types of bonds.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
