### PR TITLE
Link publicly against Qt6::OpenGLWidgets

### DIFF
--- a/avogadro/qtopengl/CMakeLists.txt
+++ b/avogadro/qtopengl/CMakeLists.txt
@@ -21,5 +21,5 @@ target_sources(QtOpenGL PRIVATE
 avogadro_add_library(QtOpenGL)
 target_link_libraries(QtOpenGL PUBLIC Avogadro::Rendering Avogadro::QtGui Qt::Widgets)
 if(QT_VERSION EQUAL 6)
-  target_link_libraries(QtOpenGL PRIVATE Qt6::OpenGLWidgets)
+  target_link_libraries(QtOpenGL PUBLIC Qt6::OpenGLWidgets)
 endif()

--- a/cmake/AvogadroLibsConfig.cmake.in
+++ b/cmake/AvogadroLibsConfig.cmake.in
@@ -19,6 +19,12 @@ set(AvogadroLibs_CMAKE_DIR       "${AvogadroLibs_LIBRARY_DIR}/cmake/avogadrolibs
 set(AvogadroLibs_PLUGINS         "@AvogadroLibs_PLUGINS@")
 set(AvogadroLibs_STATIC_PLUGINS  "@AvogadroLibs_STATIC_PLUGINS@")
 
+include(CMakeFindDependencyMacro)
+
+if (@QT_VERSION@ EQUAL 6)
+  find_dependency(Qt6OpenGLWidgets)
+endif()
+
 if(NOT TARGET AvogadroCore)
   include("${AvogadroLibs_CMAKE_DIR}/AvogadroLibsTargets.cmake")
 endif()


### PR DESCRIPTION
The public glwidget.h header uses it, so the link must be public

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
