### PR TITLE
Move arc and quad mesh and linestrip convenience classes

### DIFF
--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
@@ -15,11 +15,15 @@
 
 #include <avogadro/qtopengl/glwidget.h>
 
+#include <avogadro/rendering/arcsector.h>
+#include <avogadro/rendering/arcstrip.h>
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/glrenderer.h>
 #include <avogadro/rendering/groupnode.h>
 #include <avogadro/rendering/linestripgeometry.h>
 #include <avogadro/rendering/meshgeometry.h>
+#include <avogadro/rendering/quad.h>
+#include <avogadro/rendering/quadoutline.h>
 #include <avogadro/rendering/textlabel3d.h>
 #include <avogadro/rendering/textproperties.h>
 
@@ -49,11 +53,15 @@ using QtGui::Molecule;
 using QtGui::RWAtom;
 using QtGui::RWBond;
 using QtGui::RWMolecule;
+using Rendering::ArcSector;
+using Rendering::ArcStrip;
 using Rendering::GeometryNode;
 using Rendering::GroupNode;
 using Rendering::Identifier;
 using Rendering::LineStripGeometry;
 using Rendering::MeshGeometry;
+using Rendering::Quad;
+using Rendering::QuadOutline;
 
 namespace {
 const std::string degreeString("°");
@@ -101,193 +109,6 @@ inline float vectorAngleDegrees(const Vector3f& v1, const Vector3f& v2,
   const float signDet(crossProduct.dot(axis));
   const float angle(std::atan2(crossProductNorm, dotProduct) * RAD_TO_DEG_F);
   return signDet > 0.f ? angle : -angle;
-}
-
-// Convenience quad drawable:
-class Quad : public MeshGeometry
-{
-public:
-  Quad() {}
-  ~Quad() override {}
-
-  /**
-   * @brief setQuad Set the four corners of the quad.
-   */
-  void setQuad(const Vector3f& topLeft, const Vector3f& topRight,
-               const Vector3f& bottomLeft, const Vector3f& bottomRight);
-};
-
-void Quad::setQuad(const Vector3f& topLeft, const Vector3f& topRight,
-                   const Vector3f& bottomLeft, const Vector3f& bottomRight)
-{
-  const Vector3f bottom = bottomRight - bottomLeft;
-  const Vector3f left = topLeft - bottomLeft;
-  const Vector3f normal = bottom.cross(left).normalized();
-  Array<Vector3f> norms(4, normal);
-
-  Array<Vector3f> verts(4);
-  verts[0] = topLeft;
-  verts[1] = topRight;
-  verts[2] = bottomLeft;
-  verts[3] = bottomRight;
-
-  Array<unsigned int> indices(6);
-  indices[0] = 0;
-  indices[1] = 1;
-  indices[2] = 2;
-  indices[3] = 2;
-  indices[4] = 1;
-  indices[5] = 3;
-
-  clear();
-  addVertices(verts, norms);
-  addTriangles(indices);
-}
-
-// Convenience arc sector drawable:
-class ArcSector : public MeshGeometry
-{
-public:
-  ArcSector() {}
-  ~ArcSector() override {}
-
-  /**
-   * Define the sector.
-   * @param origin Center of the circle from which the arc is cut.
-   * @param startEdge A vector defining an leading edge of the sector. The
-   * direction is used to fix the sector's rotation about the origin, and the
-   * length defines the radius of the sector.
-   * @param normal The normal direction to the plane of the sector.
-   * @param degreesCCW The extent of the sector, measured counter-clockwise from
-   * startEdge in degrees.
-   * @param resolutionDeg The radial width of each triangle used in the sector
-   * approximation in degrees. This will be adjusted to fit an integral number
-   * of triangles in the sector. Smaller triangles (better approximations) are
-   * chosen if adjustment is needed.
-   */
-  void setArcSector(const Vector3f& origin, const Vector3f& startEdge,
-                    const Vector3f& normal, float degreesCCW,
-                    float resolutionDeg);
-};
-
-void ArcSector::setArcSector(const Vector3f& origin, const Vector3f& startEdge,
-                             const Vector3f& normal, float degreesCCW,
-                             float resolutionDeg)
-{
-  // Prepare rotation, calculate sizes
-  const auto numTriangles =
-    static_cast<unsigned int>(std::fabs(std::ceil(degreesCCW / resolutionDeg)));
-  const auto numVerts = static_cast<size_t>(numTriangles + 2);
-  const float stepAngleRads =
-    (degreesCCW / static_cast<float>(numTriangles)) * DEG_TO_RAD_F;
-  const Eigen::AngleAxisf rot(stepAngleRads, normal);
-
-  // Generate normal array
-  Array<Vector3f> norms(numVerts, normal);
-
-  // Generate vertices
-  Array<Vector3f> verts(numVerts);
-  auto vertsInserter(verts.begin());
-  auto vertsEnd(verts.end());
-  Vector3f radial = startEdge;
-  *(vertsInserter++) = origin;
-  *(vertsInserter++) = origin + radial;
-  while (vertsInserter != vertsEnd)
-    *(vertsInserter++) = origin + (radial = rot * radial);
-
-  // Generate indices
-  Array<unsigned int> indices(numTriangles * 3);
-  auto indexInserter(indices.begin());
-  auto indexEnd(indices.end());
-  for (unsigned int i = 1; indexInserter != indexEnd; ++i) {
-    *(indexInserter++) = 0;
-    *(indexInserter++) = i;
-    *(indexInserter++) = i + 1;
-  }
-
-  clear();
-  addVertices(verts, norms);
-  addTriangles(indices);
-}
-
-// Convenience quad outline drawable:
-class QuadOutline : public LineStripGeometry
-{
-public:
-  QuadOutline() {}
-  ~QuadOutline() override {}
-
-  /**
-   * @brief setQuad Set the four corners of the quad.
-   */
-  void setQuad(const Vector3f& topLeft, const Vector3f& topRight,
-               const Vector3f& bottomLeft, const Vector3f& bottomRight,
-               float lineWidth);
-};
-
-void QuadOutline::setQuad(const Vector3f& topLeft, const Vector3f& topRight,
-                          const Vector3f& bottomLeft,
-                          const Vector3f& bottomRight, float lineWidth)
-{
-  Array<Vector3f> verts(5);
-  verts[0] = topLeft;
-  verts[1] = topRight;
-  verts[2] = bottomRight;
-  verts[3] = bottomLeft;
-  verts[4] = topLeft;
-
-  clear();
-  addLineStrip(verts, lineWidth);
-}
-
-// Convenience arc drawable:
-class ArcStrip : public LineStripGeometry
-{
-public:
-  ArcStrip() {}
-  ~ArcStrip() override {}
-
-  /**
-   * Define the arc.
-   * @param origin Center of the circle from which the arc is cut.
-   * @param start A vector pointing from the origin to the start of the arc.
-   * @param normal The normal direction to the plane of the circle.
-   * @param degreesCCW The extent of the arc, measured counter-clockwise from
-   * start in degrees.
-   * @param resolutionDeg The radial width of each segment used in the arc
-   * approximation, in degrees. This will be adjusted to fit an integral number
-   * of segments into the arc. Smaller segments (better approximations) are
-   * chosen if adjustment is needed.
-   * @param lineWidth The width of the line.
-   */
-  void setArc(const Vector3f& origin, const Vector3f& start,
-              const Vector3f& normal, float degreesCCW, float resolutionDeg,
-              float lineWidth);
-};
-
-void ArcStrip::setArc(const Vector3f& origin, const Vector3f& start,
-                      const Vector3f& normal, float degreesCCW,
-                      float resolutionDeg, float lineWidth)
-{
-  // Prepare rotation, calculate sizes
-  const auto resolution =
-    static_cast<unsigned int>(std::fabs(std::ceil(degreesCCW / resolutionDeg)));
-  const auto numVerts = static_cast<size_t>(resolution + 1);
-  const float stepAngleRads =
-    (degreesCCW / static_cast<float>(resolution)) * DEG_TO_RAD_F;
-  const Eigen::AngleAxisf rot(stepAngleRads, normal);
-
-  // Generate vertices
-  Array<Vector3f> verts(numVerts);
-  auto vertsInserter(verts.begin());
-  auto vertsEnd(verts.end());
-  Vector3f radial = start;
-  *(vertsInserter++) = origin + radial;
-  while (vertsInserter != vertsEnd)
-    *(vertsInserter++) = origin + (radial = rot * radial);
-
-  clear();
-  addLineStrip(verts, lineWidth);
 }
 
 } // namespace

--- a/avogadro/rendering/CMakeLists.txt
+++ b/avogadro/rendering/CMakeLists.txt
@@ -11,6 +11,8 @@ if(WIN32 AND NOT BUILD_SHARED_LIBS)
 endif()
 
 set(HEADERS
+  arcsector.h
+  arcstrip.h
   arrowgeometry.h
   avogadrogl.h
   avogadrorendering.h
@@ -33,6 +35,8 @@ set(HEADERS
   node.h
   povrayvisitor.h
   primitive.h
+  quad.h
+  quadoutline.h
   scene.h
   shader.h
   shaderprogram.h
@@ -50,6 +54,8 @@ set(HEADERS
 )
 
 set(SOURCES
+  arcsector.cpp
+  arcstrip.cpp
   arrowgeometry.cpp
   beziergeometry.cpp
   bufferobject.cpp
@@ -69,6 +75,8 @@ set(SOURCES
   meshgeometry.cpp
   node.cpp
   povrayvisitor.cpp
+  quad.cpp
+  quadoutline.cpp
   scene.cpp
   shader.cpp
   shaderprogram.cpp

--- a/avogadro/rendering/arcsector.cpp
+++ b/avogadro/rendering/arcsector.cpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "arcsector.h"
+
+using Avogadro::Core::Array;
+
+namespace Avogadro::Rendering {
+
+void ArcSector::setArcSector(const Vector3f& origin, const Vector3f& startEdge,
+                             const Vector3f& normal, float degreesCCW,
+                             float resolutionDeg)
+{
+  // Prepare rotation, calculate sizes
+  const auto numTriangles =
+    static_cast<unsigned int>(std::fabs(std::ceil(degreesCCW / resolutionDeg)));
+  const auto numVerts = static_cast<size_t>(numTriangles + 2);
+  const float stepAngleRads =
+    (degreesCCW / static_cast<float>(numTriangles)) * DEG_TO_RAD_F;
+  const Eigen::AngleAxisf rot(stepAngleRads, normal);
+
+  // Generate normal array
+  Array<Vector3f> norms(numVerts, normal);
+
+  // Generate vertices
+  Array<Vector3f> verts(numVerts);
+  auto vertsInserter(verts.begin());
+  auto vertsEnd(verts.end());
+  Vector3f radial = startEdge;
+  *(vertsInserter++) = origin;
+  *(vertsInserter++) = origin + radial;
+  while (vertsInserter != vertsEnd)
+    *(vertsInserter++) = origin + (radial = rot * radial);
+
+  // Generate indices
+  Array<unsigned int> indices(numTriangles * 3);
+  auto indexInserter(indices.begin());
+  auto indexEnd(indices.end());
+  for (unsigned int i = 1; indexInserter != indexEnd; ++i) {
+    *(indexInserter++) = 0;
+    *(indexInserter++) = i;
+    *(indexInserter++) = i + 1;
+  }
+
+  clear();
+  addVertices(verts, norms);
+  addTriangles(indices);
+}
+
+} // End namespace Avogadro::Rendering

--- a/avogadro/rendering/arcsector.h
+++ b/avogadro/rendering/arcsector.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_RENDERING_ARCSECTOR_H
+#define AVOGADRO_RENDERING_ARCSECTOR_H
+
+#include "meshgeometry.h"
+
+#include <avogadro/core/array.h>
+
+namespace Avogadro {
+namespace Rendering {
+
+/**
+ * @class ArcSector arcsector.h
+ * <avogadro/rendering/arcsector.h>
+ * @brief The ArcSector class is a convenience class for creating an arc
+ *  disk (e.g., part of a circle) from a MeshGeometry.
+ * @see ArcStrip for the edge of a circle.
+ */
+class AVOGADRORENDERING_EXPORT  ArcSector : public MeshGeometry
+{
+public:
+  ArcSector() {}
+  ~ArcSector() override {}
+
+  /**
+   * Define the sector.
+   * @param origin Center of the circle from which the arc is cut.
+   * @param startEdge A vector defining an leading edge of the sector. The
+   * direction is used to fix the sector's rotation about the origin, and the
+   * length defines the radius of the sector.
+   * @param normal The normal direction to the plane of the sector.
+   * @param degreesCCW The extent of the sector, measured counter-clockwise from
+   * startEdge in degrees.
+   * @param resolutionDeg The radial width of each triangle used in the sector
+   * approximation in degrees. This will be adjusted to fit an integral number
+   * of triangles in the sector. Smaller triangles (better approximations) are
+   * chosen if adjustment is needed.
+   */
+  void setArcSector(const Vector3f& origin, const Vector3f& startEdge,
+                    const Vector3f& normal, float degreesCCW,
+                    float resolutionDeg);
+};
+
+
+} // End namespace Rendering
+} // End namespace Avogadro
+
+#endif // AVOGADRO_RENDERING_ARCSECTOR_H

--- a/avogadro/rendering/arcstrip.cpp
+++ b/avogadro/rendering/arcstrip.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "arcstrip.h"
+
+namespace Avogadro::Rendering {
+
+void ArcStrip::setArc(const Vector3f& origin, const Vector3f& start,
+                      const Vector3f& normal, float degreesCCW,
+                      float resolutionDeg, float lineWidth)
+{
+  // Prepare rotation, calculate sizes
+  const auto resolution =
+    static_cast<unsigned int>(std::fabs(std::ceil(degreesCCW / resolutionDeg)));
+  const auto numVerts = static_cast<size_t>(resolution + 1);
+  const float stepAngleRads =
+    (degreesCCW / static_cast<float>(resolution)) * DEG_TO_RAD_F;
+  const Eigen::AngleAxisf rot(stepAngleRads, normal);
+
+  // Generate vertices
+  Core::Array<Vector3f> verts(numVerts);
+  auto vertsInserter(verts.begin());
+  auto vertsEnd(verts.end());
+  Vector3f radial = start;
+  *(vertsInserter++) = origin + radial;
+  while (vertsInserter != vertsEnd)
+    *(vertsInserter++) = origin + (radial = rot * radial);
+
+  clear();
+  addLineStrip(verts, lineWidth);
+}
+
+} // End namespace Avogadro::Rendering

--- a/avogadro/rendering/arcstrip.h
+++ b/avogadro/rendering/arcstrip.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_RENDERING_ARCSTRIP_H
+#define AVOGADRO_RENDERING_ARCSTRIP_H
+
+#include "linestripgeometry.h"
+
+#include <avogadro/core/array.h>
+
+namespace Avogadro {
+namespace Rendering {
+
+/**
+ * @class ArcStrip arcstrip.h
+ * <avogadro/rendering/arcstrip.h>
+ * @brief The ArcStrip class is a convenience class for creating an arc
+ *  line (e.g., the edge of a circle).
+ */
+class AVOGADRORENDERING_EXPORT  ArcStrip : public LineStripGeometry
+{
+public:
+  ArcStrip() {}
+  ~ArcStrip() override {}
+
+  /**
+   * Define the arc.
+   * @param origin Center of the circle from which the arc is cut.
+   * @param start A vector pointing from the origin to the start of the arc.
+   * @param normal The normal direction to the plane of the circle.
+   * @param degreesCCW The extent of the arc, measured counter-clockwise from
+   * start in degrees.
+   * @param resolutionDeg The radial width of each segment used in the arc
+   * approximation, in degrees. This will be adjusted to fit an integral number
+   * of segments into the arc. Smaller segments (better approximations) are
+   * chosen if adjustment is needed.
+   * @param lineWidth The width of the line.
+   */
+  void setArc(const Vector3f& origin, const Vector3f& start,
+              const Vector3f& normal, float degreesCCW, float resolutionDeg,
+              float lineWidth);
+};
+
+} // End namespace Rendering
+} // End namespace Avogadro
+
+#endif // AVOGADRO_RENDERING_ARCSTRIP_H

--- a/avogadro/rendering/quad.cpp
+++ b/avogadro/rendering/quad.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "quad.h"
+
+using Avogadro::Core::Array;
+
+namespace Avogadro::Rendering {
+
+void Quad::setQuad(const Vector3f& topLeft, const Vector3f& topRight,
+                   const Vector3f& bottomLeft, const Vector3f& bottomRight)
+{
+  const Vector3f bottom = bottomRight - bottomLeft;
+  const Vector3f left = topLeft - bottomLeft;
+  const Vector3f normal = bottom.cross(left).normalized();
+  Array<Vector3f> norms(4, normal);
+
+  Array<Vector3f> verts(4);
+  verts[0] = topLeft;
+  verts[1] = topRight;
+  verts[2] = bottomLeft;
+  verts[3] = bottomRight;
+
+  Array<unsigned int> indices(6);
+  indices[0] = 0;
+  indices[1] = 1;
+  indices[2] = 2;
+  indices[3] = 2;
+  indices[4] = 1;
+  indices[5] = 3;
+
+  clear();
+  addVertices(verts, norms);
+  addTriangles(indices);
+}
+
+} // End namespace Avogadro::Rendering

--- a/avogadro/rendering/quad.h
+++ b/avogadro/rendering/quad.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_RENDERING_QUAD_H
+#define AVOGADRO_RENDERING_QUAD_H
+
+#include "meshgeometry.h"
+
+#include <avogadro/core/array.h>
+
+namespace Avogadro {
+namespace Rendering {
+
+/**
+ * @class Quad quad.h
+ * <avogadro/rendering/quad.h>
+ * @brief The Quad class is a convenience class for creating a quadrilateral mesh.
+ */
+class AVOGADRORENDERING_EXPORT  Quad : public MeshGeometry
+{
+public:
+  Quad() {}
+  ~Quad() override {}
+
+  /**
+   * @brief setQuad Set the four corners of the quad.
+   */
+  void setQuad(const Vector3f& topLeft, const Vector3f& topRight,
+               const Vector3f& bottomLeft, const Vector3f& bottomRight);
+};
+
+} // End namespace Rendering
+} // End namespace Avogadro
+
+#endif // AVOGADRO_RENDERING_QUAD_H

--- a/avogadro/rendering/quadoutline.cpp
+++ b/avogadro/rendering/quadoutline.cpp
@@ -1,0 +1,27 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "quadoutline.h"
+
+using Avogadro::Core::Array;
+
+namespace Avogadro::Rendering {
+
+void QuadOutline::setQuad(const Vector3f& topLeft, const Vector3f& topRight,
+                          const Vector3f& bottomLeft,
+                          const Vector3f& bottomRight, float lineWidth)
+{
+  Array<Vector3f> verts(5);
+  verts[0] = topLeft;
+  verts[1] = topRight;
+  verts[2] = bottomRight;
+  verts[3] = bottomLeft;
+  verts[4] = topLeft;
+
+  clear();
+  addLineStrip(verts, lineWidth);
+}
+
+} // End namespace Avogadro::Rendering

--- a/avogadro/rendering/quadoutline.h
+++ b/avogadro/rendering/quadoutline.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_RENDERING_QUADOUTLINE_H
+#define AVOGADRO_RENDERING_QUADOUTLINE_H
+
+#include "linestripgeometry.h"
+
+#include <avogadro/core/array.h>
+
+namespace Avogadro {
+namespace Rendering {
+
+/**
+ * @class QuadOutline quadoutline.h
+ * <avogadro/rendering/quadoutline.h>
+ * @brief The QuadOutline class is a convenience class for creating a
+ * quadrilateral outline as a LineStripGeometry.
+ */
+class AVOGADRORENDERING_EXPORT QuadOutline : public LineStripGeometry
+{
+public:
+  QuadOutline() {}
+  ~QuadOutline() override {}
+
+  /**
+   * @brief setQuad Set the four corners of the quad.
+   */
+  void setQuad(const Vector3f& topLeft, const Vector3f& topRight,
+               const Vector3f& bottomLeft, const Vector3f& bottomRight,
+               float lineWidth);
+};
+
+} // End namespace Rendering
+} // End namespace Avogadro
+
+#endif // AVOGADRO_RENDERING_QUADOUTLINE_H


### PR DESCRIPTION
These were hidden away and not obvious for shared use

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
