### PR TITLE
Give better warnings when scripts do not load

### DIFF
--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -100,7 +100,7 @@ QByteArray PythonScript::execute(const QStringList& args,
 
   // Write scriptStdin to the process's stdin
   if (!scriptStdin.isNull()) {
-    if (!proc.waitForStarted(5000)) {
+    if (!proc.waitForStarted(5000) && m_debug) {
       m_errors << tr("Error running script '%1 %2': Timed out waiting for "
                      "start (%3).")
                     .arg(m_pythonInterpreter,
@@ -110,7 +110,7 @@ QByteArray PythonScript::execute(const QStringList& args,
     }
 
     qint64 len = proc.write(scriptStdin);
-    if (len != static_cast<qint64>(scriptStdin.size())) {
+    if (len != static_cast<qint64>(scriptStdin.size()) && m_debug) {
       m_errors << tr("Error running script '%1 %2': failed to write to stdin "
                      "(len=%3, wrote %4 bytes, QProcess error: %5).")
                     .arg(m_pythonInterpreter)
@@ -123,7 +123,7 @@ QByteArray PythonScript::execute(const QStringList& args,
     proc.closeWriteChannel();
   }
 
-  if (!proc.waitForFinished(5000)) {
+  if (!proc.waitForFinished(5000) && m_debug) {
     m_errors << tr("Error running script '%1 %2': Timed out waiting for "
                    "finish (%3).")
                   .arg(m_pythonInterpreter, realArgs.join(QStringLiteral(" ")),
@@ -132,14 +132,17 @@ QByteArray PythonScript::execute(const QStringList& args,
   }
 
   if (proc.exitStatus() != QProcess::NormalExit || proc.exitCode() != 0) {
-    m_errors << tr("Error running script '%1 %2': Abnormal exit status %3 "
-                   "(%4: %5)\n\nOutput:\n%6")
-                  .arg(m_pythonInterpreter)
-                  .arg(realArgs.join(QStringLiteral(" ")))
-                  .arg(proc.exitCode())
-                  .arg(processErrorString(proc))
-                  .arg(proc.errorString())
-                  .arg(QString(proc.readAll()));
+    if (m_debug)
+      m_errors << tr("Error running script '%1 %2': Abnormal exit status %3 "
+                     "(%4: %5)\n\nOutput:\n%6")
+                    .arg(m_pythonInterpreter)
+                    .arg(realArgs.join(QStringLiteral(" ")))
+                    .arg(proc.exitCode())
+                    .arg(processErrorString(proc))
+                    .arg(proc.errorString())
+                    .arg(QString(proc.readAll()));
+    else
+      m_errors << tr("Warning '%1'").arg(proc.errorString());
     return QByteArray();
   }
 
@@ -254,4 +257,4 @@ QString PythonScript::processErrorString(const QProcess& proc) const
   return result;
 }
 
-} // namespace Avogadro
+} // namespace Avogadro::QtGui

--- a/avogadro/qtgui/scriptloader.cpp
+++ b/avogadro/qtgui/scriptloader.cpp
@@ -40,9 +40,8 @@ bool ScriptLoader::queryProgramName(const QString& scriptFilePath,
   displayName = gen.displayName();
   if (gen.hasErrors()) {
     displayName.clear();
-    qWarning() << "ScriptLoader::queryProgramName: Unable to retrieve program "
-                  "name for"
-               << scriptFilePath << ";" << gen.errorList().join("\n\n");
+    qWarning() << tr("Cannot load script %1")
+                    .arg(scriptFilePath);
     return false;
   }
   return true;
@@ -69,7 +68,7 @@ QMap<QString, QString> ScriptLoader::scriptList(const QString& type)
   // build up a list of possible files, then we check if they're real scripts
   QStringList fileList;
   foreach (const QString& dirStr, dirs) {
-    qDebug() << "Checking for " << type << " scripts in" << dirStr;
+    qDebug() << tr("Checking for %1 scripts in path %2").arg(type).arg(dirStr);
     QDir dir(dirStr);
     if (dir.exists() && dir.isReadable()) {
       foreach (

--- a/avogadro/qtgui/scriptloader.cpp
+++ b/avogadro/qtgui/scriptloader.cpp
@@ -27,9 +27,7 @@
 
 namespace Avogadro::QtGui {
 
-ScriptLoader::ScriptLoader(QObject* parent_)
-  : QObject(parent_)
-{}
+ScriptLoader::ScriptLoader(QObject* parent_) : QObject(parent_) {}
 
 ScriptLoader::~ScriptLoader() {}
 
@@ -40,8 +38,7 @@ bool ScriptLoader::queryProgramName(const QString& scriptFilePath,
   displayName = gen.displayName();
   if (gen.hasErrors()) {
     displayName.clear();
-    qWarning() << tr("Cannot load script %1")
-                    .arg(scriptFilePath);
+    qWarning() << tr("Cannot load script %1").arg(scriptFilePath);
     return false;
   }
   return true;
@@ -96,7 +93,7 @@ QMap<QString, QString> ScriptLoader::scriptList(const QString& type)
               if (commands.type() == QJsonValue::Array) {
                 // check if "command.*" exists as a file
                 QJsonArray list = commands.toArray();
-                for (auto && i : list) {
+                for (auto&& i : list) {
                   QJsonValue command = i.toObject()["command"];
                   QString name = command.toString();
                   if (name.isEmpty() || name.isNull())
@@ -152,4 +149,4 @@ QMap<QString, QString> ScriptLoader::scriptList(const QString& type)
   return scriptList;
 }
 
-} // namespace Avogadro
+} // namespace Avogadro::QtGui

--- a/avogadro/qtplugins/scriptcharges/chargeScripts/antechamber.py
+++ b/avogadro/qtplugins/scriptcharges/chargeScripts/antechamber.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
         if name:
             print(name)
         else:
-            raise RuntimeError("antechamber is unavailable")
+            sys.exit("antechamber is unavailable")
     elif args["charges"]:
         print(charges())
     elif args["potential"]:

--- a/avogadro/qtplugins/scriptcharges/chargeScripts/xtb.py
+++ b/avogadro/qtplugins/scriptcharges/chargeScripts/xtb.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         if name:
             print(name)
         else:
-            raise RuntimeError("xtb is unavailable")
+            sys.exit("xtb is unavailable")
     elif args["charges"]:
         print(charges())
     elif args["potential"]:


### PR DESCRIPTION
Fix #1323 - now indicates Cannot load script /path/to/antechamber.py Also enables i18n of script loader strings

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
