### PR TITLE
fix(QtOpenGL): honor QT_VERSION

### DIFF
--- a/tests/qtopengl/CMakeLists.txt
+++ b/tests/qtopengl/CMakeLists.txt
@@ -6,9 +6,9 @@ include_directories("${AvogadroLibs_BINARY_DIR}/avogadro/qtgui"
 find_package(OpenGL REQUIRED)
 include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
-include_directories(SYSTEM ${Qt5Widgets_INCLUDE_DIRS})
-add_definitions(${Qt5Widgets_DEFINITIONS})
+find_package(Qt${QT_VERSION} COMPONENTS Widgets REQUIRED)
+include_directories(SYSTEM ${Qt${QT_VERSION}Widgets_INCLUDE_DIRS})
+add_definitions(${Qt${QT_VERSION}Widgets_DEFINITIONS})
 
 # We want to find some parts of VTK in order to do image comparisons.
 find_package(VTK


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
