### PR TITLE
Avoid using QWheelEvent::pixelDelta() on X11

### DIFF
--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -13,6 +13,7 @@
 #include <avogadro/rendering/glrenderer.h>
 #include <avogadro/rendering/scene.h>
 
+#include <QtGui/QGuiApplication>
 #include <QtCore/QSettings>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
@@ -167,10 +168,11 @@ QUndoCommand* Navigator::wheelEvent(QWheelEvent* e)
   QPoint numPixels = e->pixelDelta();
   QPoint numDegrees = e->angleDelta() * 0.125;
 
-  if (!numPixels.isNull())
-    d = numPixels.y();
+  // see https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta
+  if (!numPixels.isNull() && QGuiApplication::platformName().toStdString().compare("xcb"))
+    d = numPixels.y(); // use pixelDelta() when available, except on X11
   else if (!numDegrees.isNull())
-    d = numDegrees.y();
+    d = numDegrees.y(); // fall back to angleDelta()
 
   zoom(m_renderer->camera().focus(), m_zoomDirection * d);
 


### PR DESCRIPTION
According to the [Qt5 docs](https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta) it's unreliable on this platform.
Could fix #1064, which is a 1.96 regression.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
