### PR TITLE
Optimize NeighborPerceiver

### DIFF
--- a/avogadro/core/neighborperceiver.cpp
+++ b/avogadro/core/neighborperceiver.cpp
@@ -8,7 +8,7 @@
 namespace Avogadro::Core {
 
 NeighborPerceiver::NeighborPerceiver(const Array<Vector3> points, float maxDistance)
- : m_maxDistance(maxDistance)
+ : m_maxDistance(maxDistance), m_cachedArray(nullptr)
 {
   if (!points.size()) return;
 
@@ -44,8 +44,12 @@ NeighborPerceiver::NeighborPerceiver(const Array<Vector3> points, float maxDista
 void NeighborPerceiver::getNeighborsInclusiveInPlace(
     Array<Index> &out, const Vector3 &point
 ) const {
-  out.clear();
   const std::array<int, 3> bin_index = getBinIndex(point);
+  if (&out == m_cachedArray && bin_index == m_cachedIndex)
+    return;
+  m_cachedArray = &out;
+  m_cachedIndex = bin_index;
+  out.clear();
   for (int xi = std::max(int(1), bin_index[0]) - 1;
       xi < std::min(m_binCount[0], bin_index[0] + 2); xi++) {
     for (int yi = std::max(int(1), bin_index[1]) - 1;

--- a/avogadro/core/neighborperceiver.h
+++ b/avogadro/core/neighborperceiver.h
@@ -60,6 +60,8 @@ protected:
   std::vector<std::vector<std::vector<std::vector<Index>>>> m_bins;
   Vector3 m_minPos;
   Vector3 m_maxPos;
+  mutable Array<Index> *m_cachedArray;
+  mutable std::array<int, 3> m_cachedIndex;
 };
 
 } // namespace Core


### PR DESCRIPTION
This avoids recomputing the output array of `getNeighborsInclusiveInPlace` whenever it's unnecessary. The actual performance gain for something like surface generation is just 0 - 5%, but this is a pretty small change and affects multiple code paths.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
