### PR TITLE
Advanced option to use the system generateXrd

### DIFF
--- a/avogadro/qtplugins/plotxrd/CMakeLists.txt
+++ b/avogadro/qtplugins/plotxrd/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Download the executable if we are not to use the system one
+option(USE_SYSTEM_GENXRDPATTERN "Use the system genxrdpattern" ON)
+mark_as_advanced(USE_SYSTEM_GENXRDPATTERN)
 if(NOT USE_SYSTEM_GENXRDPATTERN)
   include(DownloadGenXrdPattern)
   DownloadGenXrdPattern()
-endif(NOT USE_SYSTEM_GENXRDPATTERN)
+endif()
 
 set(plotxrd_srcs
   plotxrd.cpp


### PR DESCRIPTION
We shouldn't download things during build by default. Ideally this would get packaged or added as a step in the superbuild. Fixes issue #1186 by defaulting to expect a system binary.