### PR TITLE
Add team-id secret for Mac notarytool

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -276,15 +276,16 @@ jobs:
         # check if we have the password and the username
         if [ -n "${NOTARIZE_PASSWORD}" ] && [ -n "${NOTARIZE_USERNAME}" ]; then
           codesign -s "$CODESIGN_IDENTITY" --timestamp Avogadro2*.dmg
-          xcrun notarytool submit Avogadro2*.dmg --apple-id "$NOTARIZE_USERNAME" --password "NOTARIZE_PASSWORD" --verbose --wait
+          xcrun notarytool submit Avogadro2*.dmg --apple-id "$NOTARIZE_USERNAME" --team-id "$NOTARIZE_TEAM" --password "$NOTARIZE_PASSWORD" --verbose --wait
           xcrun stapler staple -v Avogadro2*.dmg
         fi
       working-directory: ${{ runner.workspace }}/build/avogadroapp
       env:
+        NOTARIZE_TEAM: ${{ secrets.AC_TEAM }}
         NOTARIZE_USERNAME: ${{ secrets.AC_USERNAME }}
         NOTARIZE_PASSWORD: ${{ secrets.AC_PASSWORD }}
         CODESIGN_IDENTITY: ${{ secrets.CODESIGN_ID }}
-        PRODUCT_BUNDLE_IDENTIFIER: cc.avogadro
+      continue-on-error: true
 
     - name: Setup tmate session
       if: ${{ failure() }}

--- a/.github/workflows/build_m1.yml
+++ b/.github/workflows/build_m1.yml
@@ -162,14 +162,14 @@ jobs:
           echo "codesign DMG"
           codesign -s "$CODESIGN_IDENTITY" --timestamp Avogadro2*.dmg
           echo "notarizing"
-          xcrun notarytool submit Avogadro2*.dmg --apple-id "$NOTARIZE_USERNAME" --password "NOTARIZE_PASSWORD" --verbose --wait
+          xcrun notarytool submit Avogadro2*.dmg --apple-id "$NOTARIZE_USERNAME" --team-id "$NOTARIZE_TEAM" --password "$NOTARIZE_PASSWORD" --verbose --wait
           xcrun stapler staple -v Avogadro2*.dmg
         fi
       env:
         NOTARIZE_USERNAME: ${{ secrets.AC_USERNAME }}
         NOTARIZE_PASSWORD: ${{ secrets.AC_PASSWORD }}
         CODESIGN_IDENTITY: ${{ secrets.CODESIGN_ID }}
-        PRODUCT_BUNDLE_IDENTIFIER: cc.avogadro
+        NOTARIZE_TEAM: ${{ secrets.AC_TEAM }}
       continue-on-error: true
       working-directory: ${{ runner.workspace }}/build/avogadroapp
 


### PR DESCRIPTION
Also will continue on error if notarytool fails
(It just means users need a network connection to validate.)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
