### PR TITLE
Make sure that filename validation occurs on save, not open

### DIFF
--- a/avogadro/io/fileformat.cpp
+++ b/avogadro/io/fileformat.cpp
@@ -63,7 +63,7 @@ bool FileFormat::open(const std::string& fileName_, Operation mode_)
   close();
   m_fileName = fileName_;
   m_mode = mode_;
-  if (!m_fileName.empty() && validateFileName(m_fileName)) {
+  if (!m_fileName.empty()) {
     // Imbue the standard C locale.
     locale cLocale("C");
     if (m_mode & Read) {
@@ -76,7 +76,7 @@ bool FileFormat::open(const std::string& fileName_, Operation mode_)
         appendError("Error opening file: " + fileName_);
         return false;
       }
-    } else if (m_mode & Write) {
+    } else if (m_mode & Write && validateFileName(m_fileName)) {
       auto* file = new ofstream(m_fileName.c_str(), std::ofstream::binary);
       m_out = file;
       if (file->is_open()) {

--- a/avogadro/qtgui/fileformatdialog.cpp
+++ b/avogadro/qtgui/fileformatdialog.cpp
@@ -88,7 +88,7 @@ FileFormatDialog::FormatFilePair FileFormatDialog::fileToWrite(
 
     if (FileFormat::validateFileName(fileName.toStdString()) == false) {
       QMessageBox::warning(
-        parent, caption,
+        parentWidget, caption,
         tr("The file name contains invalid characters. Please choose another "
            "file name."));
       continue;

--- a/avogadro/qtgui/fileformatdialog.cpp
+++ b/avogadro/qtgui/fileformatdialog.cpp
@@ -42,14 +42,6 @@ FileFormatDialog::FormatFilePair FileFormatDialog::fileToRead(
     if (fileName.isEmpty()) // user cancel
       return result;
 
-    if (FileFormat::validateFileName(fileName.toStdString()) == false) {
-      QMessageBox::warning(
-        parent, caption,
-        tr("The file name contains invalid characters. Please choose another "
-           "file name."));
-      continue;
-    }
-
     const Io::FileFormat* format = findFileFormat(
       parent, caption, fileName, FileFormat::File | FileFormat::Read);
 
@@ -93,6 +85,14 @@ FileFormatDialog::FormatFilePair FileFormatDialog::fileToWrite(
 
     if (fileName.isEmpty()) // user cancel
       return result;
+
+    if (FileFormat::validateFileName(fileName.toStdString()) == false) {
+      QMessageBox::warning(
+        parent, caption,
+        tr("The file name contains invalid characters. Please choose another "
+           "file name."));
+      continue;
+    }
 
     const Io::FileFormat* format = findFileFormat(
       parentWidget, caption, fileName, FileFormat::File | FileFormat::Write);


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
