### PR TITLE
Add molden as a possible reader for generic `.out` files

### DIFF
--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -9,6 +9,7 @@
 #include <avogadro/io/fileformatmanager.h>
 
 #include "gamessus.h"
+#include "molden.h"
 #include "nwchemlog.h"
 #include "orca.h"
 
@@ -49,6 +50,10 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
     } else if (line.find("GAMESS VERSION") != std::string::npos) {
       // GAMESS-US .. don't know if we can read Firefly or GAMESS-UK
       reader = new GAMESSUSOutput;
+      break;
+    } else if (line.find("[Molden Format]") != std::string::npos) {
+      // molden with .out extension
+      reader = new MoldenFile;
       break;
     } else if (line.find("O   R   C   A") != std::string::npos) {
       // ORCA reader


### PR DESCRIPTION
See https://discuss.avogadro.cc/t/impossible-to-read-molden-file/4924/

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
