### PR TITLE
Ensure MacOS binary packages are built

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -317,7 +317,7 @@ jobs:
       continue-on-error: true
 
     - name: Setup tmate session
-      if: runner.os == 'macOS'
+      if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
 
     - name: Upload

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -317,7 +317,7 @@ jobs:
       continue-on-error: true
 
     - name: Setup tmate session
-      if: ${{ failure() }}
+      if: runner.os == 'macOS'
       uses: mxschmitt/action-tmate@v3
 
     - name: Upload

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -264,7 +264,7 @@ jobs:
         fi # password exists
 
     - name: Create Mac and Windows Packages
-      if: matrix.config.os == 'windows-latest' || matrix.config.os == 'macos-latest'
+      if: matrix.config.os == 'windows-latest' || runner.os == 'macOS'
       shell: bash
       run: |
         if [ -z "${P12_PASSWORD}" ]; then

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,7 @@ env:
   # Need to do some setup before repairing the wheel on linux...
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: bash scripts/github-actions/repair_command_linux.sh
 
-  CIBW_BEFORE_ALL_LINUX: yum install -y git eigen3-devel
+  CIBW_BEFORE_ALL_LINUX: bash scripts/github-actions/repair-linux.sh
 
   # Specify eigen location for windows
   CIBW_ENVIRONMENT_WINDOWS: "EXTRA_CMAKE_ARGS=-DEIGEN3_INCLUDE_DIR:PATH=/c/eigen"

--- a/scripts/github-actions/repair-linux.sh
+++ b/scripts/github-actions/repair-linux.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ev
+
+# CentOS 7 is EOL so mirror.centos.org is offline
+# https://serverfault.com/a/1161921
+
+sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
+yum install -y git eigen3-devel


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
