### PR TITLE
Temporarily disable Codacy scan

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -14,13 +14,14 @@
 name: Codacy Security Scan
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
-  schedule:
-    - cron: '28 10 * * 6'
+  workflow_dispatch:
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    # The branches below must be a subset of the branches above
+#    branches: [ master ]
+#  schedule:
+#    - cron: '28 10 * * 6'
 
 permissions:
   contents: read


### PR DESCRIPTION
Convert it to a workflow manual option
(Generally, this is very high noise anyway)
