### PR TITLE
Avoid segfaulting while manipulating carbon bonds/hydrogens

### DIFF
--- a/avogadro/qtgui/hydrogentools.cpp
+++ b/avogadro/qtgui/hydrogentools.cpp
@@ -134,6 +134,9 @@ void HydrogenTools::adjustHydrogens(RWAtom& atom, Adjustment adjustment)
   // convenience
   RWMolecule* molecule = atom.molecule();
 
+  if (molecule == nullptr)
+    return;
+
   if (doRemove) {
     // get the list of hydrogens connected to this
     std::vector<size_t> badHIndices;


### PR DESCRIPTION
Figured I'd create this as a band-aid fix for https://github.com/OpenChemistry/avogadrolibs/issues/1492 (exact sequence of steps and screenshots included in that issue), just to avoid any crashes which could occur from someone accidentally triggering this pathway while editing something more complex. Still some more work to do to diagnose the real root cause behind the previously mentioned issue and https://github.com/OpenChemistry/avogadrolibs/issues/1478, but not sure how long that will take me to track down. 

Also happy to hold off on merging this possibly temporary fix if that sounds preferable, either way. 

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
