### PR TITLE
refactor(FindOpenBabel3): improvement

### DIFF
--- a/avogadro/qtplugins/forcefield/CMakeLists.txt
+++ b/avogadro/qtplugins/forcefield/CMakeLists.txt
@@ -13,7 +13,7 @@ set(forcefield_srcs
 
 if (BUILD_GPL_PLUGINS)
   find_package(OpenBabel3)
-  if (OpenBabel3_LIBRARY)
+  if (OpenBabel3_LIBRARIES)
     list(APPEND forcefield_srcs
       obenergy.cpp
     )
@@ -40,7 +40,7 @@ else()
   target_link_libraries(Forcefield PRIVATE Qt5::Widgets)
 endif()
 
-if (BUILD_GPL_PLUGINS AND OpenBabel3_LIBRARY)
+if (BUILD_GPL_PLUGINS AND OpenBabel3_LIBRARIES)
   target_link_libraries(Forcefield PRIVATE OpenBabel3)
 endif()
 

--- a/cmake/FindOpenBabel3.cmake
+++ b/cmake/FindOpenBabel3.cmake
@@ -7,8 +7,11 @@
 #  OpenBabel3_LIBRARY      - The OpenBabel library
 #
 find_path(OpenBabel3_INCLUDE_DIR openbabel3/openbabel/babelconfig.h)
-if(OPENBABEL3_INCLUDE_DIR)
-  set(OPENBABEL3_INCLUDE_DIR ${OPENBABEL3_INCLUDE_DIR}/openbabel3)
+if(NOT EXISTS "${OpenBabel3_INCLUDE_DIR}/openbabel/babelconfig.h"
+   AND EXISTS "${OpenBabel3_INCLUDE_DIR}/openbabel3/openbabel/babelconfig.h"
+)
+  # modify the variable in order that `#include <openbabel/babelconfig.h>` works
+  set(OpenBabel3_INCLUDE_DIR "${OpenBabel3_INCLUDE_DIR}/openbabel3" CACHE PATH "Path to a file." FORCE)
 endif()
 find_library(OpenBabel3_LIBRARY NAMES openbabel openbabel3 openbabel-3)
 
@@ -20,6 +23,7 @@ mark_as_advanced(OpenBabel3_INCLUDE_DIR OpenBabel3_LIBRARY)
 
 if(OpenBabel3_FOUND)
   set(OpenBabel3_INCLUDE_DIRS "${OpenBabel3_INCLUDE_DIR}")
+  set(OpenBabel3_LIBRARIES "${OpenBabel3_LIBRARY}")
 
   if(NOT TARGET OpenBabel3)
     add_library(OpenBabel3 SHARED IMPORTED GLOBAL)


### PR DESCRIPTION
- fix OpenBabel3_INCLUDE_DIR (#1633)
- add OpenBabel3_LIBRARIES since it is provided by OpenBabel3Config.cmake

the module is not necessary if CMake can find system OpenBabel3Config.cmake

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
