### PR TITLE
refactor: use std::exchange (C++14)

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstddef>
 #include <iostream>
+#include <utility>
 
 namespace Avogadro::Core {
 
@@ -140,18 +141,14 @@ Molecule::Molecule(Molecule&& other) noexcept
     m_vibrationLx(other.m_vibrationLx),
     m_selectedAtoms(std::move(other.m_selectedAtoms)),
     m_meshes(std::move(other.m_meshes)), m_cubes(std::move(other.m_cubes)),
+    m_basisSet(std::exchange(other.m_basisSet, nullptr)),
+    m_unitCell(std::exchange(other.m_unitCell, nullptr)),
     m_residues(other.m_residues), m_hallNumber(other.m_hallNumber),
     m_constraints(other.m_constraints),
     m_frozenAtomMask(other.m_frozenAtomMask), m_graph(other.m_graph),
     m_bondOrders(other.m_bondOrders), m_atomicNumbers(other.m_atomicNumbers),
     m_layers(LayerManager::getMoleculeLayer(this))
 {
-  m_basisSet = other.m_basisSet;
-  other.m_basisSet = nullptr;
-
-  m_unitCell = other.m_unitCell;
-  other.m_unitCell = nullptr;
-
   // Copy the layers, only if they exist
   if (other.m_layers.maxLayer() > 0)
     m_layers = LayerManager::getMoleculeLayer(&other, this);
@@ -263,12 +260,10 @@ Molecule& Molecule::operator=(Molecule&& other) noexcept
     m_cubes = std::move(other.m_cubes);
 
     delete m_basisSet;
-    m_basisSet = other.m_basisSet;
-    other.m_basisSet = nullptr;
+    m_basisSet = std::exchange(other.m_basisSet, nullptr);
 
     delete m_unitCell;
-    m_unitCell = other.m_unitCell;
-    other.m_unitCell = nullptr;
+    m_unitCell = std::exchange(other.m_unitCell, nullptr);
 
     // Copy the layers, if they exist
     if (other.m_layers.maxLayer() > 0)


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
