### PR TITLE
Fix generic "archive warn" messages for the download window

### DIFF
--- a/avogadro/qtplugins/plugindownloader/zipextracter.cpp
+++ b/avogadro/qtplugins/plugindownloader/zipextracter.cpp
@@ -53,10 +53,10 @@ QList<QString> ZipExtracter::listFiles(const std::string absolutepath)
   QList<QString> toReturn;
 
   if ((r = archive_read_open_filename(a, convert(absolutepath), 512))) {
-    toReturn.append("ERROR - archive_read_open_filename == true");
-    toReturn.append(QString::number(r));
-    QString errorMsg = archive_error_string(a);
-    toReturn.append(errorMsg);
+    toReturn
+      .append(tr("ERROR: could not open zip file to list contents.\n(%1)",
+                 "%1 is the error message from libarchive"))
+      .arg(archive_error_string(a));
     return toReturn;
   }
 
@@ -101,10 +101,10 @@ QList<QString> ZipExtracter::extract(std::string extractdir,
   archive_write_disk_set_options(ext, flags);
   archive_write_disk_set_standard_lookup(ext);
   if ((r = archive_read_open_filename(a, convert(absolutepath), 10240))) {
-    toReturn.append("ERROR - archive_read_open_filename == true");
-    toReturn.append(QString::number(r));
-    QString errorMsg = archive_error_string(a);
-    toReturn.append(errorMsg);
+    toReturn
+      .append(tr("ERROR: could not open zip file to extract files.\n(%1)",
+                 "%1 is the error message from libarchive"))
+      .arg(archive_error_string(a));
     return toReturn;
   }
   [[maybe_unused]] long itrCount = 0;
@@ -118,7 +118,8 @@ QList<QString> ZipExtracter::extract(std::string extractdir,
     if (r < ARCHIVE_OK)
       fprintf(stderr, "%s\n", archive_error_string(a));
     if (r < ARCHIVE_WARN) {
-      toReturn.append("ERROR - r < ARCHIVE_WARN");
+      toReturn.append(tr("Warning: (%1)", "%1 is the message from libarchive"))
+        .arg(archive_error_string(a));
       return toReturn;
     }
 
@@ -135,7 +136,9 @@ QList<QString> ZipExtracter::extract(std::string extractdir,
       if (r < ARCHIVE_OK)
         fprintf(stderr, "%s\n", archive_error_string(ext));
       if (r < ARCHIVE_WARN) {
-        toReturn.append("ERROR - r < ARCHIVE_WARN");
+        toReturn
+          .append(tr("Warning: (%1)", "%1 is the message from libarchive"))
+          .arg(archive_error_string(a));
         return toReturn;
       }
     }
@@ -143,7 +146,8 @@ QList<QString> ZipExtracter::extract(std::string extractdir,
     if (r < ARCHIVE_OK)
       fprintf(stderr, "%s\n", archive_error_string(ext));
     if (r < ARCHIVE_WARN) {
-      toReturn.append("ERROR - r < ARCHIVE_WARN");
+      toReturn.append(tr("Warning: (%1)", "%1 is the message from libarchive"))
+        .arg(archive_error_string(a));
       return toReturn;
     }
   }


### PR DESCRIPTION
- Ensure these can be translated / localized
- Ensure we get the exact message from libarchive

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
