### PR TITLE
Add "Automatic" resolution, smoothing pass UI, optimization

### DIFF
--- a/avogadro/core/mesh.cpp
+++ b/avogadro/core/mesh.cpp
@@ -192,7 +192,7 @@ void Mesh::smooth(int iterationCount)
     linearList[i] = Vector3(
       double(m_vertices[i](0) + 1.31*m_vertices[i](1) + 0.97*m_vertices[i](2)),
     0.0, 0.0);
-  NeighborPerceiver perceiver(linearList, 0.01);
+  NeighborPerceiver perceiver(linearList, 0.005);
 
   // Identify degenerate vertices
   std::vector<int> indexToVertexID(m_vertices.size(), -1);

--- a/avogadro/qtplugins/surfaces/surfacedialog.cpp
+++ b/avogadro/qtplugins/surfaces/surfacedialog.cpp
@@ -11,7 +11,8 @@ namespace Avogadro {
 namespace QtPlugins {
 
 SurfaceDialog::SurfaceDialog(QWidget* parent_, Qt::WindowFlags f)
-  : QDialog(parent_, f), m_ui(new Ui::SurfaceDialog)
+  : QDialog(parent_, f), m_ui(new Ui::SurfaceDialog),
+  m_automaticResolution(true)
 {
   m_ui->setupUi(this);
 
@@ -56,6 +57,7 @@ void SurfaceDialog::surfaceComboChanged(int n)
 
 void SurfaceDialog::resolutionComboChanged(int n)
 {
+  m_automaticResolution = false;
   // resolutions are in Angstrom
   switch (n) {
     case 0: // Very low resolution
@@ -78,7 +80,11 @@ void SurfaceDialog::resolutionComboChanged(int n)
       m_ui->resolutionDoubleSpinBox->setValue(0.05);
       m_ui->resolutionDoubleSpinBox->setEnabled(false);
       break;
-    case 5: // Custom resolution
+    case 5: // Automatic resolution
+      m_automaticResolution = true;
+      m_ui->resolutionDoubleSpinBox->setEnabled(false);
+      break;
+    case 6: // Custom resolution
       m_ui->resolutionDoubleSpinBox->setValue(0.18);
       m_ui->resolutionDoubleSpinBox->setEnabled(true);
       break;
@@ -195,9 +201,19 @@ float SurfaceDialog::isosurfaceValue()
   return static_cast<float>(m_ui->isosurfaceDoubleSpinBox->value());
 }
 
+int SurfaceDialog::smoothingPassesValue()
+{
+  return static_cast<int>(m_ui->smoothingPassesSpinBox->value());
+}
+
 float SurfaceDialog::resolution()
 {
   return static_cast<float>(m_ui->resolutionDoubleSpinBox->value());
+}
+
+bool SurfaceDialog::automaticResolution()
+{
+  return m_automaticResolution;
 }
 
 int SurfaceDialog::step()

--- a/avogadro/qtplugins/surfaces/surfacedialog.cpp
+++ b/avogadro/qtplugins/surfaces/surfacedialog.cpp
@@ -34,6 +34,8 @@ SurfaceDialog::SurfaceDialog(QWidget* parent_, Qt::WindowFlags f)
           SLOT(surfaceComboChanged(int)));
   connect(m_ui->resolutionCombo, SIGNAL(currentIndexChanged(int)),
           SLOT(resolutionComboChanged(int)));
+  connect(m_ui->smoothingCombo, SIGNAL(currentIndexChanged(int)),
+          SLOT(smoothingComboChanged(int)));
   connect(m_ui->stepValue, SIGNAL(valueChanged(int)), SIGNAL(stepChanged(int)));
   connect(m_ui->calculateButton, SIGNAL(clicked()), SLOT(calculateClicked()));
   connect(m_ui->recordButton, SIGNAL(clicked()), SLOT(record()));
@@ -91,6 +93,36 @@ void SurfaceDialog::resolutionComboChanged(int n)
     default:
       m_ui->resolutionDoubleSpinBox->setValue(0.18);
       m_ui->resolutionDoubleSpinBox->setEnabled(false);
+      break;
+  }
+}
+
+void SurfaceDialog::smoothingComboChanged(int n)
+{
+  switch (n) {
+    case 0: // No smoothing
+      m_ui->smoothingPassesSpinBox->setValue(0);
+      m_ui->smoothingPassesSpinBox->setEnabled(false);
+      break;
+    case 1: // Light smoothing
+      m_ui->smoothingPassesSpinBox->setValue(1);
+      m_ui->smoothingPassesSpinBox->setEnabled(false);
+      break;
+    case 2: // Medium smoothing
+      m_ui->smoothingPassesSpinBox->setValue(5);
+      m_ui->smoothingPassesSpinBox->setEnabled(false);
+      break;
+    case 3: // Strong smoothing
+      m_ui->smoothingPassesSpinBox->setValue(9);
+      m_ui->smoothingPassesSpinBox->setEnabled(false);
+      break;
+    case 4: // Custom smoothing
+      m_ui->smoothingPassesSpinBox->setValue(5);
+      m_ui->smoothingPassesSpinBox->setEnabled(true);
+      break;
+    default:
+      m_ui->smoothingPassesSpinBox->setValue(5);
+      m_ui->smoothingPassesSpinBox->setEnabled(false);
       break;
   }
 }

--- a/avogadro/qtplugins/surfaces/surfacedialog.h
+++ b/avogadro/qtplugins/surfaces/surfacedialog.h
@@ -66,6 +66,7 @@ public slots:
 protected slots:
   void surfaceComboChanged(int n);
   void resolutionComboChanged(int n);
+  void smoothingComboChanged(int n);
   void calculateClicked();
   void record();
 

--- a/avogadro/qtplugins/surfaces/surfacedialog.h
+++ b/avogadro/qtplugins/surfaces/surfacedialog.h
@@ -52,7 +52,11 @@ public:
 
   float isosurfaceValue();
 
+  int smoothingPassesValue();
+
   float resolution();
+
+  bool automaticResolution();
 
   int step();
   void setStep(int step);
@@ -72,6 +76,7 @@ signals:
 
 private:
   Ui::SurfaceDialog* m_ui;
+  bool m_automaticResolution;
 };
 
 } // End namespace QtPlugins

--- a/avogadro/qtplugins/surfaces/surfacedialog.ui
+++ b/avogadro/qtplugins/surfaces/surfacedialog.ui
@@ -278,7 +278,7 @@
      <item row="4" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
-        <string>Smoothing Passes:</string>
+        <string>Smoothing:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -288,18 +288,59 @@
      <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_7">
        <item>
+        <widget class="QComboBox" name="smoothingCombo">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="currentText">
+          <string>Medium</string>
+         </property>
+         <property name="currentIndex">
+          <number>2</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>None</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Light</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Medium</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Strong</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Custom</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
         <widget class="QSpinBox" name="smoothingPassesSpinBox">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="minimum">
           <double>0</double>
          </property>
          <property name="maximum">
-          <double>99</double>
+          <double>19</double>
          </property>
          <property name="singleStep">
           <double>1</double>
          </property>
          <property name="value">
-          <double>6</double>
+          <double>5</double>
          </property>
         </widget>
        </item>

--- a/avogadro/qtplugins/surfaces/surfacedialog.ui
+++ b/avogadro/qtplugins/surfaces/surfacedialog.ui
@@ -150,10 +150,10 @@
           <bool>true</bool>
          </property>
          <property name="currentText">
-          <string>Medium</string>
+          <string>Automatic</string>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>5</number>
          </property>
          <item>
           <property name="text">
@@ -182,6 +182,11 @@
          </item>
          <item>
           <property name="text">
+           <string>Automatic</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Custom</string>
           </property>
          </item>
@@ -190,7 +195,7 @@
        <item>
         <widget class="QDoubleSpinBox" name="resolutionDoubleSpinBox">
          <property name="enabled">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="suffix">
           <string> Å</string>
@@ -271,6 +276,49 @@
       </layout>
      </item>
      <item row="4" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Smoothing Passes:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <widget class="QSpinBox" name="smoothingPassesSpinBox">
+         <property name="minimum">
+          <double>0</double>
+         </property>
+         <property name="maximum">
+          <double>99</double>
+         </property>
+         <property name="singleStep">
+          <double>1</double>
+         </property>
+         <property name="value">
+          <double>6</double>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="5" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Frame:</string>
@@ -280,7 +328,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_6">
        <item>
         <widget class="QSpinBox" name="stepValue">

--- a/avogadro/qtplugins/surfaces/surfaces.h
+++ b/avogadro/qtplugins/surfaces/surfaces.h
@@ -84,6 +84,8 @@ private slots:
   void movieFrame();
 
 private:
+  float resolution();
+
   QList<QAction*> m_actions;
   QProgressDialog* m_progressDialog = nullptr;
 


### PR DESCRIPTION
This PR adds:
* An "Automatic" resolution for surfaces, which chooses an appropriate resolution for the current molecule.
* A "Smoothing Passes" widget within the surfaces UI. Setting to zero passes disables smoothing and makes the operation faster.
* An optimization to the smoothing code: setting the maximum `NeighborPerceiver` distance to half its value. This makes it fast enough in most cases (still the main bottleneck), while constraining the largest mesh that can be smoothed without running into RAM limits ("typical" proteins seem to run fine, but I can't process e.g. a whole ribosome). I plan on doing a more targeted optimization in the future, but this should allow actually using the new code for now.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
