### PR TITLE
More signpath

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -145,7 +145,7 @@ jobs:
         signing-policy-slug: 'test-signing'
         github-artifact-id: '${{ steps.upload-artifact.outputs.artifact-id }}'
         wait-for-completion: true
-        output-artifact-directory: '${{ runner.workspace }}/build/avogadroapp'
+        output-artifact-directory: '../build/'
 
     - name: Setup tmate session
       if: failure()

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -147,6 +147,14 @@ jobs:
         wait-for-completion: true
         output-artifact-directory: '../build/'
 
+    - name: Upload
+      if: matrix.config.artifact != 0
+      id: upload-signed-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ runner.workspace }}/build/Win64*.*
+        name: 'Win64-signed.exe'
+
     - name: Setup tmate session
       if: failure()
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
