### PR TITLE
Add atoms for selection in wireframe rendering

### DIFF
--- a/avogadro/qtplugins/wireframe/wireframe.cpp
+++ b/avogadro/qtplugins/wireframe/wireframe.cpp
@@ -126,11 +126,16 @@ void Wireframe::process(const QtGui::Molecule& molecule,
   auto* lines = new LineStripGeometry;
   lines->identifier().molecule = &molecule;
   lines->identifier().type = Rendering::BondType;
+  // add tiny atom sites for selection
+  auto atoms = new SphereGeometry;
+  atoms->identifier().molecule = &molecule;
+  atoms->identifier().type = Rendering::AtomType;
   auto selectedAtoms = new SphereGeometry;
   selectedAtoms->setOpacity(0.42);
   Vector3ub selectedColor(0, 0, 255);
 
   geometry->addDrawable(lines);
+  geometry->addDrawable(atoms);
   geometry->addDrawable(selectedAtoms);
   for (Index i = 0; i < molecule.bondCount(); ++i) {
     Core::Bond bond = molecule.bond(i);
@@ -162,6 +167,10 @@ void Wireframe::process(const QtGui::Molecule& molecule,
     if (interface1.multiBonds || interface2.multiBonds)
       lineWidth *= bond.order();
     lines->addLineStrip(points, colors, lineWidth);
+    // add small spheres to allow the selection tool to work
+    // smaller than this gets ignored
+    atoms->addSphere(pos1, color1, 0.001f, bond.atom1().index());
+    atoms->addSphere(pos2, color2, 0.001f, bond.atom2().index());
     if (bond.atom1().selected())
       selectedAtoms->addSphere(pos1, selectedColor, 0.3f, i);
     if (bond.atom2().selected())


### PR DESCRIPTION
Previously, no AtomType rendering was presented.
Fix #1127

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
