### PR TITLE
Fix reading MO from Molden, including correct eV conversion

### DIFF
--- a/avogadro/core/avogadrocore.h
+++ b/avogadro/core/avogadrocore.h
@@ -79,13 +79,18 @@ constexpr double RAD_TO_DEG_D = 180.0 / PI_D;
 constexpr float RAD_TO_DEG_F = static_cast<float>(RAD_TO_DEG_D);
 constexpr Real RAD_TO_DEG = static_cast<Real>(RAD_TO_DEG_D);
 
-constexpr double BOHR_TO_ANGSTROM_D = 0.52917721092;
+// from NIST
+constexpr double BOHR_TO_ANGSTROM_D = 0.529177210544;
 constexpr float BOHR_TO_ANGSTROM_F = static_cast<float>(BOHR_TO_ANGSTROM_D);
 constexpr Real BOHR_TO_ANGSTROM = static_cast<Real>(BOHR_TO_ANGSTROM_D);
 
 constexpr double ANGSTROM_TO_BOHR_D = 1.0 / BOHR_TO_ANGSTROM_D;
 constexpr float ANGSTROM_TO_BOHR_F = static_cast<float>(ANGSTROM_TO_BOHR_D);
 constexpr Real ANGSTROM_TO_BOHR = static_cast<Real>(ANGSTROM_TO_BOHR_D);
+
+constexpr double HARTREE_TO_EV_D = 27.211386245981;
+constexpr float HARTREE_TO_EV_F = static_cast<float>(HARTREE_TO_EV_D);
+constexpr Real HARTREE_TO_EV = static_cast<Real>(HARTREE_TO_EV_D);
 /** @} */
 
 } // namespace Avogadro

--- a/avogadro/quantumio/molden.h
+++ b/avogadro/quantumio/molden.h
@@ -66,6 +66,7 @@ private:
   std::vector<double> m_c;
   std::vector<double> m_csp;
   std::vector<double> m_orbitalEnergy;
+  std::vector<std::string> m_symmetryLabels;
   std::vector<double> m_MOcoeffs;
 
   Core::Array<double> m_frequencies;


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
