### PR TITLE
Only build MoleQueue tests when requested

### DIFF
--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -4,9 +4,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}"
   "${AvogadroLibs_SOURCE_DIR}/tests/core")
 
 find_package(Qt${QT_VERSION} COMPONENTS Widgets Network Test REQUIRED)
-# Pull in MoleQueue for QtJson
-find_package(MoleQueue REQUIRED NO_MODULE)
-include_directories(${MoleQueue_INCLUDE_DIRS})
 
 # Find python interpreter for input generator
 find_package(PythonInterp 3)
@@ -25,9 +22,18 @@ set(tests
   # GitHub is showing this as a free() bug
   # TODO: Fix this
   # Molecule
-  MoleQueueQueueListModel
   RWMolecule
   )
+
+if (BUILD_MOLEQUEUE)
+  # Pull in MoleQueue
+  find_package(MoleQueue REQUIRED NO_MODULE)
+  include_directories(${MoleQueue_INCLUDE_DIRS})
+  list(APPEND tests
+    MoleQueueQueueListModel
+  )
+  set(MoleQueueLink Avogadro::MoleQueue MoleQueueClient)
+endif()
 
 if(PYTHON_EXECUTABLE AND AVOGADRO_DATA)
   list(APPEND tests
@@ -48,8 +54,9 @@ endforeach()
 
 # Add a single executable for all of our tests.
 add_executable(AvogadroQtGuiTests ${testSrcs})
-target_link_libraries(AvogadroQtGuiTests Avogadro::QtGui Avogadro::MoleQueue
-  MoleQueueClient ${GTEST_BOTH_LIBRARIES} ${EXTRA_LINK_LIB} Qt${QT_VERSION}::Widgets Qt${QT_VERSION}::Test)
+target_link_libraries(AvogadroQtGuiTests Avogadro::QtGui ${MoleQueueLink}
+ ${GTEST_BOTH_LIBRARIES} ${EXTRA_LINK_LIB}
+ Qt${QT_VERSION}::Widgets Qt${QT_VERSION}::Test)
 
 # Now add all of the tests, using the gtest_filter argument so that only those
 # cases are run in each test invocation.


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
