### PR TITLE
style(i18n): add --check=ellipsis-unicode for gettext and use unicode ellipsis

### DIFF
--- a/avogadro/qtplugins/apbs/apbsdialog.ui
+++ b/avogadro/qtplugins/apbs/apbsdialog.ui
@@ -47,7 +47,7 @@
           <item>
            <widget class="QPushButton" name="openPdbFileButton">
             <property name="text">
-             <string>...</string>
+             <string>…</string>
             </property>
            </widget>
           </item>
@@ -139,7 +139,7 @@
           <item>
            <widget class="QPushButton" name="openPqrFileButton">
             <property name="text">
-             <string>...</string>
+             <string>…</string>
             </property>
            </widget>
           </item>

--- a/avogadro/qtplugins/spectra/spectradialog.ui
+++ b/avogadro/qtplugins/spectra/spectradialog.ui
@@ -230,7 +230,7 @@
           <string>Imports a tsv of experimental spectra to overlay on the plot.</string>
          </property>
          <property name="text">
-          <string>&amp;Import...</string>
+          <string>&amp;Import…</string>
          </property>
         </widget>
        </item>
@@ -246,7 +246,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Set Color...</string>
+          <string>Set Color…</string>
          </property>
         </widget>
        </item>
@@ -298,7 +298,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Set Color...</string>
+          <string>Set Color…</string>
          </property>
         </widget>
        </item>
@@ -314,7 +314,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&amp;Export...</string>
+          <string>&amp;Export…</string>
          </property>
         </widget>
        </item>
@@ -327,7 +327,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Set Color...</string>
+          <string>Set Color…</string>
          </property>
         </widget>
        </item>
@@ -366,7 +366,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Set Color...</string>
+          <string>Set Color…</string>
          </property>
         </widget>
        </item>
@@ -585,7 +585,7 @@ Scroll wheel: Zoom to cursor</string>
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&amp;Load data...</string>
+      <string>&amp;Load data…</string>
      </property>
     </widget>
    </item>

--- a/scripts/extract-messages.sh
+++ b/scripts/extract-messages.sh
@@ -34,6 +34,7 @@ xgettext --from-code=UTF-8 -C -T --qt -kde -ci18n -ki18n:1 -ki18nc:1c,2 -ki18np:
   -ktrUtf8:1,2c -ktr:1,1t -ktr:1,2c,2t -ktr:1,1,2c,3t -ktrUtf8:1 \
   --package-name=${PACKAGE} --package-version=${VERSION} \
 	--msgid-bugs-address="${BUGADDR}" --foreign-user --copyright-holder="The Avogadro Project" \
+	--check=ellipsis-unicode \
 	--files-from=infiles.list -D ${BASEDIR} -D ${WDIR} -o ${PROJECT}.pot || { echo "error while calling xgettext. aborting."; exit 1; }
 echo "Done extracting messages"
 


### PR DESCRIPTION
replace "..." with "…"

https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html#index-_002d_002dcheck_002c-xgettext-option

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
