### PR TITLE
build: replace FindPythonInterp with FindPython3

### DIFF
--- a/avogadro/qtgui/CMakeLists.txt
+++ b/avogadro/qtgui/CMakeLists.txt
@@ -19,11 +19,11 @@ if(USE_SPGLIB)
 endif()
 
 # Find python for input generator scripts:
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/avogadropython.h.in"
 "namespace Avogadro {
-static const char *pythonInterpreterPath = \"${PYTHON_EXECUTABLE}\";
+static const char *pythonInterpreterPath = \"${Python3_EXECUTABLE}\";
 }
 ")
 configure_file("${CMAKE_CURRENT_BINARY_DIR}/avogadropython.h.in"

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}"
 find_package(Qt${QT_VERSION} COMPONENTS Widgets Network Test REQUIRED)
 
 # Find python interpreter for input generator
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 # Setup config file with data location
 if(AVOGADRO_DATA_ROOT)
@@ -35,7 +35,7 @@ if (BUILD_MOLEQUEUE)
   set(MoleQueueLink Avogadro::MoleQueue MoleQueueClient)
 endif()
 
-if(PYTHON_EXECUTABLE AND AVOGADRO_DATA)
+if(Python3_EXECUTABLE AND AVOGADRO_DATA)
   list(APPEND tests
 # FIXME: These tests are broken
 #    FileBrowseWidget


### PR DESCRIPTION
FindPythonInterp is deprecated since CMake 3.12
https://cmake.org/cmake/help/v3.12/module/FindPythonInterp.html

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
