### PR TITLE
Fix build with clang: reinterpret_cast<const GLvoid*>(NULL)

### DIFF
--- a/avogadro/rendering/ambientocclusionspheregeometry.cpp
+++ b/avogadro/rendering/ambientocclusionspheregeometry.cpp
@@ -910,7 +910,7 @@ public:
     // draw
     glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(m_numVertices),
                         static_cast<GLsizei>(m_numIndices), GL_UNSIGNED_INT,
-                        reinterpret_cast<const GLvoid*>(NULL));
+                        (const GLvoid*)nullptr);
 
     m_vbo.release();
     m_ibo.release();
@@ -984,7 +984,7 @@ public:
     // draw
     glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(m_numVertices),
                         static_cast<GLsizei>(m_numIndices), GL_UNSIGNED_INT,
-                        reinterpret_cast<const GLvoid*>(NULL));
+                        (const GLvoid*)nullptr);
 
     m_vbo.release();
     m_ibo.release();
@@ -1298,7 +1298,7 @@ void AmbientOcclusionSphereGeometry::render(const Camera& camera)
   // Render the loaded spheres using the shader and bound VBO.
   glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(d->numberOfVertices),
                       static_cast<GLsizei>(d->numberOfIndices), GL_UNSIGNED_INT,
-                      reinterpret_cast<const GLvoid*>(NULL));
+                      (const GLvoid*)nullptr);
 
   d->vbo.release();
   d->ibo.release();

--- a/avogadro/rendering/spheregeometry.cpp
+++ b/avogadro/rendering/spheregeometry.cpp
@@ -203,7 +203,7 @@ void SphereGeometry::render(const Camera& camera)
   // Render the loaded spheres using the shader and bound VBO.
   glDrawRangeElements(GL_TRIANGLES, 0, static_cast<GLuint>(d->numberOfVertices),
                       static_cast<GLsizei>(d->numberOfIndices), GL_UNSIGNED_INT,
-                      reinterpret_cast<const GLvoid*>(NULL));
+                      (const GLvoid*)nullptr);
 
   d->vbo.release();
   d->ibo.release();


### PR DESCRIPTION
Firstly, NULL isn't strictly defined in modern C++ and it can be defined as "0".

Secondly, clang fails on 'reinterpret_cast<const GLvoid*>(nullptr)':
error: reinterpret_cast from 'std::nullptr_t' to 'const GLvoid *' (aka 'const void *') is not allowed

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
