### PR TITLE
Fix crash at startup when opening a file from commandline

### DIFF
--- a/avogadro/qtgui/sceneplugin.h
+++ b/avogadro/qtgui/sceneplugin.h
@@ -77,13 +77,26 @@ public:
    */
   virtual void setEnabled(bool enable);
 
+  /**
+   * @return the widget for plugin settings (e.g., colors, widths, etc.)
+   */
   virtual QWidget* setupWidget();
+  /**
+   * This method exists to query without creating the widget.
+   * @return true if the plugin has a setup widget
+   */
+  virtual bool hasSetupWidget() const { return false; }
 
   /**
-  * Returns if this plugin should be considered in the default behavior,
-  * or it should reset to true or false.
-  */
-  enum DefaultBehavior { Ignore, False, True };
+   * Returns if this plugin should be considered in the default behavior,
+   * or it should reset to true or false.
+   */
+  enum DefaultBehavior
+  {
+    Ignore,
+    False,
+    True
+  };
   virtual DefaultBehavior defaultBehavior() const { return Ignore; }
 
 signals:

--- a/avogadro/qtgui/scenepluginmodel.cpp
+++ b/avogadro/qtgui/scenepluginmodel.cpp
@@ -86,7 +86,7 @@ QVariant ScenePluginModel::data(const QModelIndex& index_, int role) const
     switch (role) {
       case Qt::DisplayRole:
       case Qt::EditRole:
-        return (item->setupWidget() != nullptr) ? "•••" : " ";
+        return (item->hasSetupWidget()) ? "•••" : " ";
       case Qt::ToolTipRole:
       case Qt::WhatsThisRole:
         return tr("Settings");

--- a/avogadro/qtplugins/ballandstick/ballandstick.h
+++ b/avogadro/qtplugins/ballandstick/ballandstick.h
@@ -34,6 +34,7 @@ public:
   }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {

--- a/avogadro/qtplugins/cartoons/cartoons.h
+++ b/avogadro/qtplugins/cartoons/cartoons.h
@@ -27,7 +27,10 @@ public:
   void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const override { return tr("Cartoons", "protein ribbon / cartoon rendering"); }
+  QString name() const override
+  {
+    return tr("Cartoons", "protein ribbon / cartoon rendering");
+  }
 
   QString description() const override
   {
@@ -35,6 +38,7 @@ public:
   }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {

--- a/avogadro/qtplugins/closecontacts/closecontacts.h
+++ b/avogadro/qtplugins/closecontacts/closecontacts.h
@@ -27,14 +27,18 @@ public:
   void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 
-  QString name() const override { return tr("Close Contacts", "rendering of non-covalent close contacts"); }
+  QString name() const override
+  {
+    return tr("Close Contacts", "rendering of non-covalent close contacts");
+  }
 
   QString description() const override
   {
     return tr("Render close contacts between atoms.");
   }
-  
+
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {
@@ -47,10 +51,10 @@ public slots:
 
 private:
   std::string m_name = "Close Contacts";
-  
-  const std::array<QString, 3> INTERACTION_NAMES = {
-	tr("Contact"), tr("Salt Bridge"), tr("Repulsive")
-  };
+
+  const std::array<QString, 3> INTERACTION_NAMES = { tr("Contact"),
+                                                     tr("Salt Bridge"),
+                                                     tr("Repulsive") };
 
   std::array<double, 3> m_maximumDistances;
   std::array<Vector3ub, 3> m_lineColors;

--- a/avogadro/qtplugins/crystal/crystalscene.h
+++ b/avogadro/qtplugins/crystal/crystalscene.h
@@ -36,6 +36,7 @@ public:
   }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
 private slots:
   void setColor(const QColor& color);

--- a/avogadro/qtplugins/label/label.h
+++ b/avogadro/qtplugins/label/label.h
@@ -30,6 +30,8 @@ public:
   }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
+
   void process(const QtGui::Molecule& molecule,
                Rendering::GroupNode& node) override;
 

--- a/avogadro/qtplugins/meshes/meshes.h
+++ b/avogadro/qtplugins/meshes/meshes.h
@@ -31,6 +31,7 @@ public:
   QString description() const override { return tr("Render polygon meshes."); }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {

--- a/avogadro/qtplugins/noncovalent/noncovalent.h
+++ b/avogadro/qtplugins/noncovalent/noncovalent.h
@@ -33,8 +33,9 @@ public:
   {
     return tr("Render a few non-covalent interactions.");
   }
-  
+
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {
@@ -48,11 +49,11 @@ public slots:
 
 private:
   const std::string m_name = "Non-Covalent";
-  
-  const std::array<QString, 3> INTERACTION_NAMES = {
-	tr("Hydrogen"), tr("Halogen"), tr("Chalcogen")
-  };
-  
+
+  const std::array<QString, 3> INTERACTION_NAMES = { tr("Hydrogen"),
+                                                     tr("Halogen"),
+                                                     tr("Chalcogen") };
+
   std::array<double, 3> m_angleTolerancesDegrees;
   std::array<double, 3> m_maximumDistances;
   std::array<Vector3ub, 3> m_lineColors;

--- a/avogadro/qtplugins/wireframe/wireframe.h
+++ b/avogadro/qtplugins/wireframe/wireframe.h
@@ -33,6 +33,7 @@ public:
   }
 
   QWidget* setupWidget() override;
+  bool hasSetupWidget() const override { return true; }
 
   DefaultBehavior defaultBehavior() const override
   {


### PR DESCRIPTION
App would query if render plugins had options too early Added separate method (vs. checking for nullptr)

Fix #1617

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
