### PR TITLE
Add specialization for char* and MatrixXf types

### DIFF
--- a/avogadro/core/variant-inline.h
+++ b/avogadro/core/variant-inline.h
@@ -21,11 +21,13 @@ inline Variant::Variant(T v) : m_type(Null)
   setValue(v);
 }
 
+template <>
 inline Variant::Variant(const char* v) : m_type(String)
 {
   m_value.string = new std::string(v);
 }
 
+template <>
 inline Variant::Variant(const MatrixXf& v) : m_type(Matrix)
 {
   MatrixX* m = new MatrixX(v.rows(), v.cols());

--- a/avogadro/core/variant-inline.h
+++ b/avogadro/core/variant-inline.h
@@ -13,14 +13,24 @@
 namespace Avogadro {
 namespace Core {
 
-inline Variant::Variant() : m_type(Null)
-{
-}
+inline Variant::Variant() : m_type(Null) {}
 
 template <typename T>
 inline Variant::Variant(T v) : m_type(Null)
 {
   setValue(v);
+}
+
+inline Variant::Variant(const char* v) : m_type(String)
+{
+  m_value.string = new std::string(v);
+}
+
+inline Variant::Variant(const MatrixXf& v) : m_type(Matrix)
+{
+  MatrixX* m = new MatrixX(v.rows(), v.cols());
+  *m = v.cast<double>();
+  m_value.matrix = m;
 }
 
 inline Variant::Variant(const Variant& variant) : m_type(variant.type())
@@ -444,7 +454,7 @@ inline T Variant::lexical_cast(const std::string& str)
   return value;
 }
 
-} // end Core namespace
-} // end Avogadro namespace
+} // namespace Core
+} // namespace Avogadro
 
 #endif // AVOGADRO_CORE_VARIANT_INLINE_H

--- a/avogadro/core/variant.h
+++ b/avogadro/core/variant.h
@@ -48,12 +48,6 @@ public:
   template <typename T>
   Variant(T value);
 
-  /** Creates a std::string variant to store @p value */
-  Variant(const char* value);
-
-  /** Creates a MatrixX variant to store @p value */
-  Variant(const MatrixXf& value);
-
   /** Creates a new copy of @p variant. */
   inline Variant(const Variant& variant);
 

--- a/avogadro/core/variant.h
+++ b/avogadro/core/variant.h
@@ -48,6 +48,12 @@ public:
   template <typename T>
   Variant(T value);
 
+  /** Creates a std::string variant to store @p value */
+  Variant(const char* value);
+
+  /** Creates a MatrixX variant to store @p value */
+  Variant(const MatrixXf& value);
+
   /** Creates a new copy of @p variant. */
   inline Variant(const Variant& variant);
 
@@ -146,8 +152,8 @@ private:
   } m_value;
 };
 
-} // end Core namespace
-} // end Avogadro namespace
+} // namespace Core
+} // namespace Avogadro
 
 #include "variant-inline.h"
 


### PR DESCRIPTION
Implicit conversion does not work for these types

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
