### PR TITLE
Implement basic tabbed interface for NonCovalent

### DIFF
--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -20,10 +20,13 @@
 #include <QtGui/QColor>
 #include <QtWidgets/QDoubleSpinBox>
 #include <QtWidgets/QFormLayout>
+#include <QtWidgets/QTabWidget>
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QWidget>
 
+#include <algorithm>
 #include <cmath>
+#include <sstream>
 
 // bond angles
 #define M_TETRAHEDRAL (acosf(-1.0f / 3.0f))
@@ -49,8 +52,16 @@ NonCovalent::NonCovalent(QObject *p) : ScenePlugin(p)
   m_layerManager = PluginLayerManager(m_name);
   
   QSettings settings;
-  m_angleToleranceDegrees = settings.value("nonCovalent/angleTolerance", 40.0).toDouble();
-  m_maximumDistance = settings.value("nonCovalent/maximumDistance", 3.0).toDouble();
+  m_angleTolerancesDegrees = {
+  	settings.value("nonCovalent/angleTolerance0", 40.0).toDouble(),
+  	settings.value("nonCovalent/angleTolerance1", 40.0).toDouble(),
+  	settings.value("nonCovalent/angleTolerance2", 40.0).toDouble()
+  };
+  m_maximumDistances = {
+  	settings.value("nonCovalent/maximumDistance", 1.0).toDouble(),
+  	settings.value("nonCovalent/maximumDistance", 1.0).toDouble(),
+  	settings.value("nonCovalent/maximumDistance", 2.0).toDouble()
+  };
   QColor hydrogenBColor = settings.value("nonCovalent/lineColor0", QColor(64, 192, 255)).value<QColor>();
   QColor halogenBColor = settings.value("nonCovalent/lineColor1", QColor(128, 255, 64)).value<QColor>();
   QColor chalcogenBColor = settings.value("nonCovalent/lineColor2", QColor(255, 192, 64)).value<QColor>();
@@ -59,11 +70,7 @@ NonCovalent::NonCovalent(QObject *p) : ScenePlugin(p)
     Vector3ub(halogenBColor.red(), halogenBColor.green(), halogenBColor.blue()),
     Vector3ub(chalcogenBColor.red(), chalcogenBColor.green(), chalcogenBColor.blue())
   };
-  m_lineWidths = {
-    settings.value("nonCovalent/lineWidth0", 2.0).toFloat(),
-    settings.value("nonCovalent/lineWidth1", 2.0).toFloat(),
-    settings.value("nonCovalent/lineWidth2", 2.0).toFloat()
-  };
+  m_lineWidth = settings.value("nonCovalent/lineWidth0", 5.0).toFloat();
 }
 
 NonCovalent::~NonCovalent() {}
@@ -264,14 +271,17 @@ void NonCovalent::process(const Molecule &molecule, Rendering::GroupNode &node)
     enabledPositions.push_back(molecule.atomPosition3d(i));
     atomRadii.push_back(Elements::radiusVDW(molecule.atomicNumber(i)));
   }
-  NeighborPerceiver perceiver(enabledPositions, m_maximumDistance);
+  float absoluteMaxDistance = *std::max_element(
+  	m_maximumDistances.begin(), m_maximumDistances.end()
+  );
+  NeighborPerceiver perceiver(enabledPositions, absoluteMaxDistance);
 
   GeometryNode *geometry = new GeometryNode;
   node.addChild(geometry);
   DashedLineGeometry *lines = new DashedLineGeometry;
   lines->identifier().molecule = &molecule;
   lines->identifier().type = Rendering::BondType;
-  lines->setLineWidth(m_lineWidths[0]);
+  lines->setLineWidth(m_lineWidth);
   geometry->addDrawable(lines);
   Array<Index> neighbors;
   for (Index i: enabledAtoms) {
@@ -290,12 +300,12 @@ void NonCovalent::process(const Molecule &molecule, Rendering::GroupNode &node)
       double nradius = atomRadii[n];
       Vector3 distance_vector = npos - pos;
 
-      if (distance_vector.norm() > m_maximumDistance + radius + nradius)
+      if (distance_vector.norm() > m_maximumDistances[interactionType] + radius + nradius)
         continue;
       if (!checkAtomPairNotBonded(molecule, i, n))
         continue;
 
-      float angleTolerance = m_angleToleranceDegrees * M_PI / 180.0;
+      float angleTolerance = m_angleTolerancesDegrees[interactionType] * M_PI / 180.0;
       if (!checkHoleVector(molecule, i, distance_vector, angleTolerance))
         continue;
       if (!checkPairVector(molecule, n, -distance_vector, angleTolerance))
@@ -310,69 +320,84 @@ QWidget *NonCovalent::setupWidget()
 {
   QWidget *widget = new QWidget(qobject_cast<QWidget *>(this->parent()));
   QVBoxLayout *v = new QVBoxLayout;
-
-  // angle tolerance
-  QDoubleSpinBox *angle_spin = new QDoubleSpinBox;
-  angle_spin->setRange(0.0, 180.0);
-  angle_spin->setSingleStep(1.0);
-  angle_spin->setDecimals(0);
-  angle_spin->setSuffix(tr(" °"));
-  angle_spin->setValue(m_angleToleranceDegrees);
-  QObject::connect(angle_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setAngleTolerance);
+  QTabWidget *tabs = new QTabWidget;
   
-  // maximum distance
-  QDoubleSpinBox *distance_spin = new QDoubleSpinBox;
-  distance_spin->setRange(1.0, 10.0);
-  distance_spin->setSingleStep(0.1);
-  distance_spin->setDecimals(1);
-  distance_spin->setSuffix(tr(" Å"));
-  distance_spin->setValue(m_angleToleranceDegrees);
-  QObject::connect(distance_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setMaximumDistance);
+  for (Index i = 0; i < 3; i++) {
+  	// angle tolerance
+		QDoubleSpinBox *angle_spin = new QDoubleSpinBox;
+		angle_spin->setRange(0.0, 180.0);
+		angle_spin->setSingleStep(1.0);
+		angle_spin->setDecimals(0);
+		angle_spin->setSuffix(tr(" °"));
+		angle_spin->setValue(m_angleTolerancesDegrees[i]);
+		QObject::connect(angle_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+			[this, i](float width){ return setAngleTolerance(width, i); }
+		);
+		
+		// maximum distance
+		QDoubleSpinBox *distance_spin = new QDoubleSpinBox;
+		distance_spin->setRange(1.0, 10.0);
+		distance_spin->setSingleStep(0.1);
+		distance_spin->setDecimals(1);
+		distance_spin->setSuffix(tr(" Å"));
+		distance_spin->setValue(m_maximumDistances[i]);
+		QObject::connect(distance_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, 
+			[this, i](float width){ return setMaximumDistance(width, i); }
+		);
   
-  // line width
-  QDoubleSpinBox* lineWidth_spin = new QDoubleSpinBox;
-  lineWidth_spin->setRange(1.0, 10.0);
-  lineWidth_spin->setSingleStep(0.5);
-  lineWidth_spin->setDecimals(1);
-  lineWidth_spin->setValue(m_lineWidths[0]);
-  QObject::connect(lineWidth_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setLineWidth);
-
-  QFormLayout *form = new QFormLayout;
-  form->addRow(QObject::tr("Angle tolerance:"), angle_spin);
-  form->addRow(QObject::tr("Maximum distance:"), distance_spin);
-  form->addRow(QObject::tr("Line width:"), lineWidth_spin);
-  v->addLayout(form);
-
+  	// line width
+		QDoubleSpinBox* lineWidth_spin = new QDoubleSpinBox;
+		lineWidth_spin->setRange(1.0, 10.0);
+		lineWidth_spin->setSingleStep(0.5);
+		lineWidth_spin->setDecimals(1);
+		lineWidth_spin->setValue(m_lineWidth);
+		QObject::connect(lineWidth_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &NonCovalent::setLineWidth);
+		
+		QFormLayout *form = new QFormLayout;
+  	form->addRow(QObject::tr("Angle tolerance:"), angle_spin);
+  	form->addRow(QObject::tr("Maximum distance:"), distance_spin);
+  	form->addRow(QObject::tr("Line width:"), lineWidth_spin);
+  	
+  	QWidget *page = new QWidget;
+  	page->setLayout(form);
+  	tabs->addTab(page, INTERACTION_NAMES[i]);
+  }
+  
+  v->addWidget(tabs);
   v->addStretch(1);
   widget->setLayout(v);
   return widget;
 }
 
-void NonCovalent::setAngleTolerance(float angleTolerance)
+void NonCovalent::setAngleTolerance(float angleTolerance, Index index)
 {
-  m_angleToleranceDegrees = float(angleTolerance);
+  m_angleTolerancesDegrees[index] = float(angleTolerance);
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("nonCovalent/angleTolerance", m_angleToleranceDegrees);
+  settings.setValue(QString((
+  	std::ostringstream() << "nonCovalent/angleTolerance" << index
+  ).str().c_str()), angleTolerance);
 }
 
-void NonCovalent::setMaximumDistance(float maximumDistance)
+void NonCovalent::setMaximumDistance(float maximumDistance, Index index)
 {
-  m_maximumDistance = float(maximumDistance);
+  m_maximumDistances[index] = float(maximumDistance);
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("nonCovalent/maximumDistance", m_maximumDistance);
+  settings.setValue(QString((
+  	std::ostringstream() << "nonCovalent/maximumDistance" << index
+  ).str().c_str()), maximumDistance);
 }
 
 void NonCovalent::setLineWidth(float width)
 {
-  m_lineWidths[0] = width;
+  m_lineWidth = width;
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("nonCovalent/lineWidth0", width);
+  settings.setValue("nonCovalent/lineWidth", width);
 }
 
 } // namespace QtPlugins

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -375,9 +375,7 @@ void NonCovalent::setAngleTolerance(float angleTolerance, Index index)
   emit drawablesChanged();
 
   QSettings settings;
-  std::ostringstream stream;
-  stream << "nonCovalent/angleTolerance" << index;
-  settings.setValue(QString(stream.str().c_str()), angleTolerance);
+  settings.setValue(QString("nonCovalent/angleTolerance%1").arg(index), angleTolerance);
 }
 
 void NonCovalent::setMaximumDistance(float maximumDistance, Index index)
@@ -386,9 +384,7 @@ void NonCovalent::setMaximumDistance(float maximumDistance, Index index)
   emit drawablesChanged();
 
   QSettings settings;
-  std::ostringstream stream;
-  stream << "nonCovalent/maximumDistance" << index;
-  settings.setValue(QString(stream.str().c_str()), maximumDistance);
+  settings.setValue(QString("nonCovalent/maximumDistance%1").arg(index), maximumDistance);
 }
 
 void NonCovalent::setLineWidth(float width)

--- a/avogadro/qtplugins/noncovalent/noncovalent.cpp
+++ b/avogadro/qtplugins/noncovalent/noncovalent.cpp
@@ -58,9 +58,9 @@ NonCovalent::NonCovalent(QObject *p) : ScenePlugin(p)
   	settings.value("nonCovalent/angleTolerance2", 40.0).toDouble()
   };
   m_maximumDistances = {
-  	settings.value("nonCovalent/maximumDistance", 1.0).toDouble(),
-  	settings.value("nonCovalent/maximumDistance", 1.0).toDouble(),
-  	settings.value("nonCovalent/maximumDistance", 2.0).toDouble()
+  	settings.value("nonCovalent/maximumDistance0", 1.0).toDouble(),
+  	settings.value("nonCovalent/maximumDistance1", 2.0).toDouble(),
+  	settings.value("nonCovalent/maximumDistance2", 2.0).toDouble()
   };
   QColor hydrogenBColor = settings.value("nonCovalent/lineColor0", QColor(64, 192, 255)).value<QColor>();
   QColor halogenBColor = settings.value("nonCovalent/lineColor1", QColor(128, 255, 64)).value<QColor>();
@@ -375,9 +375,9 @@ void NonCovalent::setAngleTolerance(float angleTolerance, Index index)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue(QString((
-  	std::ostringstream() << "nonCovalent/angleTolerance" << index
-  ).str().c_str()), angleTolerance);
+  std::ostringstream stream;
+  stream << "nonCovalent/angleTolerance" << index;
+  settings.setValue(QString(stream.str().c_str()), angleTolerance);
 }
 
 void NonCovalent::setMaximumDistance(float maximumDistance, Index index)
@@ -386,9 +386,9 @@ void NonCovalent::setMaximumDistance(float maximumDistance, Index index)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue(QString((
-  	std::ostringstream() << "nonCovalent/maximumDistance" << index
-  ).str().c_str()), maximumDistance);
+  std::ostringstream stream;
+  stream << "nonCovalent/maximumDistance" << index;
+  settings.setValue(QString(stream.str().c_str()), maximumDistance);
 }
 
 void NonCovalent::setLineWidth(float width)

--- a/avogadro/qtplugins/noncovalent/noncovalent.h
+++ b/avogadro/qtplugins/noncovalent/noncovalent.h
@@ -44,7 +44,7 @@ public:
 public slots:
   void setAngleTolerance(float angleTolerance, Index index);
   void setMaximumDistance(float maximumDistance, Index index);
-  void setLineWidth(float width);
+  void setLineWidth(float width, Index index);
 
 private:
   const std::string m_name = "Non-Covalent";
@@ -56,7 +56,7 @@ private:
   std::array<double, 3> m_angleTolerancesDegrees;
   std::array<double, 3> m_maximumDistances;
   std::array<Vector3ub, 3> m_lineColors;
-  float m_lineWidth;
+  std::array<float, 3> m_lineWidths;
 };
 
 } // end namespace QtPlugins

--- a/avogadro/qtplugins/noncovalent/noncovalent.h
+++ b/avogadro/qtplugins/noncovalent/noncovalent.h
@@ -42,17 +42,21 @@ public:
   }
 
 public slots:
-  void setAngleTolerance(float angleTolerance);
-  void setMaximumDistance(float maximumDistance);
+  void setAngleTolerance(float angleTolerance, Index index);
+  void setMaximumDistance(float maximumDistance, Index index);
   void setLineWidth(float width);
 
 private:
-  std::string m_name = "Non-Covalent";
+  const std::string m_name = "Non-Covalent";
   
-  double m_angleToleranceDegrees;
-  double m_maximumDistance;
+  const std::array<QString, 3> INTERACTION_NAMES = {
+	tr("Hydrogen"), tr("Halogen"), tr("Chalcogen")
+  };
+  
+  std::array<double, 3> m_angleTolerancesDegrees;
+  std::array<double, 3> m_maximumDistances;
   std::array<Vector3ub, 3> m_lineColors;
-  std::array<float, 3> m_lineWidths;
+  float m_lineWidth;
 };
 
 } // end namespace QtPlugins


### PR DESCRIPTION
It features independent angle tolerances and distances for every bond type, with one single line width value. It doesn't yet have options to disable individual types or change their color.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
