### PR TITLE
Explicitly use signed char in meshgenerator to avoid narrowing error on ARM

### DIFF
--- a/avogadro/qtgui/meshgenerator.cpp
+++ b/avogadro/qtgui/meshgenerator.cpp
@@ -454,7 +454,7 @@ void MeshGenerator::FlyingEdgesAlgorithmPass4()
             }
 
             // Add triangles
-            const char* caseTri = m_caseTriangles[caseId]; // size 16
+            const signed char* caseTri = m_caseTriangles[caseId]; // size 16
             for(int idx = 0; caseTri[idx] != -1; idx += 3)
             {
               

--- a/avogadro/qtgui/meshgenerator.cpp
+++ b/avogadro/qtgui/meshgenerator.cpp
@@ -925,7 +925,7 @@ const bool MeshGenerator::m_isCut[256][12] =
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 };
 
-const char MeshGenerator::m_caseTriangles[256][16]
+const signed char MeshGenerator::m_caseTriangles[256][16]
     {
         {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
         {0,  3,  8,  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},

--- a/avogadro/qtgui/meshgenerator.h
+++ b/avogadro/qtgui/meshgenerator.h
@@ -252,7 +252,7 @@ protected:
    */
   static const unsigned char m_numTris[256];
   static const bool m_isCut[256][12];
-  static const char m_caseTriangles[256][16];
+  static const signed char m_caseTriangles[256][16];
   static const unsigned char m_edgeVertices[12][2];
 };
 


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
