### PR TITLE
fix: fix test suite names

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -22,7 +22,7 @@ set(tests
   VariantMap
   )
 if(USE_SPGLIB)
-  list(APPEND tests Spacegroup)
+  list(APPEND tests SpaceGroup)
 endif()
 
 # Build up the source file names.

--- a/tests/core/atomtypertest.cpp
+++ b/tests/core/atomtypertest.cpp
@@ -14,7 +14,7 @@
 
 using namespace Avogadro::Core;
 
-TEST(AtomTyper, singleAtomTyping)
+TEST(AtomTyperTest, singleAtomTyping)
 {
   Molecule molecule;
   Array<double> ref;
@@ -64,7 +64,7 @@ TEST(AtomTyper, singleAtomTyping)
     << "Failed getting cached result.";
 }
 
-TEST(AtomTyper, resetOnMoleculeChange)
+TEST(AtomTyperTest, resetOnMoleculeChange)
 {
   Molecule molecule1;
   Molecule molecule2;
@@ -80,7 +80,7 @@ TEST(AtomTyper, resetOnMoleculeChange)
   EXPECT_EQ(0, typer.types().size());
 }
 
-TEST(AtomTyper, nameAtomTyper)
+TEST(AtomTyperTest, nameAtomTyper)
 {
   Molecule molecule;
   Array<std::string> ref;
@@ -100,7 +100,7 @@ TEST(AtomTyper, nameAtomTyper)
   }
 }
 
-TEST(AtomTyper, symbolAtomTyper)
+TEST(AtomTyperTest, symbolAtomTyper)
 {
   Molecule molecule;
   Array<std::string> ref;


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
