### PR TITLE
Fix Qt6 code signing for macOS including notarization

### DIFF
--- a/.github/workflows/build_qt6.yml
+++ b/.github/workflows/build_qt6.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install eigen glew pixi
+        brew install eigen glew pixi create-dmg
 
     - name: Checkout openchemistry
       uses: actions/checkout@v5
@@ -220,16 +220,23 @@ jobs:
         done;
         macdeployqt prefix/Avogadro2.app ${args} -libpath=prefix/lib -always-overwrite
         if [ -n "${P12_PASSWORD}" ]; then
-          echo "Signing Avogadro2.app with ${CODESIGN_IDENTITY}"
-          /usr/bin/codesign -s ${CODESIGN_IDENTITY} -f --timestamp --deep --options runtime --entitlements ../avogadrolibs/avogadroapp/cmake/Entitlements.plist prefix/Avogadro2.app
+          /usr/bin/codesign -s "${CODESIGN_IDENTITY}"" -f --timestamp --deep --options runtime --entitlements ../avogadrolibs/avogadroapp/cmake/Entitlements.plist prefix/Avogadro2.app
         fi
         cd prefix
         /usr/bin/ditto -c -k --keepParent Avogadro2.app Avogadro2.zip
         mv Avogadro2.zip ../Avogadro2-macOS.zip
+        cd ..
+        xcrun notarytool submit Avogadro2*.zip --apple-id "$NOTARIZE_USERNAME" --team-id "$NOTARIZE_TEAM" --password "$NOTARIZE_PASSWORD" --verbose --wait
+        xcrun stapler staple -v Avogadro2*.zip
       working-directory: ${{ runner.workspace }}/build/
+      continue-on-error: true
       env:
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        NOTARIZE_TEAM: ${{ secrets.AC_TEAM }}
+        NOTARIZE_USERNAME: ${{ secrets.AC_USERNAME }}
+        NOTARIZE_PASSWORD: ${{ secrets.AC_PASSWORD }}
         CODESIGN_IDENTITY: ${{ secrets.CODESIGN_ID }}
+        PRODUCT_BUNDLE_IDENTIFIER: cc.avogadro
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
 
     - name: Create Windows Packages
       if: runner.os == 'Windows'


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
