### PR TITLE
Add mode numbers to Vibrational Modes table

### DIFF
--- a/avogadro/qtplugins/vibrations/vibrationdialog.cpp
+++ b/avogadro/qtplugins/vibrations/vibrationdialog.cpp
@@ -17,7 +17,7 @@ VibrationDialog::VibrationDialog(QWidget* parent_, Qt::WindowFlags f)
 {
   m_ui->setupUi(this);
 
-  m_ui->tableView->verticalHeader()->setVisible(false);
+  m_ui->tableView->verticalHeader()->setVisible(true);
   m_ui->tableView->horizontalHeader()->setSectionResizeMode(
     QHeaderView::Stretch);
   m_ui->tableView->setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/avogadro/qtplugins/vibrations/vibrationmodel.cpp
+++ b/avogadro/qtplugins/vibrations/vibrationmodel.cpp
@@ -61,6 +61,9 @@ QVariant VibrationModel::headerData(int section, Qt::Orientation orientation,
           return QString("Raman Intensity (Å⁴/amu)");
       }
     }
+    else if (orientation == Qt::Vertical) {
+      return QString::number(section + 1);
+    }
   }
   return QVariant();
 }


### PR DESCRIPTION
Add a column to the left with the index of each normal mode in the table. This feature can be helpful for quickly identifying the mode for certain analyses.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
