### PR TITLE
Fix ODR violations, move enums into class scope

### DIFF
--- a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
+++ b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
@@ -37,16 +37,6 @@ using Avogadro::MoleQueue::JobObject;
 
 namespace Avogadro::QtPlugins {
 
-enum CalculateOption
-{
-  CalculateEnergy = 0,
-  CalculateEnergyAndForces,
-  CalculateMolecularDynamics,
-  CalculateGeometryOptimization,
-
-  CalculateCount
-};
-
 enum FunctionalOption
 {
   FunctionalBLYP = 0,
@@ -56,17 +46,6 @@ enum FunctionalOption
   FunctionalPBE,
 
   FunctionalCount
-};
-
-enum BasisOption
-{
-  BasisSZVGTH = 0,
-  BasisDZVGTH,
-  BasisDZVPGTH,
-  BasisTZVPGTH,
-  BasisTZV2PGTH,
-
-  BasisCount
 };
 
 enum MethodOption

--- a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h
+++ b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h
@@ -31,6 +31,27 @@ class Cp2kInputDialog : public QDialog
 {
   Q_OBJECT
 
+  enum CalculateOption
+  {
+    CalculateEnergy = 0,
+    CalculateEnergyAndForces,
+    CalculateMolecularDynamics,
+    CalculateGeometryOptimization,
+
+    CalculateCount
+  };
+
+  enum BasisOption
+  {
+    BasisSZVGTH = 0,
+    BasisDZVGTH,
+    BasisDZVPGTH,
+    BasisTZVPGTH,
+    BasisTZV2PGTH,
+
+    BasisCount
+  };
+
 public:
   explicit Cp2kInputDialog(QWidget* parent_ = nullptr,
                            Qt::WindowFlags f = Qt::WindowFlags());


### PR DESCRIPTION
Only the both concerned enum are moved.

```
avogadrolibs-1.100.0/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp:61:6: error: type ‘Avogadro::QtPlugins::BasisOption’ violates the C++ One Definition Rule [-Werror=odr]
   61 | enum BasisOption
      |      ^
avogadrolibs-1.100.0/work/avogadrolibs-1.100.0/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp:40:6:
error: type ‘Avogadro::QtPlugins::CalculateOption’ violates the C++ One Definition Rule [-Werror=odr]
   40 | enum CalculateOption
      |      ^
```

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
