### PR TITLE
Add formal charge combobox to template tool

### DIFF
--- a/avogadro/qtplugins/templatetool/templatetool.cpp
+++ b/avogadro/qtplugins/templatetool/templatetool.cpp
@@ -285,6 +285,7 @@ void TemplateTool::emptyLeftClick(QMouseEvent *e)
       center = templateMolecule.atomPosition3d(i);
       centerIndex = i;
       templateMolecule.setAtomicNumber(i, m_toolWidget->atomicNumber());
+      templateMolecule.setFormalCharge(i, m_toolWidget->formalCharge());
       continue;
     }
   }

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
@@ -86,6 +86,11 @@ unsigned char TemplateToolWidget::atomicNumber() const
   return atomicNum;
 }
 
+signed char TemplateToolWidget::formalCharge() const
+{
+  return m_ui->chargeComboBox->currentIndex() - 0;
+}
+
 void TemplateToolWidget::setCoordination(unsigned char order)
 {
   if (order < m_ui->coordinationComboBox->count())

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.h
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.h
@@ -30,6 +30,8 @@ public:
   void setAtomicNumber(unsigned char atomicNum);
   unsigned char atomicNumber() const;
 
+  signed char formalCharge() const;
+
   void setCoordination(unsigned char order);
   unsigned char coordination() const;
   QString coordinationString() const;

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.ui
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.ui
@@ -28,12 +28,12 @@
         <rect>
          <x>0</x>
          <y>10</y>
-         <width>281</width>
+         <width>290</width>
          <height>250</height>
         </rect>
        </property>
        <layout class="QFormLayout" name="formLayout_2">
-        <item row="1" column="1">
+        <item row="2" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QComboBox" name="coordinationComboBox">
@@ -175,14 +175,14 @@
           </item>
          </layout>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="coordinationLabel">
           <property name="text">
            <string>Coordination:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QToolButton" name="preview">
           <property name="text">
            <string>octahedral</string>
@@ -198,6 +198,74 @@
            </size>
           </property>
          </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Formal charge:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QComboBox" name="chargeComboBox">
+            <item>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+1</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+3</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+4</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+5</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+6</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>+7</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
@@ -226,8 +294,7 @@
         <item row="1" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QComboBox" name="ligandComboBox">
-           </widget>
+           <widget class="QComboBox" name="ligandComboBox"/>
           </item>
           <item>
            <spacer name="horizontalSpacer_2">


### PR DESCRIPTION
Just a small PR to add a formal charge selection feature to the new template tool. Formal charges are currently 0 to +7.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
