### PR TITLE
Only enable PQR search if site is up

### DIFF
--- a/avogadro/qtplugins/importpqr/importpqr.h
+++ b/avogadro/qtplugins/importpqr/importpqr.h
@@ -10,6 +10,7 @@
 #include <avogadro/io/fileformatmanager.h>
 #include <avogadro/qtgui/extensionplugin.h>
 
+#include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
 
 #include <QtCore/QString>
@@ -50,6 +51,7 @@ public slots:
 
 private slots:
   void menuActivated();
+  void checkAccess(QNetworkReply* reply);
 
 private:
   QAction* m_action;
@@ -59,8 +61,9 @@ private:
   QString m_moleculeName;
   QString m_moleculePath;
   QByteArray m_moleculeData;
+  QNetworkAccessManager* m_manager;
 };
-}
-}
+} // namespace QtPlugins
+} // namespace Avogadro
 
 #endif // AVOGADRO_QTPLUGINS_IMPORTPQR_H


### PR DESCRIPTION
Fix #1687

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
