### PR TITLE
Avoid crash in orbitals when switching molecules

### DIFF
--- a/avogadro/qtplugins/quantuminput/CMakeLists.txt
+++ b/avogadro/qtplugins/quantuminput/CMakeLists.txt
@@ -18,12 +18,13 @@ set(_prefix "${AvogadroLibs_SOURCE_DIR}/../avogadrogenerators")
 if(EXISTS "${_prefix}/generators.cmake")
   # Bundled generator scripts,
   include("${_prefix}/generators.cmake")
-  message("We have ${input_generators}")
+  # message("We have ${input_generators}")
   unset(_generators)
   foreach(gen ${input_generators})
     list(APPEND _generators "${_prefix}/${gen}")
   endforeach()
-  message("We have ${_generators}")
+  # debugging info with paths
+  # message("We have ${_generators}")
 
   option(INSTALL_TEST_INPUT_GENERATOR
     "Install a dummy input generator that is used to test generator scripts."

--- a/avogadro/qtplugins/surfaces/orbitals.cpp
+++ b/avogadro/qtplugins/surfaces/orbitals.cpp
@@ -95,11 +95,6 @@ void Orbitals::setMolecule(QtGui::Molecule* mol)
   m_currentRunningCalculation = -1;
   m_currentMeshCalculation = -1;
 
-  if (m_basis) {
-    delete m_basis;
-    m_basis = nullptr;
-  }
-
   loadBasis();
 
   if (!m_basis || m_basis->electronCount() == 0 || !hasOrbitals)


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
