### PR TITLE
Tweak rendering multiple bonds, rotate 45 degree angle

### DIFF
--- a/avogadro/qtplugins/ballandstick/ballandstick.cpp
+++ b/avogadro/qtplugins/ballandstick/ballandstick.cpp
@@ -176,12 +176,10 @@ void BallAndStick::process(const QtGui::Molecule& molecule,
       continue;
     }
 
-    auto& interface1 =
-      m_layerManager.getSetting<LayerBallAndStick>(
-        m_layerManager.getLayerID(bond.atom1().index()));
-    auto& interface2 =
-      m_layerManager.getSetting<LayerBallAndStick>(
-        m_layerManager.getLayerID(bond.atom2().index()));
+    auto& interface1 = m_layerManager.getSetting<LayerBallAndStick>(
+      m_layerManager.getLayerID(bond.atom1().index()));
+    auto& interface2 = m_layerManager.getSetting<LayerBallAndStick>(
+      m_layerManager.getLayerID(bond.atom2().index()));
 
     if (!interface1.showHydrogens && !interface2.showHydrogens &&
         (bond.atom1().atomicNumber() == 1 ||
@@ -198,24 +196,33 @@ void BallAndStick::process(const QtGui::Molecule& molecule,
     Vector3f bondVector = pos2 - pos1;
     float bondLength = bondVector.norm();
     bondVector /= bondLength;
+
     switch (interface1.multiBonds || interface2.multiBonds ? bond.order() : 1) {
       case 3: {
-        Vector3f delta = bondVector.unitOrthogonal() * (2.0f * bondRadius);
-        cylinders->addCylinder(pos1 + delta, pos2 + delta, bondRadius, color1,
-                               color2, i);
-        cylinders->addCylinder(pos1 - delta, pos2 - delta, bondRadius, color1,
-                               color2, i);
+        Vector3f delta = bondVector.unitOrthogonal();
+        // Rotate 45 degrees around the bond vector.
+        Eigen::Quaternionf q;
+        q = Eigen::AngleAxisf(45.0f * DEG_TO_RAD_F, bondVector);
+        delta = q * delta * 2.0f * bondRadius;
+        cylinders->addCylinder(pos1 + delta, pos2 + delta, bondRadius * 1.15,
+                               color1, color2, i);
+        cylinders->addCylinder(pos1 - delta, pos2 - delta, bondRadius * 1.15,
+                               color1, color2, i);
       }
       default:
       case 1:
         cylinders->addCylinder(pos1, pos2, m_bondRadius, color1, color2, i);
         break;
       case 2: {
-        Vector3f delta = bondVector.unitOrthogonal() * bondRadius;
-        cylinders->addCylinder(pos1 + delta, pos2 + delta, bondRadius, color1,
-                               color2, i);
-        cylinders->addCylinder(pos1 - delta, pos2 - delta, bondRadius, color1,
-                               color2, i);
+        Vector3f delta = bondVector.unitOrthogonal();
+        // Rotate 45 degrees around the bond vector.
+        Eigen::Quaternionf q;
+        q = Eigen::AngleAxisf(45.0f * DEG_TO_RAD_F, bondVector);
+        delta = q * delta * bondRadius;
+        cylinders->addCylinder(pos1 + delta, pos2 + delta, bondRadius * 1.3,
+                               color1, color2, i);
+        cylinders->addCylinder(pos1 - delta, pos2 - delta, bondRadius * 1.3,
+                               color1, color2, i);
       }
     }
   }
@@ -278,4 +285,4 @@ void BallAndStick::showHydrogens(bool show)
   settings.setValue("ballandstick/showHydrogens", show);
 }
 
-} // namespace Avogadro
+} // namespace Avogadro::QtPlugins


### PR DESCRIPTION
Orthogonal unit vector always seems to be in the XY plane

I'll clean this up a bit so it doesn't have weird constants

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
