### PR TITLE
Fix some compiler warnings not related to Qt

### DIFF
--- a/avogadro/core/ringperceiver.cpp
+++ b/avogadro/core/ringperceiver.cpp
@@ -47,11 +47,6 @@ DistanceMatrix::~DistanceMatrix()
   delete[] m_values;
 }
 
-size_t DistanceMatrix::operator()(size_t i, size_t j) const
-{
-  return m_values[i * m_size + j];
-}
-
 size_t& DistanceMatrix::operator()(size_t i, size_t j)
 {
   return m_values[i * m_size + j];

--- a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
+++ b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
@@ -759,13 +759,13 @@ void Cp2kInputDialog::updatePreviewText()
   file += "&END FORCE_EVAL\n";
 
   if (m_molecule) {
-    std::vector<int> atomList;
+    std::vector<unsigned int> atomList;
     bool inlist = true;
 
     for (size_t i = 0; i < m_molecule->atomCount(); ++i) {
       Core::Atom atom = m_molecule->atom(i);
-      for (int i : atomList) {
-        if (i == atom.atomicNumber()) {
+      for (unsigned iat : atomList) {
+        if (iat == atom.atomicNumber()) {
           inlist = false;
           break;
         } else {

--- a/avogadro/qtplugins/scriptcharges/scriptchargemodel.cpp
+++ b/avogadro/qtplugins/scriptcharges/scriptchargemodel.cpp
@@ -358,11 +358,11 @@ void ScriptChargeModel::processElementString(const QString& str)
   str2.replace(',', ' ');
   // then split on whitespace
   QStringList strList = str2.split(QRegExp("\\s+"), QString::SkipEmptyParts);
-  foreach (QString str, strList) {
+  foreach (QString sstr, strList) {
     // these should be numbers or ranges (e.g., 1-84)
-    if (str.contains('-')) {
+    if (sstr.contains('-')) {
       // range, so split on the dash
-      QStringList strList2 = str.split('-');
+      QStringList strList2 = sstr.split('-');
       if (strList2.size() != 2)
         return;
 
@@ -379,7 +379,7 @@ void ScriptChargeModel::processElementString(const QString& str)
     }
 
     bool ok;
-    int i = str.toInt(&ok);
+    int i = sstr.toInt(&ok);
     if (!ok || i < 1 || i > 119)
       return;
 

--- a/avogadro/qtplugins/symmetry/symmetry.cpp
+++ b/avogadro/qtplugins/symmetry/symmetry.cpp
@@ -183,15 +183,14 @@ void Symmetry::detectSymmetry()
   // interface with libmsym
   msym_error_t ret = MSYM_SUCCESS;
   msym_element_t* elements = nullptr;
-  const char* error = nullptr;
   char point_group[6];
-  double cm[3], radius = 0.0, symerr = 0.0;
+  double cm[3], radius = 0.0;
 
   /* Do not free these variables */
   const msym_symmetry_operation_t* msops = nullptr;
   const msym_subgroup_t* msg = nullptr;
   const msym_equivalence_set_t* mes = nullptr;
-  int mesl = 0, msgl = 0, msopsl = 0, mlength = 0;
+  int mesl = 0, msgl = 0, msopsl = 0;
 
   // initialize the c-style array of atom names and coordinates
   msym_element_t* a;

--- a/avogadro/qtplugins/symmetry/symmetrywidget.cpp
+++ b/avogadro/qtplugins/symmetry/symmetrywidget.cpp
@@ -285,10 +285,10 @@ void SymmetryWidget::equivalenceSelectionChanged(
   if (a == nullptr)
     return;
 
-  unsigned int length = m_molecule->atomCount();
+  Index length = m_molecule->atomCount();
   // unselect all the atoms
-  for (Index i = 0; i < length; ++i) {
-    m_molecule->setAtomSelected(i, false);
+  for (Index iat = 0; iat < length; ++iat) {
+    m_molecule->setAtomSelected(iat, false);
   }
   // this is yucky, but libmsym uses <void*> for id
   auto selectedAtom = reinterpret_cast<Index>(a->id);

--- a/utilities/resdata/resdataparse.cxx
+++ b/utilities/resdata/resdataparse.cxx
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
           output << "ResidueData " << currResidue << "Data(\"" << currResidue
                  << "\",\n"
                  << "// Atoms\n{";
-          int i = 0;
+          size_t i = 0;
           for (i = 0; i < atoms.size(); ++i) {
             output << "\"" << atoms[i] << "\"";
             if (i != atoms.size() - 1)
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
   }
 
   output << "std::map<std::string, ResidueData> residueDict = {\n";
-  for (int j = 0; j < residueClassNames.size(); ++j) {
+  for (size_t j = 0; j < residueClassNames.size(); ++j) {
     output << "{\"" << residueClassNames[j] << "\", " << residueClassNames[j]
            << "Data}";
     if (j != residueClassNames.size() - 1)


### PR DESCRIPTION
There are a few more related to Qt where `length()` methods return `int` that I didn't touch under the assumption that Qt 6 may change things.

---

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
