### PR TITLE
[skip-ci] Update to allow clazy-standalone runs too

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ github.ref != 'refs/heads/master' }}
     steps:
     - name: 'Install clang-format'
-      run: sudo apt-get -qq install clang-format-15
+      run: sudo apt-get -qq install clang-format-16
 
     - uses: actions/checkout@v4
 
@@ -17,17 +17,16 @@ jobs:
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/openchemistry/avogadrolibs
         git fetch origin master:master
 
-        echo `which clang-format-diff-13`
         export MASTER_SHA=`cat .git/refs/heads/master`
         echo MASTER_SHA=${MASTER_SHA}
 
         git diff `cat .git/refs/heads/master` --name-only
-        DIFF=`git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-13 -p1`
+        DIFF=`git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-16 -p1`
         if [ -z "$DIFF" ]; then
           printf "clang-format-diff reports no problems"
           exit 0
         else
-          git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-13 -p1 >${{ runner.workspace }}/clang-format.diff
+          git diff -U0 ${MASTER_SHA} -- '*.h' '*.cpp' | clang-format-diff-16 -p1 >${{ runner.workspace }}/clang-format.diff
           exit 1
         fi
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,7 +1,7 @@
 name: Clang-Tidy Static Analysis
 
-on: 
-  workflow_dispatch:
+on:
+  [pull_request, workflow_dispatch]
 
 env:
   FEATURES: -DUSE_VTK=ON -DBUILD_GPL_PLUGINS=ON -DWITH_COORDGEN=OFF -DUSE_YAEHMOP=ON
@@ -29,10 +29,11 @@ jobs:
     - name: Install Dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
+        sudo add-apt-repository -y universe
         sudo apt-get -qq update
-        sudo apt-get -qq install ninja-build bear libeigen3-dev libboost-all-dev libglew-dev libxml2-dev 
+        sudo apt-get -qq install ninja-build bear libeigen3-dev libboost-all-dev libglew-dev libxml2-dev
         sudo apt-get -qq install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5x11extras5-dev libqt5svg5-dev
-        sudo apt-get -qq install clang-tidy
+        sudo apt-get -qq install clang-tidy clazy
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -82,11 +83,15 @@ jobs:
         bear -- ninja
       shell: bash
       working-directory: ${{ runner.workspace }}/build
-        
+
     - name: Create results directory
       run: |
         mkdir ${{ runner.workspace }}/clang-tidy-result
-    
+
+    # let's try manually running clazy
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Analyze
       run: |
         # generate the fixes and we'll make a diff
@@ -96,7 +101,7 @@ jobs:
         echo "Generating diff"
         git diff >${{ runner.workspace }}/clang-tidy-result/tidy.patch
       working-directory: ${{ runner.workspace }}/avogadrolibs
-    
+
     - name: Save PR metadata
       run: |
         echo ${{ github.event.number }} > ${{ runner.workspace }}/clang-tidy-result/pr-id.txt
@@ -107,7 +112,3 @@ jobs:
       with:
         name: clang-tidy-result
         path: ${{ runner.workspace }}/clang-tidy-result/
-        
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,6 +7,8 @@ env:
   FEATURES: -DUSE_VTK=ON -DBUILD_GPL_PLUGINS=ON -DWITH_COORDGEN=OFF -DUSE_YAEHMOP=ON
   BUILD_TYPE: RelWithDebInfo
   QT_VERSION: 5.15.2
+  CACHE: -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   build:
@@ -33,7 +35,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install ninja-build bear libeigen3-dev libboost-all-dev libglew-dev libxml2-dev
         sudo apt-get -qq install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5x11extras5-dev libqt5svg5-dev
-        sudo apt-get -qq install clang-tidy clazy
+        sudo apt-get -qq install clang-tidy clang-tools clazy
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -61,12 +63,14 @@ jobs:
 
     - name: Grab cache files
       uses: actions/cache@v4
-      if: runner.os != 'Windows'
       with:
         path: |
           ${{ runner.workspace }}/build/thirdparty
           ${{ runner.workspace }}/build/Downloads
         key: ${{ matrix.config.name }}-thirdparty
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@main
 
     - name: Configure
       run: |
@@ -77,7 +81,7 @@ jobs:
 
     - name: Build
       run: |
-        CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} ninja
+        CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} CMAKE_C_COMPILER_LAUNCHER=sccache CMAKE_CXX_COMPILER_LAUNCHER=sccache ninja
         # only re-compile avogadrolibs
         (cd avogadrolibs; ninja clean)
         bear -- ninja
@@ -86,29 +90,31 @@ jobs:
 
     - name: Create results directory
       run: |
-        mkdir ${{ runner.workspace }}/clang-tidy-result
+        mkdir ${{ runner.workspace }}/results
 
-    # let's try manually running clazy
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    - name: Clazy
+      run: |
+        find ../avogadrolibs/avogadrolibs/avogadro/ -name "*.cpp" | xargs clazy-standalone -p compile_commands.json -checks=old-style-connect -export-fixes=${{ runner.workspace }}/results/clazy-fixes.yaml
+        clang-apply-replacements ${{ runner.workspace }}/results/clazy-fixes.yaml
+      working-directory: ${{ runner.workspace }}/build
 
     - name: Analyze
       run: |
         # generate the fixes and we'll make a diff
-        run-clang-tidy -p ../build -fix
+        #run-clang-tidy -p ../build -fix
         cd avogadrolibs
         pwd
         echo "Generating diff"
-        git diff >${{ runner.workspace }}/clang-tidy-result/tidy.patch
+        git diff >${{ runner.workspace }}/results/tidy.patch
       working-directory: ${{ runner.workspace }}/avogadrolibs
 
     - name: Save PR metadata
       run: |
-        echo ${{ github.event.number }} > ${{ runner.workspace }}/clang-tidy-result/pr-id.txt
-        echo ${{ github.event.pull_request.head.repo.full_name }} > ${{ runner.workspace }}/clang-tidy-result/pr-head-repo.txt
-        echo ${{ github.event.pull_request.head.ref }} > ${{ runner.workspace }}/clang-tidy-result/pr-head-ref.txt
+        echo ${{ github.event.number }} > ${{ runner.workspace }}/results/pr-id.txt
+        echo ${{ github.event.pull_request.head.repo.full_name }} > ${{ runner.workspace }}/results/pr-head-repo.txt
+        echo ${{ github.event.pull_request.head.ref }} > ${{ runner.workspace }}/results/pr-head-ref.txt
 
     - uses: actions/upload-artifact@v4
       with:
-        name: clang-tidy-result
-        path: ${{ runner.workspace }}/clang-tidy-result/
+        name: results
+        path: ${{ runner.workspace }}/results/

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -92,6 +92,9 @@ jobs:
       run: |
         mkdir ${{ runner.workspace }}/results
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Clazy
       run: |
         find ../avogadrolibs/avogadrolibs/avogadro/ -name "*.cpp" | xargs clazy-standalone -p compile_commands.json -checks=old-style-connect -export-fixes=${{ runner.workspace }}/results/clazy-fixes.yaml


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
