### PR TITLE
Surface optimization from EDTSurf

### DIFF
--- a/avogadro/qtplugins/surfaces/surfaces.h
+++ b/avogadro/qtplugins/surfaces/surfaces.h
@@ -94,7 +94,7 @@ private:
 
   Core::Cube* m_cube = nullptr;
   std::vector<Core::Cube*> m_cubes;
-  QFutureWatcher<void> m_cubesWatcher;
+  QFutureWatcher<void> m_displayMeshWatcher;
   Core::Mesh* m_mesh1 = nullptr;
   Core::Mesh* m_mesh2 = nullptr;
   QtGui::MeshGenerator* m_meshGenerator1 = nullptr;


### PR DESCRIPTION
Now the cube calculation step is 100 - 200x faster (QElapsedTimer).

Basically, this involves iterating over atoms rather than cubes, then for each atom visiting all cubes taken up by it, and only those.

Before:
![image](https://user-images.githubusercontent.com/38228836/175177133-dd675092-2f4c-4535-b0a3-e42389f9273a.png)

After:
![image](https://user-images.githubusercontent.com/38228836/175177203-18f6ad36-f21a-4144-9129-a42c8c4cbf89.png)


Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
