### PR TITLE
Add double-check for addEdge to prevent potential crash

### DIFF
--- a/avogadro/core/graph.cpp
+++ b/avogadro/core/graph.cpp
@@ -224,7 +224,10 @@ size_t Graph::addEdge(size_t a, size_t b)
       m_subgraphDirty[subgraphA] || m_subgraphDirty[subgraphB];
     for (size_t i : m_subgraphToVertices[subgraphB]) {
       m_subgraphToVertices[subgraphA].insert(i);
-      m_vertexToSubgraph[i] = subgraphA;
+      if (i < m_vertexToSubgraph.size())
+        m_vertexToSubgraph[i] = subgraphA;
+      else
+        m_vertexToSubgraph.push_back(subgraphA);
     }
     // Just leave it empty, it could be reused
     m_subgraphToVertices[subgraphB].clear();
@@ -433,8 +436,7 @@ size_t Graph::edgeCount() const
 
 std::vector<size_t> Graph::neighbors(size_t index) const
 {
-  if(index==size())
-  {
+  if (index == size()) {
     std::vector<size_t> emptyVector;
     return std::vector<size_t>(emptyVector);
   }


### PR DESCRIPTION
Fixes bug from @aeonik
https://discuss.avogadro.cc/t/crash-when-dragging-atom-over-other-atom-to-create-bond/4964/18

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
