### PR TITLE
refactor: avoid strncmp

### DIFF
--- a/avogadro/io/vaspformat.cpp
+++ b/avogadro/io/vaspformat.cpp
@@ -333,7 +333,7 @@ bool OutcarFormat::read(std::istream& inStream, Core::Molecule& mol)
 
   while (getline(inStream, buffer)) {
     // Checks whether the buffer object contains the lattice vectors keyword
-    if (strncmp(buffer.c_str(), latticeStr.c_str(), latticeStr.size()) == 0) {
+    if (buffer.substr(0, latticeStr.size()) == latticeStr) {
       // Checks whether lattice vectors have been already set. Reason being that
       // only the first occurrence denotes the true lattice vectors, and the
       // ones following these are vectors of the primitive cell.
@@ -376,18 +376,16 @@ bool OutcarFormat::read(std::istream& inStream, Core::Molecule& mol)
     }
 
     // Checks whether the buffer object contains the POSITION keyword
-    else if (strncmp(buffer.c_str(), positionStr.c_str(), positionStr.size()) ==
-             0) {
+    else if (buffer.substr(0, positionStr.size()) == positionStr) {
       getline(inStream, buffer);
       // Double checks whether the succeeding line is a sequence of dashes
-      if (strncmp(buffer.c_str(), dashedStr.c_str(), dashedStr.size()) == 0) {
+      if (buffer.substr(0, dashedStr.size()) == dashedStr) {
         // natoms is not known, so the loop proceeds till the bottom dashed line
         // is encountered
         while (true) {
           getline(inStream, buffer);
           // Condition for encountering dashed line
-          if (strncmp(buffer.c_str(), dashedStr.c_str(), dashedStr.size()) ==
-              0) {
+          if (buffer.substr(0, dashedStr.size()) == dashedStr) {
             if (coordSet == 0) {
               mol.setCoordinate3d(mol.atomPositions3d(), coordSet++);
               positions.reserve(natoms);


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
