### PR TITLE
Declare cylinder, sphere, and text shaders static

### DIFF
--- a/avogadro/rendering/cylindergeometry.cpp
+++ b/avogadro/rendering/cylindergeometry.cpp
@@ -38,9 +38,9 @@ public:
   BufferObject vbo;
   BufferObject ibo;
 
-  Shader vertexShader;
-  Shader fragmentShader;
-  ShaderProgram program;
+  inline static Shader* vertexShader = nullptr;
+  inline static Shader* fragmentShader = nullptr;
+  inline static ShaderProgram* program = nullptr;
 
   size_t numberOfVertices;
   size_t numberOfIndices;
@@ -76,7 +76,7 @@ void CylinderGeometry::update()
   // Check if the VBOs are ready, if not get them ready.
   if (!d->vbo.ready() || m_dirty) {
     // Set some defaults for our cylinders.
-    const unsigned int resolution = 12; // points per circle
+    const unsigned int resolution = 8; // points per circle
     const float resolutionRadians =
       2.0f * static_cast<float>(M_PI) / static_cast<float>(resolution);
     std::vector<Vector3f> radials;
@@ -144,24 +144,31 @@ void CylinderGeometry::update()
   }
 
   // Build and link the shader if it has not been used yet.
-  if (d->vertexShader.type() == Shader::Unknown) {
-    d->vertexShader.setType(Shader::Vertex);
-    d->vertexShader.setSource(cylinders_vs);
-    d->fragmentShader.setType(Shader::Fragment);
-    d->fragmentShader.setSource(cylinders_fs);
-    if (!d->vertexShader.compile())
-      cout << d->vertexShader.error() << endl;
-    if (!d->fragmentShader.compile())
-      cout << d->fragmentShader.error() << endl;
-    d->program.attachShader(d->vertexShader);
-    d->program.attachShader(d->fragmentShader);
-    if (!d->program.link())
-      cout << d->program.error() << endl;
+  if (d->vertexShader == nullptr) {
+    d->vertexShader = new Shader;
+    d->vertexShader->setType(Shader::Vertex);
+    d->vertexShader->setSource(cylinders_vs);
+    d->fragmentShader = new Shader;
+    d->fragmentShader->setType(Shader::Fragment);
+    d->fragmentShader->setSource(cylinders_fs);
+    if (!d->vertexShader->compile())
+      cout << d->vertexShader->error() << endl;
+    if (!d->fragmentShader->compile())
+      cout << d->fragmentShader->error() << endl;
 
-    d->program.detachShader(d->vertexShader);
-    d->program.detachShader(d->fragmentShader);
+    if (d->program == nullptr)
+      d->program = new ShaderProgram;
+
+    d->program->attachShader(*d->vertexShader);
+    d->program->attachShader(*d->fragmentShader);
+    if (!d->program->link())
+      cout << d->program->error() << endl;
+
+/*    d->program->detachShader(d->vertexShader);
+    d->program->detachShader(d->fragmentShader);
     d->vertexShader.cleanup();
     d->fragmentShader.cleanup();
+    */
   }
 }
 
@@ -173,45 +180,45 @@ void CylinderGeometry::render(const Camera& camera)
   // Prepare the VBOs, IBOs and shader program if necessary.
   update();
 
-  if (!d->program.bind())
-    cout << d->program.error() << endl;
+  if (!d->program->bind())
+    cout << d->program->error() << endl;
 
   d->vbo.bind();
   d->ibo.bind();
 
   // Set up our attribute arrays.
-  if (!d->program.enableAttributeArray("vertex"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray("vertex", ColorNormalVertex::vertexOffset(),
+  if (!d->program->enableAttributeArray("vertex"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray("vertex", ColorNormalVertex::vertexOffset(),
                                     sizeof(ColorNormalVertex), FloatType, 3,
                                     ShaderProgram::NoNormalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
-  if (!d->program.enableAttributeArray("color"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray("color", ColorNormalVertex::colorOffset(),
+  if (!d->program->enableAttributeArray("color"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray("color", ColorNormalVertex::colorOffset(),
                                     sizeof(ColorNormalVertex), UCharType, 3,
                                     ShaderProgram::Normalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
-  if (!d->program.enableAttributeArray("normal"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray("normal", ColorNormalVertex::normalOffset(),
+  if (!d->program->enableAttributeArray("normal"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray("normal", ColorNormalVertex::normalOffset(),
                                     sizeof(ColorNormalVertex), FloatType, 3,
                                     ShaderProgram::NoNormalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
 
   // Set up our uniforms (model-view and projection matrices right now).
-  if (!d->program.setUniformValue("modelView", camera.modelView().matrix())) {
-    cout << d->program.error() << endl;
+  if (!d->program->setUniformValue("modelView", camera.modelView().matrix())) {
+    cout << d->program->error() << endl;
   }
-  if (!d->program.setUniformValue("projection", camera.projection().matrix())) {
-    cout << d->program.error() << endl;
+  if (!d->program->setUniformValue("projection", camera.projection().matrix())) {
+    cout << d->program->error() << endl;
   }
   Matrix3f normalMatrix = camera.modelView().linear().inverse().transpose();
-  if (!d->program.setUniformValue("normalMatrix", normalMatrix))
-    std::cout << d->program.error() << std::endl;
+  if (!d->program->setUniformValue("normalMatrix", normalMatrix))
+    std::cout << d->program->error() << std::endl;
 
   // Render the loaded spheres using the shader and bound VBO.
   glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(d->numberOfVertices),
@@ -221,11 +228,11 @@ void CylinderGeometry::render(const Camera& camera)
   d->vbo.release();
   d->ibo.release();
 
-  d->program.disableAttributeArray("vector");
-  d->program.disableAttributeArray("color");
-  d->program.disableAttributeArray("normal");
+  d->program->disableAttributeArray("vector");
+  d->program->disableAttributeArray("color");
+  d->program->disableAttributeArray("normal");
 
-  d->program.release();
+  d->program->release();
 }
 
 std::multimap<float, Identifier> CylinderGeometry::hits(

--- a/avogadro/rendering/spheregeometry.cpp
+++ b/avogadro/rendering/spheregeometry.cpp
@@ -39,9 +39,9 @@ public:
   BufferObject vbo;
   BufferObject ibo;
 
-  Shader vertexShader;
-  Shader fragmentShader;
-  ShaderProgram program;
+  inline static Shader* vertexShader = nullptr;
+  inline static Shader* fragmentShader = nullptr;
+  inline static ShaderProgram* program = nullptr;
 
   size_t numberOfVertices;
   size_t numberOfIndices;
@@ -123,24 +123,32 @@ void SphereGeometry::update()
   }
 
   // Build and link the shader if it has not been used yet.
-  if (d->vertexShader.type() == Shader::Unknown) {
-    d->vertexShader.setType(Shader::Vertex);
-    d->vertexShader.setSource(spheres_vs);
-    d->fragmentShader.setType(Shader::Fragment);
-    d->fragmentShader.setSource(spheres_fs);
-    if (!d->vertexShader.compile())
-      cout << d->vertexShader.error() << endl;
-    if (!d->fragmentShader.compile())
-      cout << d->fragmentShader.error() << endl;
-    d->program.attachShader(d->vertexShader);
-    d->program.attachShader(d->fragmentShader);
-    if (!d->program.link())
-      cout << d->program.error() << endl;
+  if (d->vertexShader == nullptr) {
+    d->vertexShader = new Shader;
+    d->vertexShader->setType(Shader::Vertex);
+    d->vertexShader->setSource(spheres_vs);
+    d->fragmentShader = new Shader;
+    d->fragmentShader->setType(Shader::Fragment);
+    d->fragmentShader->setSource(spheres_fs);
+    if (!d->vertexShader->compile())
+      cout << d->vertexShader->error() << endl;
+    if (!d->fragmentShader->compile())
+      cout << d->fragmentShader->error() << endl;
 
+    if (d->program == nullptr)
+      d->program = new ShaderProgram;
+
+    d->program->attachShader(*d->vertexShader);
+    d->program->attachShader(*d->fragmentShader);
+    if (!d->program->link())
+      cout << d->program->error() << endl;
+
+/*
     d->program.detachShader(d->vertexShader);
     d->program.detachShader(d->fragmentShader);
     d->vertexShader.cleanup();
     d->fragmentShader.cleanup();
+    */
   }
 }
 
@@ -152,44 +160,44 @@ void SphereGeometry::render(const Camera& camera)
   // Prepare the VBOs, IBOs and shader program if necessary.
   update();
 
-  if (!d->program.bind())
-    cout << d->program.error() << endl;
+  if (!d->program->bind())
+    cout << d->program->error() << endl;
 
   d->vbo.bind();
   d->ibo.bind();
 
   // Set up our attribute arrays.
-  if (!d->program.enableAttributeArray("vertex"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray(
+  if (!d->program->enableAttributeArray("vertex"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray(
         "vertex", ColorTextureVertex::vertexOffset(),
         sizeof(ColorTextureVertex), FloatType, 3, ShaderProgram::NoNormalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
-  if (!d->program.enableAttributeArray("color"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray("color", ColorTextureVertex::colorOffset(),
+  if (!d->program->enableAttributeArray("color"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray("color", ColorTextureVertex::colorOffset(),
                                     sizeof(ColorTextureVertex), UCharType, 3,
                                     ShaderProgram::Normalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
-  if (!d->program.enableAttributeArray("texCoordinate"))
-    cout << d->program.error() << endl;
-  if (!d->program.useAttributeArray(
+  if (!d->program->enableAttributeArray("texCoordinate"))
+    cout << d->program->error() << endl;
+  if (!d->program->useAttributeArray(
         "texCoordinate", ColorTextureVertex::textureCoordOffset(),
         sizeof(ColorTextureVertex), FloatType, 2, ShaderProgram::NoNormalize)) {
-    cout << d->program.error() << endl;
+    cout << d->program->error() << endl;
   }
 
   // Set up our uniforms (model-view and projection matrices right now).
-  if (!d->program.setUniformValue("modelView", camera.modelView().matrix())) {
-    cout << d->program.error() << endl;
+  if (!d->program->setUniformValue("modelView", camera.modelView().matrix())) {
+    cout << d->program->error() << endl;
   }
-  if (!d->program.setUniformValue("projection", camera.projection().matrix())) {
-    cout << d->program.error() << endl;
+  if (!d->program->setUniformValue("projection", camera.projection().matrix())) {
+    cout << d->program->error() << endl;
   }
-  if (!d->program.setUniformValue("opacity", m_opacity)) {
-    cout << d->program.error() << endl;
+  if (!d->program->setUniformValue("opacity", m_opacity)) {
+    cout << d->program->error() << endl;
   }
 
   // Render the loaded spheres using the shader and bound VBO.
@@ -200,11 +208,11 @@ void SphereGeometry::render(const Camera& camera)
   d->vbo.release();
   d->ibo.release();
 
-  d->program.disableAttributeArray("vector");
-  d->program.disableAttributeArray("color");
-  d->program.disableAttributeArray("texCoordinates");
+  d->program->disableAttributeArray("vector");
+  d->program->disableAttributeArray("color");
+  d->program->disableAttributeArray("texCoordinates");
 
-  d->program.release();
+  d->program->release();
 }
 
 std::multimap<float, Identifier> SphereGeometry::hits(

--- a/avogadro/rendering/textlabelbase.cpp
+++ b/avogadro/rendering/textlabelbase.cpp
@@ -58,9 +58,9 @@ public:
   Texture2D texture;
 
   // Shaders
-  Shader vertexShader;
-  Shader fragmentShader;
-  ShaderProgram shaderProgram;
+  inline static Shader* vertexShader = nullptr;
+  inline static Shader* fragmentShader = nullptr;
+  inline static ShaderProgram* shaderProgram = nullptr;
 
   RenderImpl();
   ~RenderImpl() {}
@@ -178,26 +178,26 @@ void TextLabelBase::RenderImpl::render(const Camera& cam)
   }
 
   // Setup shaders
-  if (!shaderProgram.bind() || !shaderProgram.setUniformValue("mv", mv) ||
-      !shaderProgram.setUniformValue("proj", proj) ||
-      !shaderProgram.setUniformValue("vpDims", vpDims) ||
-      !shaderProgram.setUniformValue("anchor", anchor) ||
-      !shaderProgram.setUniformValue("radius", radius) ||
-      !shaderProgram.setTextureSampler("texture", texture) ||
+  if (!shaderProgram->bind() || !shaderProgram->setUniformValue("mv", mv) ||
+      !shaderProgram->setUniformValue("proj", proj) ||
+      !shaderProgram->setUniformValue("vpDims", vpDims) ||
+      !shaderProgram->setUniformValue("anchor", anchor) ||
+      !shaderProgram->setUniformValue("radius", radius) ||
+      !shaderProgram->setTextureSampler("texture", texture) ||
 
-      !shaderProgram.enableAttributeArray("offset") ||
-      !shaderProgram.useAttributeArray("offset", PackedVertex::offsetOffset(),
+      !shaderProgram->enableAttributeArray("offset") ||
+      !shaderProgram->useAttributeArray("offset", PackedVertex::offsetOffset(),
                                        sizeof(PackedVertex), IntType, 2,
                                        ShaderProgram::NoNormalize) ||
 
-      !shaderProgram.enableAttributeArray("texCoord") ||
-      !shaderProgram.useAttributeArray("texCoord", PackedVertex::tcoordOffset(),
+      !shaderProgram->enableAttributeArray("texCoord") ||
+      !shaderProgram->useAttributeArray("texCoord", PackedVertex::tcoordOffset(),
                                        sizeof(PackedVertex), FloatType, 2,
                                        ShaderProgram::NoNormalize)) {
     std::cerr << "Error setting up TextLabelBase shader program: "
-              << shaderProgram.error() << std::endl;
+              << shaderProgram->error() << std::endl;
     vbo.release();
-    shaderProgram.release();
+    shaderProgram->release();
     return;
   }
 
@@ -205,38 +205,45 @@ void TextLabelBase::RenderImpl::render(const Camera& cam)
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
   // Release resources:
-  shaderProgram.disableAttributeArray("texCoords");
-  shaderProgram.disableAttributeArray("offset");
-  shaderProgram.release();
+  shaderProgram->disableAttributeArray("texCoords");
+  shaderProgram->disableAttributeArray("offset");
+  shaderProgram->release();
   vbo.release();
 }
 
 void TextLabelBase::RenderImpl::compileShaders()
 {
-  vertexShader.setType(Shader::Vertex);
-  vertexShader.setSource(textlabelbase_vs);
-  if (!vertexShader.compile()) {
-    std::cerr << vertexShader.error() << std::endl;
+  if (vertexShader == nullptr)
+    vertexShader = new Shader;
+  vertexShader->setType(Shader::Vertex);
+  vertexShader->setSource(textlabelbase_vs);
+  if (!vertexShader->compile()) {
+    std::cerr << vertexShader->error() << std::endl;
     return;
   }
 
-  fragmentShader.setType(Shader::Fragment);
-  fragmentShader.setSource(textlabelbase_fs);
-  if (!fragmentShader.compile()) {
-    std::cerr << fragmentShader.error() << std::endl;
+  if (fragmentShader == nullptr)
+    fragmentShader = new Shader;
+  fragmentShader->setType(Shader::Fragment);
+  fragmentShader->setSource(textlabelbase_fs);
+  if (!fragmentShader->compile()) {
+    std::cerr << fragmentShader->error() << std::endl;
     return;
   }
 
-  shaderProgram.attachShader(vertexShader);
-  shaderProgram.attachShader(fragmentShader);
-  if (!shaderProgram.link()) {
-    std::cerr << shaderProgram.error() << std::endl;
+  if (shaderProgram == nullptr)
+    shaderProgram = new ShaderProgram;
+  shaderProgram->attachShader(*vertexShader);
+  shaderProgram->attachShader(*fragmentShader);
+  if (!shaderProgram->link()) {
+    std::cerr << shaderProgram->error() << std::endl;
     return;
   }
-  shaderProgram.detachShader(vertexShader);
-  shaderProgram.detachShader(fragmentShader);
-  vertexShader.cleanup();
-  fragmentShader.cleanup();
+/*  shaderProgram->detachShader(vertexShader);
+  shaderProgram->detachShader(fragmentShader);
+  vertexShader->cleanup();
+  fragmentShader->cleanup();
+  */
 
   shadersInvalid = false;
 }


### PR DESCRIPTION
Ensures they're only initialized once.
Definitely seems to improve interaction speed.

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
