### PR TITLE
Fix both the manipulate and label tool to rotate / navigate by default

### DIFF
--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -667,11 +667,18 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
           // std::cout << " property: " << element.key() << " = " << matrix
           //           << " size " << matrix.rows() << 'x' << matrix.cols()
           //          << std::endl;
+        } else if (element.value().type() == json::value_t::number_float) {
+          molecule.setData(element.key(), element.value().get<double>());
+        } else if (element.value().type() == json::value_t::number_integer) {
+          molecule.setData(element.key(), element.value().get<int>());
+        } else if (element.value().type() == json::value_t::boolean) {
+          molecule.setData(element.key(), element.value().get<bool>());
+        } else if (element.value().type() == json::value_t::string) {
+          molecule.setData(element.key(), element.value().get<std::string>());
         } else {
-          molecule.setData(element.key(), element.value());
-          // std::cout << " property: " << element.key() << " = "
-          //          << element.value() << " type "
-          //          << element.value().type_name() << std::endl;
+          std::cout << " cannot store property: " << element.key() << " = "
+                    << element.value() << " type "
+                    << element.value().type_name() << std::endl;
         }
       }
     }

--- a/avogadro/qtplugins/label/labeleditor.cpp
+++ b/avogadro/qtplugins/label/labeleditor.cpp
@@ -32,7 +32,8 @@ LabelEditor::LabelEditor(QObject* parent_)
   m_activateAction->setText(tr("Edit Labels"));
   m_activateAction->setToolTip(
     tr("Atom Label Tool \t(%1)\n\n"
-       "Left Mouse: \tClick on Atoms to add Custom Labels").arg(shortcut));
+       "Left Mouse: \tClick on Atoms to add Custom Labels")
+      .arg(shortcut));
   setIcon();
 }
 
@@ -46,13 +47,15 @@ void LabelEditor::setIcon(bool darkTheme)
     m_activateAction->setIcon(QIcon(":/icons/label_light.svg"));
 }
 
-QUndoCommand* LabelEditor::mouseReleaseEvent(QMouseEvent*)
+QUndoCommand* LabelEditor::mouseReleaseEvent(QMouseEvent* e)
 {
+  e->ignore();
   return nullptr;
 }
 
-QUndoCommand* LabelEditor::mouseMoveEvent(QMouseEvent*)
+QUndoCommand* LabelEditor::mouseMoveEvent(QMouseEvent* e)
 {
+  e->ignore();
   return nullptr;
 }
 
@@ -82,7 +85,6 @@ void LabelEditor::save()
   m_selectedAtom = RWAtom();
 
   // make sure the label display is made active
-  qDebug() << "Requesting active display types";
   emit requestActiveDisplayTypes(QStringList() << "Labels");
 }
 
@@ -92,18 +94,25 @@ QUndoCommand* LabelEditor::mousePressEvent(QMouseEvent* e)
     return nullptr;
 
   if (e->buttons() & Qt::LeftButton) {
-    e->accept();
     if (m_selectedAtom.isValid()) {
+      e->accept();
       save();
+      emit drawablesChanged();
     }
 
     Identifier clickedObject = m_renderer->hit(e->pos().x(), e->pos().y());
     m_selected = (clickedObject.type == Rendering::AtomType);
     if (m_selected) {
+      e->accept();
       m_selectedAtom = m_molecule->atom(clickedObject.index);
       m_text = QString::fromStdString(m_selectedAtom.label());
+      emit drawablesChanged();
+    } else {
+      // clicked on empty space
+      e->ignore();
     }
-    emit drawablesChanged();
+  } else {
+    e->ignore();
   }
 
   return nullptr;

--- a/avogadro/qtplugins/manipulator/manipulator.cpp
+++ b/avogadro/qtplugins/manipulator/manipulator.cpp
@@ -51,7 +51,8 @@ Manipulator::Manipulator(QObject* parent_)
   m_activateAction->setToolTip(
     tr("Manipulation Tool \t(%1)\n\n"
        "Left Mouse: \tClick and drag to move atoms\n"
-       "Right Mouse: \tClick and drag to rotate atoms.\n").arg(shortcut));
+       "Right Mouse: \tClick and drag to rotate atoms.\n")
+      .arg(shortcut));
   setIcon();
   connect(m_toolWidget->buttonBox, SIGNAL(clicked(QAbstractButton*)), this,
           SLOT(buttonClicked(QAbstractButton*)));
@@ -235,10 +236,17 @@ QUndoCommand* Manipulator::mouseReleaseEvent(QMouseEvent* e)
 
 QUndoCommand* Manipulator::mouseMoveEvent(QMouseEvent* e)
 {
+  // if we're dragging through empty space, just return and ignore
+  // (e.g., fall back to the navigate tool)
+  const Core::Molecule* mol = &m_molecule->molecule();
+  if (mol->isSelectionEmpty() && m_object.type == Rendering::InvalidType) {
+    e->ignore();
+    return nullptr;
+  }
+
   updatePressedButtons(e, false);
   e->ignore();
 
-  const Core::Molecule* mol = &m_molecule->molecule();
   Vector2f windowPos(e->localPos().x(), e->localPos().y());
 
   if (mol->isSelectionEmpty() && m_object.type == Rendering::AtomType &&


### PR DESCRIPTION
If nothing is selected or clicked, tools should fall back to rotate / pan

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
