### PR TITLE
Switch text rendering to use interpolation

### DIFF
--- a/avogadro/rendering/textlabelbase.cpp
+++ b/avogadro/rendering/textlabelbase.cpp
@@ -21,7 +21,7 @@
 namespace {
 #include "textlabelbase_fs.h"
 #include "textlabelbase_vs.h"
-} // end anon namespace
+} // namespace
 
 #include <iostream>
 
@@ -80,8 +80,8 @@ TextLabelBase::RenderImpl::RenderImpl()
   : vertices(4), shadersInvalid(true), textureInvalid(true), vboInvalid(true),
     radius(0.0)
 {
-  texture.setMinFilter(Texture2D::Nearest);
-  texture.setMagFilter(Texture2D::Nearest);
+  texture.setMinFilter(Texture2D::Linear);
+  texture.setMagFilter(Texture2D::Linear);
   texture.setWrappingS(Texture2D::ClampToEdge);
   texture.setWrappingT(Texture2D::ClampToEdge);
 }
@@ -187,13 +187,13 @@ void TextLabelBase::RenderImpl::render(const Camera& cam)
 
       !shaderProgram->enableAttributeArray("offset") ||
       !shaderProgram->useAttributeArray("offset", PackedVertex::offsetOffset(),
-                                       sizeof(PackedVertex), IntType, 2,
-                                       ShaderProgram::NoNormalize) ||
+                                        sizeof(PackedVertex), IntType, 2,
+                                        ShaderProgram::NoNormalize) ||
 
       !shaderProgram->enableAttributeArray("texCoord") ||
-      !shaderProgram->useAttributeArray("texCoord", PackedVertex::tcoordOffset(),
-                                       sizeof(PackedVertex), FloatType, 2,
-                                       ShaderProgram::NoNormalize)) {
+      !shaderProgram->useAttributeArray(
+        "texCoord", PackedVertex::tcoordOffset(), sizeof(PackedVertex),
+        FloatType, 2, ShaderProgram::NoNormalize)) {
     std::cerr << "Error setting up TextLabelBase shader program: "
               << shaderProgram->error() << std::endl;
     vbo.release();
@@ -213,7 +213,8 @@ void TextLabelBase::RenderImpl::render(const Camera& cam)
 
 void TextLabelBase::RenderImpl::compileShaders()
 {
-  if (vertexShader != nullptr && fragmentShader != nullptr && shaderProgram != nullptr)
+  if (vertexShader != nullptr && fragmentShader != nullptr &&
+      shaderProgram != nullptr)
     return;
 
   if (vertexShader == nullptr)
@@ -242,11 +243,11 @@ void TextLabelBase::RenderImpl::compileShaders()
     std::cerr << shaderProgram->error() << std::endl;
     return;
   }
-/*  shaderProgram->detachShader(vertexShader);
-  shaderProgram->detachShader(fragmentShader);
-  vertexShader->cleanup();
-  fragmentShader->cleanup();
-  */
+  /*  shaderProgram->detachShader(vertexShader);
+    shaderProgram->detachShader(fragmentShader);
+    vertexShader->cleanup();
+    fragmentShader->cleanup();
+    */
 
   shadersInvalid = false;
 }
@@ -259,9 +260,7 @@ void TextLabelBase::RenderImpl::uploadVbo()
     vboInvalid = false;
 }
 
-TextLabelBase::TextLabelBase() : m_render(new RenderImpl)
-{
-}
+TextLabelBase::TextLabelBase() : m_render(new RenderImpl) {}
 
 TextLabelBase::TextLabelBase(const TextLabelBase& other)
   : Drawable(other), m_text(other.m_text),
@@ -368,4 +367,4 @@ void TextLabelBase::markDirty()
   m_render->vboInvalid = true;
 }
 
-} // namespace Avogadro
+} // namespace Avogadro::Rendering


### PR DESCRIPTION
Fix #1363 - much smoother rendering when text is scaled

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
