### PR TITLE
Refactor Cube class to use smart pointers

### DIFF
--- a/avogadro/core/cube.cpp
+++ b/avogadro/core/cube.cpp
@@ -7,21 +7,17 @@
 
 #include "molecule.h"
 #include "mutex.h"
+#include <memory>
 
 namespace Avogadro::Core {
 
-Cube::Cube()
-  : m_data(0), m_min(0.0, 0.0, 0.0), m_max(0.0, 0.0, 0.0),
-    m_spacing(0.0, 0.0, 0.0), m_points(0, 0, 0), m_minValue(0.0),
-    m_maxValue(0.0), m_lock(new Mutex)
-{
-}
+    Cube::Cube()
+            : m_data(0), m_min(0.0, 0.0, 0.0), m_max(0.0, 0.0, 0.0),
+              m_spacing(0.0, 0.0, 0.0), m_points(0, 0, 0), m_minValue(0.0),
+              m_maxValue(0.0),
+              m_lock(std::make_unique<Mutex>()) // Initializes m_lock with a new Mutex instance
 
-Cube::~Cube()
-{
-  delete m_lock;
-  m_lock = nullptr;
-}
+    Cube:: ~Cube() = default; // With unique_ptr, default destructor is fine.
 
 bool Cube::setLimits(const Vector3& min_, const Vector3& max_,
                      const Vector3i& points)


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

This is in response to issue #1346 /Continue Modernizing Code’

This commit replaces raw pointers with `std::unique_ptr` for managing
the `Mutex` in the `Cube` class. The constructor and destructor have been updated accordingly, enhancing resource management and code safety.

  Manual memory management with raw pointers is error-prone and
  can lead to memory leaks or double deletion issues. By adopting
  `std::unique_ptr`, we automatically manage the lifecycle of `Mutex`
  objects, aligning with modern C++ standards and best practices.

  - Ensures exception safety and automatic resource management.
  - Reduces boilerplate code for manual memory management.
  - Improves code readability and maintainability.

**Affected Files**:
- `avogadro/core/cube.cpp`


Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
