### PR TITLE
Fix manipulate dialog - rotate around origin, molecule center, selection center

### DIFF
--- a/avogadro/qtplugins/manipulator/manipulatewidget.ui
+++ b/avogadro/qtplugins/manipulator/manipulatewidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
-    <height>247</height>
+    <width>371</width>
+    <height>292</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -104,6 +104,39 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Rotate around:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="rotateComboBox">
+       <item>
+        <property name="text">
+         <string>Origin</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Center of Molecule</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Center of Selection</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="2" column="0">
       <widget class="QDoubleSpinBox" name="xRotateSpinBox">
@@ -174,23 +207,30 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_9">
        <property name="text">
-        <string>Rotate around:</string>
+        <string>Move:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="rotateComboBox">
+     <item>
+      <widget class="QComboBox" name="moveComboBox">
        <item>
         <property name="text">
-         <string>Origin</string>
+         <string>Selected Atoms</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Geometry</string>
+         <string>Everything Else</string>
         </property>
        </item>
       </widget>

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -70,8 +70,8 @@ private:
   void updatePressedButtons(QMouseEvent*, bool release);
 
   void resetObject() { m_object = Rendering::Identifier(); }
-  void translate(Vector3 delta);
-  void rotate(Vector3 delta, Vector3 centroid);
+  void translate(Vector3 delta, bool moveSelected = true);
+  void rotate(Vector3 delta, Vector3 centroid, bool moveSelected = true);
   void tilt(Vector3 delta, Vector3 centroid);
 
   QAction* m_activateAction;


### PR DESCRIPTION
Fix #1755 
Also allows rotating everything else if you want to fix the selection

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
