### PR TITLE
Fix input generators (and other scripts) with translation

### DIFF
--- a/avogadro/qtgui/jsonwidget.cpp
+++ b/avogadro/qtgui/jsonwidget.cpp
@@ -171,19 +171,19 @@ void JsonWidget::buildOptionGui()
 
     // Title first
     if (userOptions.contains("Title"))
-      addOptionRow(tr("Title"), userOptions.take("Title"));
+      addOptionRow("Title", tr("Title"), userOptions.take("Title"));
 
     // File basename next:
     if (userOptions.contains("Filename Base"))
-      addOptionRow(tr("Filename Base"), userOptions.take("Filename Base"));
+      addOptionRow("Filename Base", tr("Filename Base"), userOptions.take("Filename Base"));
 
     // Number of cores next:
     if (userOptions.contains("Processor Cores"))
-      addOptionRow(tr("Processor Cores"), userOptions.take("Processor Cores"));
+      addOptionRow("Processor Cores", tr("Processor Cores"), userOptions.take("Processor Cores"));
 
     // Calculation Type next:
     if (userOptions.contains("Calculation Type"))
-      addOptionRow(tr("Calculation Type"),
+      addOptionRow("Calculation Type", tr("Calculation Type"),
                    userOptions.take("Calculation Type"));
 
     // Theory/basis next. Combine into one row if both present.
@@ -192,16 +192,16 @@ void JsonWidget::buildOptionGui()
 
     // Other special cases: Charge / Multiplicity
     if (userOptions.contains("Charge"))
-      addOptionRow(tr("Charge"), userOptions.take("Charge"));
+      addOptionRow("Charge", tr("Charge"), userOptions.take("Charge"));
 
     if (userOptions.contains("Multiplicity"))
-      addOptionRow(tr("Multiplicity"), userOptions.take("Multiplicity"));
+      addOptionRow("Multiplicity", tr("Multiplicity"), userOptions.take("Multiplicity"));
 
     // Add remaining keys at bottom.
     for (QJsonObject::const_iterator it = userOptions.constBegin(),
                                      itEnd = userOptions.constEnd();
          it != itEnd; ++it) {
-      addOptionRow(it.key(), it.value());
+      addOptionRow(it.key(), it.key(), it.value());
     }
 
     // Make connections for standard options:
@@ -258,13 +258,13 @@ void JsonWidget::combinedOptionRow(const QString& label1, const QString& label2,
     m_currentLayout->addRow(tr1, hbox);
   } else {
     if (option1)
-      addOptionRow(tr1, options.take(label1));
+      addOptionRow(label1, tr1, options.take(label1));
     if (option2)
-      addOptionRow(tr2, options.take(label2));
+      addOptionRow(label2, tr2, options.take(label2));
   }
 }
 
-void JsonWidget::addOptionRow(const QString& name, const QJsonValue& option)
+void JsonWidget::addOptionRow(const QString& key, const QString& name, const QJsonValue& option)
 {
   QWidget* widget = createOptionWidget(option);
   if (!widget)
@@ -279,7 +279,7 @@ void JsonWidget::addOptionRow(const QString& name, const QJsonValue& option)
   }
 
   // For lookups during unit testing:
-  widget->setObjectName(name);
+  widget->setObjectName(key);
   QString label(name);
 
   QJsonObject obj = option.toObject();
@@ -290,7 +290,7 @@ void JsonWidget::addOptionRow(const QString& name, const QJsonValue& option)
   }
 
   form->addRow(label + ":", widget);
-  m_widgets.insert(name, widget);
+  m_widgets.insert(key, widget);
 
   // optionally hide rows .. can be shown by the script later
   bool hide = false;

--- a/avogadro/qtgui/jsonwidget.h
+++ b/avogadro/qtgui/jsonwidget.h
@@ -83,7 +83,7 @@ protected:
   void combinedOptionRow(const QString& label1, const QString& label2,
                          const QString& tr1, const QString& tr2,
                          QJsonObject& options);
-  void addOptionRow(const QString& label, const QJsonValue& option);
+  void addOptionRow(const QString& key, const QString& label, const QJsonValue& option);
 
   QWidget* createOptionWidget(const QJsonValue& option);
   QWidget* createStringListWidget(const QJsonObject& obj);


### PR DESCRIPTION
Previously would use the translated string for a key
(e.g., Cím in Hungarian instead of "Title")

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
