### PR TITLE
Revert "Perform culling on translucent surfaces"

### DIFF
--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -45,6 +45,7 @@ GLRenderer::GLRenderer()
   m_orthographicFrustum = {
     -5.0f * aspectRatio, 5.0f * aspectRatio, -5.0f, 5.0f, -offset, offset
   };
+
 }
 
 GLRenderer::~GLRenderer()
@@ -116,21 +117,13 @@ void GLRenderer::render()
   // nvidia drivers have a bug where they don't like blending
   //  so on Mac we can use this (they don't use nvidia)
 #ifdef __APPLE__
-  // glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 #else
   // Thanks to Giuseppe D'Angelo for a related comment:
   // https://bugreports.qt.io/browse/QTBUG-36739
   glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
 #endif
-  glEnable(GL_CULL_FACE);
   m_scene.rootNode().accept(visitor);
-
-  // Setup for opaque geometry
-  visitor.setRenderPass(OpaquePass);
-  m_scene.rootNode().accept(visitor);
-  glDisable(GL_CULL_FACE);
-  glDisable(GL_BLEND);
 
   // Setup for 3d overlay rendering
   visitor.setRenderPass(Overlay3DPass);
@@ -174,8 +167,7 @@ void GLRenderer::resetCamera()
 void GLRenderer::resetGeometry()
 {
   m_scene.setDirty(true);
-  if (m_camera.focus()(0) != m_camera.focus()(0) ||
-      m_camera.focus() == m_center)
+  if (m_camera.focus()(0) != m_camera.focus()(0) || m_camera.focus() == m_center)
     m_camera.setFocus(m_scene.center());
   m_center = m_scene.center();
   m_radius = m_scene.radius();
@@ -354,4 +346,4 @@ Array<Identifier> GLRenderer::hits(int x1, int y1, int x2, int y2) const
   return hits(&m_scene.rootNode(), f);
 }
 
-} // namespace Avogadro::Rendering
+} // namespace Avogadro


### PR DESCRIPTION
This reverts commit d8785f5377ff5248185dcefa3f0953250415194e.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
