### PR TITLE
Enable Open Babel charge models, including caching partial charges

### DIFF
--- a/avogadro/calc/chargemanager.cpp
+++ b/avogadro/calc/chargemanager.cpp
@@ -107,7 +107,7 @@ std::set<std::string> ChargeManager::identifiersForMolecule(
 }
 
 const MatrixX ChargeManager::partialCharges(
-  const std::string& identifier, const Core::Molecule& molecule) const
+  const std::string& identifier, Core::Molecule& molecule) const
 {
   // first check if the type is found in the molecule
   // (i.e., read from a file not computed dynamically)
@@ -130,7 +130,7 @@ const MatrixX ChargeManager::partialCharges(
 }
 
 double ChargeManager::potential(const std::string& identifier,
-                                const Core::Molecule& molecule,
+                                Core::Molecule& molecule,
                                 const Vector3& point) const
 {
   // If the type is found in the molecule
@@ -153,7 +153,7 @@ double ChargeManager::potential(const std::string& identifier,
 }
 
 Core::Array<double> ChargeManager::potentials(
-  const std::string& identifier, const Core::Molecule& molecule,
+  const std::string& identifier, Core::Molecule& molecule,
   const Core::Array<Vector3>& points) const
 {
   // As above

--- a/avogadro/calc/chargemanager.h
+++ b/avogadro/calc/chargemanager.h
@@ -109,13 +109,13 @@ public:
    * @return atomic partial charges for the molecule, or 0.0 if undefined
    */
   const MatrixX partialCharges(const std::string& identifier,
-                               const Core::Molecule& mol) const;
+                               Core::Molecule& mol) const;
 
   /**
    * @return the potential at the point for the molecule, or 0.0 if the model is
    * not available
    */
-  double potential(const std::string& identifier, const Core::Molecule& mol,
+  double potential(const std::string& identifier, Core::Molecule& mol,
                    const Vector3& point) const;
 
   /**
@@ -123,7 +123,7 @@ public:
    * the model is not available
    */
   Core::Array<double> potentials(const std::string& identifier,
-                                 const Core::Molecule& mol,
+                                 Core::Molecule& mol,
                                  const Core::Array<Vector3>& points) const;
 
   /**

--- a/avogadro/calc/chargemodel.cpp
+++ b/avogadro/calc/chargemodel.cpp
@@ -23,7 +23,7 @@ ChargeModel::ChargeModel() : m_dielectric(1.0) {}
 
 ChargeModel::~ChargeModel() {}
 
-double ChargeModel::potential(const Molecule& mol, const Vector3& point) const
+double ChargeModel::potential(Molecule& mol, const Vector3& point) const
 {
   // default is to get the set of partial atomic charges
   const MatrixX charges = partialCharges(mol);
@@ -46,7 +46,7 @@ double ChargeModel::potential(const Molecule& mol, const Vector3& point) const
   return potential / m_dielectric;
 }
 
-Array<double> ChargeModel::potentials(const Core::Molecule& mol,
+Array<double> ChargeModel::potentials(Core::Molecule& mol,
                                       const Array<Vector3>& points) const
 {
   // This is naive and slow, but can be re-implemented by methods

--- a/avogadro/calc/chargemodel.h
+++ b/avogadro/calc/chargemodel.h
@@ -80,8 +80,7 @@ public:
    */
   virtual float dielectric() const { return m_dielectric; }
 
-  virtual const MatrixX partialCharges(
-    const Core::Molecule& mol) const = 0;
+  virtual const MatrixX partialCharges(Core::Molecule& mol) const = 0;
 
   /**
    * @brief Calculate the electrostatic potential at a particular point in
@@ -90,8 +89,7 @@ public:
    * @param point The point in space to calculate the potential at.
    * @return The electrostatic potential at the point.
    */
-  virtual double potential(const Core::Molecule& mol,
-                           const Vector3& point) const;
+  virtual double potential(Core::Molecule& mol, const Vector3& point) const;
 
   /**
    * @brief Calculate the electrostatic potential at multiple points
@@ -102,8 +100,8 @@ public:
    * This method is used for batch calculation and defaults to simply
    * calculating each point at a time. Some methods work faster in batches.
    */
-  virtual Core::Array<double> potentials(const Core::Molecule& mol,
-                                    const Core::Array<Vector3>& points) const;
+  virtual Core::Array<double> potentials(
+    Core::Molecule& mol, const Core::Array<Vector3>& points) const;
 
 protected:
   /**

--- a/avogadro/calc/defaultmodel.cpp
+++ b/avogadro/calc/defaultmodel.cpp
@@ -26,8 +26,7 @@ DefaultModel::DefaultModel(const std::string& id)
 
 DefaultModel::~DefaultModel() {}
 
-const MatrixX DefaultModel::partialCharges(
-  const Core::Molecule& mol) const
+const MatrixX DefaultModel::partialCharges(Core::Molecule& mol) const
 {
   return mol.partialCharges(m_identifier);
 }

--- a/avogadro/qtplugins/openbabel/CMakeLists.txt
+++ b/avogadro/qtplugins/openbabel/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories("${AvogadroLibs_SOURCE_DIR}/thirdparty")
 
 set(openbabel_srcs
+  obcharges.cpp
   obfileformat.cpp
   obforcefielddialog.cpp
   obprocess.cpp
@@ -20,4 +21,4 @@ avogadro_plugin(OpenBabel
   "${openbabel_uis}"
 )
 
-target_link_libraries(OpenBabel PRIVATE AvogadroIO)
+target_link_libraries(OpenBabel PRIVATE AvogadroIO AvogadroCalc)

--- a/avogadro/qtplugins/openbabel/obcharges.cpp
+++ b/avogadro/qtplugins/openbabel/obcharges.cpp
@@ -1,0 +1,198 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "obcharges.h"
+#include "obprocess.h"
+
+#include <avogadro/core/array.h>
+#include <avogadro/core/molecule.h>
+
+#include <nlohmann/json.hpp>
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QTimer>
+
+namespace Avogadro {
+
+using Core::Array;
+using Core::Molecule;
+
+namespace QtPlugins {
+
+class OBCharges::ProcessListener : public QObject
+{
+  Q_OBJECT
+public:
+  ProcessListener() : QObject(), m_finished(false) {}
+
+  bool waitForOutput(Array<double> output, int msTimeout = 120000)
+  {
+    if (!wait(msTimeout))
+      return false;
+
+    // success!
+    output = m_output;
+    return true;
+  }
+
+public slots:
+  void responseReceived(const Array<double> output)
+  {
+    m_finished = true;
+    m_output = output;
+  }
+
+private:
+  bool wait(int msTimeout)
+  {
+    QTimer timer;
+    timer.start(msTimeout);
+
+    while (timer.isActive() && !m_finished)
+      qApp->processEvents(QEventLoop::AllEvents, 500);
+
+    return m_finished;
+  }
+
+  OBProcess* m_process;
+  bool m_finished;
+  Array<double> m_output;
+};
+
+OBCharges::OBCharges(const std::string& id) : m_identifier(id), ChargeModel() 
+{
+  // set the element mask based on our type / identifier 
+  m_elements.reset();
+  if (id == "eqeq") {
+    // defined for 1-84
+    for (unsigned int i = 1; i <= 84; ++i) {
+      m_elements.set(i);
+    }
+  } else if (id == "eem") {
+    // H, Li, B, C, N, O, F, Na, Mg, Si, P, S, Cl
+    m_elements.set(1);
+    m_elements.set(3);
+    m_elements.set(5);
+    m_elements.set(6);
+    m_elements.set(7);
+    m_elements.set(8);
+    m_elements.set(9);
+    m_elements.set(11);
+    m_elements.set(12);
+    m_elements.set(14);
+    m_elements.set(15);
+    m_elements.set(16);
+    m_elements.set(17);
+  } else if (id == "eem2015ba") {
+    // H, C, N, O, F, P, S, Cl, Br, I
+    m_elements.set(1);
+    m_elements.set(6);
+    m_elements.set(7);
+    m_elements.set(8);
+    m_elements.set(9);
+    m_elements.set(15);
+    m_elements.set(16);
+    m_elements.set(17);
+    m_elements.set(35);
+    m_elements.set(53);
+  } else if ( id == "gasteiger") {
+    // H, C, N, O, F, P, S, Cl, Br, I, Al
+    m_elements.set(1);
+    m_elements.set(6);
+    m_elements.set(7);
+    m_elements.set(8);
+    m_elements.set(9);
+    m_elements.set(13);
+    m_elements.set(15);
+    m_elements.set(16);
+    m_elements.set(17);
+    m_elements.set(35);
+    m_elements.set(53);
+  } else if ( id == "mmff94" ) {
+    // H, C, N, O, F, Si, P, S, Cl, Br, and I
+    // ions - Fe, F, Cl, Br, Li, Na, K, Zn, Ca, Cu, Mg
+    m_elements.set(1);
+    m_elements.set(6);
+    m_elements.set(7);
+    m_elements.set(8);
+    m_elements.set(9);
+    m_elements.set(14);
+    m_elements.set(15);
+    m_elements.set(16);
+    m_elements.set(17);
+    m_elements.set(35);
+    m_elements.set(53);
+
+    // ions
+    m_elements.set(3);
+    m_elements.set(11);
+    m_elements.set(12);
+    m_elements.set(19);
+    m_elements.set(20);
+    m_elements.set(26);
+    m_elements.set(29);
+    m_elements.set(30);
+  }
+}
+
+OBCharges::~OBCharges() {}
+
+std::string OBCharges::name() const
+{
+  if (m_identifier == "eqeq")
+    return "EQEq";
+  else if (m_identifier == "eem")
+    return "EEM";
+  else if (m_identifier == "eem2015ba")
+    return "EEM 2015";
+  else if (m_identifier == "gasteiger")
+    return "Gasteiger";
+  else if (m_identifier == "mmff94")
+    return "MMFF94";
+  else
+    return "";
+}
+
+const MatrixX OBCharges::partialCharges(Core::Molecule& molecule) const
+{
+  // get the charges from obabel
+  MatrixX charges(molecule.atomCount(), 1);
+
+  if (m_identifier.empty()) {
+    // no identifier, so we can't get the charges
+    return charges;
+  }
+
+  // otherwise, we're going to run obprocess to get the charges
+  OBProcess process;
+  ProcessListener listener;
+  QObject::connect(&process, &OBProcess::chargesFinished, &listener,
+                   &ProcessListener::responseReceived);
+
+  std::string outputString;
+  // todo - check for failure, append errors, etc.
+  m_cmlFormat.writeString(outputString, molecule);
+
+  process.calculateCharges(QByteArray(outputString.c_str()), "cml", m_identifier);
+
+  const Core::Array<double> output;
+  if (!listener.waitForOutput(output)) {
+    //appendError(std::string("Charges timed out."));
+    return charges;
+  }
+
+  // push the output into our charges array
+  for (unsigned int i = 0; i < output.size(); ++i)
+    charges(i, 0) = output[i];
+
+  // cache the charges and allow them to show up in output
+  molecule.setPartialCharges(m_identifier, charges);
+  return charges;
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#include "obcharges.moc"

--- a/avogadro/qtplugins/openbabel/obcharges.cpp
+++ b/avogadro/qtplugins/openbabel/obcharges.cpp
@@ -56,7 +56,7 @@ private:
     return m_finished;
   }
 
-  OBProcess* m_process;
+  //OBProcess* m_process;
   bool m_finished;
   Array<double> m_output;
 };

--- a/avogadro/qtplugins/openbabel/obcharges.h
+++ b/avogadro/qtplugins/openbabel/obcharges.h
@@ -15,14 +15,14 @@ namespace QtPlugins {
 class OBCharges : public Avogadro::Calc::ChargeModel
 {
 public:
-  OBCharges(const std::string& identifier);
+  OBCharges(const std::string& identifier = "");
   virtual ~OBCharges();
 
   /**
    * Create a new instance of the file format class. Ownership passes to the
    * caller.
    */
-  virtual OBCharges* newInstance() const override { return new OBCharges(""); }
+  virtual OBCharges* newInstance() const override { return new OBCharges; }
 
   /**
    * @brief A unique identifier defined by the file

--- a/avogadro/qtplugins/openbabel/obcharges.h
+++ b/avogadro/qtplugins/openbabel/obcharges.h
@@ -3,46 +3,26 @@
   This source code is released under the 3-Clause BSD License, (see "LICENSE").
 ******************************************************************************/
 
-#ifndef AVOGADRO_CALC_DEFAULTMODEL_H
-#define AVOGADRO_CALC_DEFAULTMODEL_H
-
-#include "avogadrocalcexport.h"
+#ifndef AVOGADRO_QTPLUGINS_OBCHARGES_H
+#define AVOGADRO_QTPLUGINS_OBCHARGES_H
 
 #include <avogadro/calc/chargemodel.h>
+#include <avogadro/io/cmlformat.h>
 
 namespace Avogadro {
+namespace QtPlugins {
 
-namespace Core {
-class Molecule;
-}
-
-namespace Calc {
-
-/**
- * @class DefaultModel defaultmodel.h <avogadro/calc/defaultmodel.h>
- * @brief Default charge model for file-provided atomic charges
- * @author Geoffrey R. Hutchison
- *
- * This is a default model for using atomic partial charges from a
- * file (e.g., quantum chemistry packages often provide Mulliken charges)
- *
- * The class
- */
-
-class AVOGADROCALC_EXPORT DefaultModel : public ChargeModel
+class OBCharges : public Avogadro::Calc::ChargeModel
 {
 public:
-  DefaultModel(const std::string& identifier = "");
-  virtual ~DefaultModel();
+  OBCharges(const std::string& identifier);
+  virtual ~OBCharges();
 
   /**
    * Create a new instance of the file format class. Ownership passes to the
    * caller.
    */
-  virtual DefaultModel* newInstance() const override
-  {
-    return new DefaultModel;
-  }
+  virtual OBCharges* newInstance() const override { return new OBCharges(""); }
 
   /**
    * @brief A unique identifier defined by the file
@@ -58,17 +38,17 @@ public:
   }
 
   /**
-   * @brief We don't have any other name beyond the identifier in the file
+   * @brief Based on the identifiers -- for the menus, etc.
    */
-  virtual std::string name() const override { return m_identifier; }
+  virtual std::string name() const override;
 
   /**
-   * @brief This default method is defined for whatever is in a molecule
-   * @return all elements - technically not true, but we don't have the mol
+   * @brief The element mask for a particular OB charge model (e.g., Gasteiger)
+   * @return the mask relevant for this method
    */
   virtual Core::Molecule::ElementMask elements() const override
   {
-    return (m_elements);
+    return m_elements;
   }
 
   /**
@@ -76,12 +56,20 @@ public:
    */
   virtual const MatrixX partialCharges(Core::Molecule& mol) const override;
 
+  /**
+   * @brief Synchronous use of the OBProcess.
+   */
+  class ProcessListener;
+
 protected:
   std::string m_identifier;
+  std::string m_name;
   Core::Molecule::ElementMask m_elements;
+
+  mutable Io::CmlFormat m_cmlFormat;
 };
 
-} // namespace Calc
+} // namespace QtPlugins
 } // namespace Avogadro
 
-#endif // AVOGADRO_CALC_CHARGEMODEL_H
+#endif // AVOGADRO_QTPLUGINS_OBCHARGES_H

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -324,6 +324,74 @@ void OBProcess::queryChargesPrepare()
   emit queryChargesFinished(result);
 }
 
+bool OBProcess::calculateCharges(const QByteArray& mol,
+                                 const std::string& format,
+                                 const std::string& type)
+{
+  if (!tryLockProcess()) {
+    qWarning() << "OBProcess::calculateCharges(): process already in use.";
+    return false;
+  }
+
+  QStringList realOptions;
+
+  if (format == "cjson") {
+    realOptions << "-icjson";
+  } else {
+    realOptions << "-icml";
+  }
+  realOptions << "-onul" // ignore the output
+              << "--partialcharge"
+              << type.c_str()
+              << "--print";
+
+  // Start the optimization
+  executeObabel(realOptions, this, SLOT(chargesPrepareOutput()), mol);
+  return true;
+}
+
+void OBProcess::chargesPrepareOutput()
+{
+  if (m_aborted) {
+    releaseProcess();
+    return;
+  }
+
+  // Keep this empty if an error occurs:
+  QByteArray output;
+
+  // Check for errors.
+  QString errorOutput = QString::fromLatin1(m_process->readAllStandardError());
+  QRegExp errorChecker("\\b0 molecules converted\\b"
+                       "|"
+                       "obabel: cannot read input format!");
+  if (!errorOutput.contains(errorChecker)) {
+    if (m_process->exitStatus() == QProcess::NormalExit)
+      output = m_process->readAllStandardOutput();
+  }
+
+  /// Print any meaningful warnings @todo This should go to a log at some point.
+  if (!errorOutput.isEmpty() && errorOutput != "1 molecule converted\n")
+    qWarning() << m_obabelExecutable << " stderr:\n" << errorOutput;
+
+  // Convert the output line-by-line to charges
+  Core::Array<double> charges;
+  QTextStream stream(output);
+  QString line;
+  bool ok;
+  double charge;
+  while (stream.readLineInto(&line)) {
+    charge = line.toDouble(&ok);
+    if (!ok)
+      break;
+    
+    charges.push_back(charge);
+  }
+
+  emit chargesFinished(charges);
+  releaseProcess();
+}
+
 bool OBProcess::optimizeGeometry(const QByteArray& mol,
                                  const QStringList& options,
                                  const std::string format)

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -378,10 +378,9 @@ void OBProcess::chargesPrepareOutput()
   Core::Array<double> charges;
   QTextStream stream(output);
   QString line;
-  bool ok;
-  double charge;
   while (stream.readLineInto(&line)) {
-    charge = line.toDouble(&ok);
+    bool ok;
+    double charge = line.toDouble(&ok);
     if (!ok)
       break;
     

--- a/avogadro/qtplugins/openbabel/obprocess.h
+++ b/avogadro/qtplugins/openbabel/obprocess.h
@@ -7,6 +7,8 @@
 #ifndef AVOGADRO_QTPLUGINS_OBPROCESS_H
 #define AVOGADRO_QTPLUGINS_OBPROCESS_H
 
+#include <avogadro/core/array.h>
+
 #include <QtCore/QMap>
 #include <QtCore/QObject>
 #include <QtCore/QStringList>
@@ -342,6 +344,36 @@ public slots:
 
 private slots:
   void queryChargesPrepare();
+
+public slots:
+  /**
+   * Calculate the partial charges on the molecule @a input using @a type
+   *
+   * @param input String containing molecule representation in @a inFormat
+   * format.
+   * @param inFormat File extension corresponding to input format
+   * (see `obabel -L formats`).
+   * @param type The charge model to use (e.g., MMFF94, gasteiger, etc.)
+   *
+   * After calling this method, the chargesFinished signal will be emitted to
+   * indicate return status along with the charges as text.
+   *
+   * The process is performed as:
+   * `obabel -i<inFormat> -onul --partialcharge <type> --print < input  > output`
+   *
+   * @return True if the process started successfully, false otherwise.
+   */
+  bool calculateCharges(const QByteArray& input, const std::string& inFormat = "cml", const std::string& type = "mmff94");
+
+private slots:
+  void chargesPrepareOutput();
+
+signals:
+  /**
+   * Emitted after a call to calculateCharges() finishes.
+   * @param output the set of partial charges
+   */
+  void chargesFinished(const Core::Array<double>& charges);
   // end Charge Models doxygen group
   /**@}*/
 

--- a/avogadro/qtplugins/openbabel/openbabel.h
+++ b/avogadro/qtplugins/openbabel/openbabel.h
@@ -8,7 +8,7 @@
 
 #include <avogadro/qtgui/extensionplugin.h>
 
-#include <QtCore/QMap>
+#include <QtCore/QMultiMap>
 
 class QAction;
 class QProgressDialog;
@@ -94,10 +94,10 @@ private:
   QList<QByteArray> m_moleculeQueue;
   bool m_readFormatsPending;
   bool m_writeFormatsPending;
-  QMap<QString, QString> m_readFormats;
-  QMap<QString, QString> m_writeFormats;
-  QMap<QString, QString> m_forceFields;
-  QMap<QString, QString> m_charges;
+  QMultiMap<QString, QString> m_readFormats;
+  QMultiMap<QString, QString> m_writeFormats;
+  QMultiMap<QString, QString> m_forceFields;
+  QMultiMap<QString, QString> m_charges;
   std::string m_defaultFormat;
   QProgressDialog* m_progress;
 };


### PR DESCRIPTION
Required removing const for molecules on multiiple methods
but it's worth it (e.g., save the Gasteiger or MMFF charges)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
