### PR TITLE
vtk: Add missing OpenGL link target

### DIFF
--- a/avogadro/vtk/CMakeLists.txt
+++ b/avogadro/vtk/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(Vtk PUBLIC Avogadro::Rendering Avogadro::QtGui
   VTK::RenderingOpenGL2 VTK::GUISupportQt VTK::RenderingVolumeOpenGL2
   VTK::RenderingFreeType VTK::InteractionStyle VTK::ChartsCore VTK::ViewsContext2D
   VTK::RenderingContextOpenGL2 VTK::DomainsChemistryOpenGL2 Qt::Widgets
-  PRIVATE GLEW::GLEW)
+  PRIVATE GLEW::GLEW OpenGL::GL)
 
 vtk_module_autoinit(TARGETS Vtk MODULES
   VTK::RenderingOpenGL2 VTK::GUISupportQt VTK::RenderingVolumeOpenGL2


### PR DESCRIPTION
Without this, linking fails with
```
CMakeFiles/Vtk.dir/vtkAvogadroActor.cpp.o: in function `vtkAvogadroActor::RenderOpaqueGeometry(vtkViewport*)':
/usr/src/debug/avogadrolibs/avogadrolibs-1.98.0/avogadro/vtk/vtkAvogadroActor.cpp:56:(.text+0x27a): undefined reference to `glGetFloatv'
/usr/bin/ld: /usr/src/debug/avogadrolibs/avogadrolibs-1.98.0/avogadro/vtk/vtkAvogadroActor.cpp:57:(.text+0x28d): undefined reference to `glGetFloatv'
/usr/bin/ld: CMakeFiles/Vtk.dir/vtkAvogadroActor.cpp.o: in function `vtkAvogadroActor::RenderTranslucentPolygonalGeometry(vtkViewport*)':
/usr/src/debug/avogadrolibs/avogadrolibs-1.98.0/avogadro/vtk/vtkAvogadroActor.cpp:74:(.text+0x4af): undefined reference to `glGetFloatv'
/usr/bin/ld: /usr/src/debug/avogadrolibs/avogadrolibs-1.98.0/avogadro/vtk/vtkAvogadroActor.cpp:75:(.text+0x4c2): undefined reference to `glGetFloatv'
collect2: error: ld returned 1 exit status
```

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
