### PR TITLE
Ensure the VTK plot widget has a minimum size

### DIFF
--- a/avogadro/vtk/vtkplot.cpp
+++ b/avogadro/vtk/vtkplot.cpp
@@ -35,6 +35,9 @@ namespace Avogadro::VTK {
 VtkPlot::VtkPlot() : m_widget(new QVTKOpenGLStereoWidget)
 {
   m_widget->setRenderWindow(m_renderWindow);
+  // This is a hack to ensure something is displayed.
+  m_widget->setMinimumWidth(600);
+  m_widget->setMinimumHeight(600);
 
   // Set up the view
   m_widget->setFormat(QVTKOpenGLStereoWidget::defaultFormat());


### PR DESCRIPTION
This is very hackish, but it allows you to see the plot. The main issue is that this should have always been in a dialog or similar with a layout. The way that VTK interacts with Qt has changed and so the size being set does not appear to act as it once did. Issue #1107.