### PR TITLE
add UniqueID label type

### DIFF
--- a/avogadro/qtplugins/label/label.cpp
+++ b/avogadro/qtplugins/label/label.cpp
@@ -66,7 +66,8 @@ struct LayerLabel : Core::LayerData
     Index = 0x01,
     Name = 0x02,
     Custom = 0x04,
-    Ordinal = 0x08
+    Ordinal = 0x08,
+    UniqueID = 0x16
   };
   unsigned short atomOptions;
   unsigned short residueOptions;
@@ -326,6 +327,9 @@ void Label::processAtom(const Core::Molecule& molecule,
       text += (text == "" ? "" : " / ") +
               std::string(Elements::symbol(atomicNumber) +
                           std::to_string(atomCount[atomicNumber]));
+    }
+    if (interface.atomOptions & LayerLabel::LabelOptions::UniqueID) {
+      text += (text == "" ? "" : " / ") + std::to_string(atom.index());
     }
     if (text != "") {
       const Vector3f pos(atom.position3d().cast<float>());

--- a/avogadro/qtplugins/label/label.cpp
+++ b/avogadro/qtplugins/label/label.cpp
@@ -148,7 +148,7 @@ struct LayerLabel : Core::LayerData
 
       auto* atom = new QComboBox;
       atom->setObjectName("atom");
-      char elements[] = { None, Index, Name, Custom, Ordinal };
+      char elements[] = { None, Index, Name, Custom, Ordinal, UniqueID };
       for (char option : elements) {
         if (option == 0) {
           atom->addItem(QObject::tr("None"), QVariant(LabelOptions::None));
@@ -173,6 +173,11 @@ struct LayerLabel : Core::LayerData
             text << ((text.size() == 0) ? QObject::tr("Element & Number")
                                         : QObject::tr("El.&No."));
             val |= LabelOptions::Ordinal;
+          }
+          if (option & LabelOptions::UniqueID) {
+            text << ((text.size() == 0) ? QObject::tr("Unique ID")
+                                        : QObject::tr("Un.ID"));
+            val |= LabelOptions::UniqueID;
           }
           QString join = QObject::tr(", ");
           atom->addItem(text.join(join), QVariant(val));


### PR DESCRIPTION
If UniqueID label type is chosen, atoms are numbered from zero, in contrast to index, where atoms are human-numbered from unity.

UniqueID mode is needed e.g. for chemists working with Orca quantum chemistry software. It is common to specify atoms in Orca input file (e.g., for a forming bond in a TS search), and Orca counts from zero.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
