### PR TITLE
Fixes for filling the unit cell

### DIFF
--- a/avogadro/core/spacegroups.cpp
+++ b/avogadro/core/spacegroups.cpp
@@ -301,10 +301,7 @@ void SpaceGroups::fillUnitCell(Molecule& mol, unsigned short hallNumber,
     }
   }
 
-  // if (wrapToCell)
-  //   CrystalTools::wrapAtomsToUnitCell(mol);
-
-  // Now we need to generate any copies on the unit boundary
+  // Now we generate any copies on the unit boundary
   // We need to loop through all the atoms again
   // if a fractional coordinate contains 0.0, we need to generate a copy
   // of the atom at 1.0

--- a/avogadro/core/spacegroups.h
+++ b/avogadro/core/spacegroups.h
@@ -126,7 +126,7 @@ public:
    */
   static void fillUnitCell(Molecule& mol, unsigned short hallNumber,
                            double cartTol = 1e-5, bool wrapToCell = true,
-                           bool allCopies = true);
+                           bool allCopies = false);
 
   /**
    * Reduce a cell to its asymmetric unit.

--- a/avogadro/core/unitcell.h
+++ b/avogadro/core/unitcell.h
@@ -291,6 +291,14 @@ inline Vector3 UnitCell::wrapFractional(const Vector3& f) const
     ++result[1];
   if (result[2] < static_cast<Real>(0.0))
     ++result[2];
+  // set anything at 1.0 to 0.0
+  if (result[0] >= static_cast<Real>(0.999999))
+    result[0] = static_cast<Real>(0.0);
+  if (result[1] == static_cast<Real>(0.999999))
+    result[1] = static_cast<Real>(0.0);
+  if (result[2] == static_cast<Real>(0.999999))
+    result[2] = static_cast<Real>(0.0);
+
   return result;
 }
 
@@ -305,6 +313,14 @@ inline void UnitCell::wrapFractional(const Vector3& f, Vector3& wrapped) const
     ++wrapped[1];
   if (wrapped[2] < static_cast<Real>(0.0))
     ++wrapped[2];
+
+  // set anything at 1.0 to 0.0
+  if (wrapped[0] >= static_cast<Real>(0.999999))
+    wrapped[0] = static_cast<Real>(0.0);
+  if (wrapped[1] >= static_cast<Real>(0.999999))
+    wrapped[1] = static_cast<Real>(0.0);
+  if (wrapped[2] >= static_cast<Real>(0.999999))
+    wrapped[2] = static_cast<Real>(0.0);
 }
 
 inline Vector3 UnitCell::wrapCartesian(const Vector3& cart) const

--- a/avogadro/qtplugins/spacegroup/spacegroup.cpp
+++ b/avogadro/qtplugins/spacegroup/spacegroup.cpp
@@ -73,7 +73,8 @@ SpaceGroup::SpaceGroup(QObject* parent_)
   m_fillUnitCellAction->setText(tr("Fill Unit Cell…"));
   connect(m_fillUnitCellAction, SIGNAL(triggered()), SLOT(fillUnitCell()));
   m_actions.push_back(m_fillUnitCellAction);
-  m_fillUnitCellAction->setProperty("menu priority", 50);
+  // should fall next to the "Wrap Atoms to Unit Cell" action
+  m_fillUnitCellAction->setProperty("menu priority", 185);
 
   m_reduceToAsymmetricUnitAction->setText(tr("Reduce to Asymmetric Unit"));
   connect(m_reduceToAsymmetricUnitAction, SIGNAL(triggered()),
@@ -100,8 +101,11 @@ QList<QAction*> SpaceGroup::actions() const
   return m_actions;
 }
 
-QStringList SpaceGroup::menuPath(QAction*) const
+QStringList SpaceGroup::menuPath(QAction* action) const
 {
+  if (action == m_fillUnitCellAction)
+    return QStringList() << tr("&Crystal");
+
   return QStringList() << tr("&Crystal") << tr("Space Group");
 }
 


### PR DESCRIPTION
- Move "fill unit cell" to the main menu for easy discovery
- Wrap any atoms at 1.0 fractional to 0.0 for convention
- Don't generate "all copies" by default (eventually we should have this as a separate command)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
