### PR TITLE
Adjust nitrogen valence determination

### DIFF
--- a/avogadro/core/mdlvalence_p.h
+++ b/avogadro/core/mdlvalence_p.h
@@ -97,7 +97,7 @@ static unsigned int atomValence(const unsigned char atomicNumber,
         case -1:
           return 2;
         case 0:
-          if (numBonds <= 3)
+          if (numBonds != 5)
             return 3;
           return 5;
         case 1:

--- a/tests/qtgui/hydrogentoolstest.cpp
+++ b/tests/qtgui/hydrogentoolstest.cpp
@@ -173,9 +173,10 @@ TEST(HydrogenToolsTest, valencyAdjustment_N)
   RWAtom N = mol.addAtom(7);
   int expectedAdjustment = 3;
   for (int i = 0; i < 8; ++i, --expectedAdjustment) {
-    if (i == 4) // neutral N can have 3 or 5 bonds in our valence model.
-      expectedAdjustment += 2;
-    EXPECT_EQ(expectedAdjustment, HydrogenTools::valencyAdjustment(N));
+    if (i == 5) // neutral N can have 3 or 5 bonds in our valence model.
+      EXPECT_EQ(0, HydrogenTools::valencyAdjustment(N));
+    else
+      EXPECT_EQ(expectedAdjustment, HydrogenTools::valencyAdjustment(N));
     mol.addBond(mol.addAtom(1), N, 1);
   }
 }


### PR DESCRIPTION
Fix #1201 - only allow valence of 5 if there's a nitro group

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
