### PR TITLE
Fix MacOS builds using older runner (x86 only) for now

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -44,8 +44,8 @@ jobs:
             cpack: "",
           }
         - {
-            name: "macOS Latest Clang", artifact: "macOS.dmg",
-            os: macos-latest,
+            name: "macOS Clang", artifact: "macOS.dmg",
+            os: macos-13,
             cc: "clang", cxx: "clang++",
             build_type: "Release",
             cmake_flags: "-G Ninja",
@@ -115,6 +115,18 @@ jobs:
       with:
         repository: openchemistry/molecules
         path: molecules
+
+    - name: Checkout fragments
+      uses: actions/checkout@v4
+      with:
+        repository: openchemistry/fragments
+        path: fragments
+
+    - name: Checkout crystals
+      uses: actions/checkout@v4
+      with:
+        repository: openchemistry/crystals
+        path: crystals
 
     - name: Checkout i18n
       uses: actions/checkout@v4

--- a/.github/workflows/build_qt6.yml
+++ b/.github/workflows/build_qt6.yml
@@ -39,7 +39,7 @@ jobs:
           }
         - {
             name: "macOS Qt6", artifact: "",
-            os: macos-latest,
+            os: macos-13,
             cc: "clang", cxx: "clang++",
             build_type: "Release",
             cmake_flags: "-G Ninja",


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
