### PR TITLE
Use the light or dark X icon for the molecule list

### DIFF
--- a/avogadro/qtgui/moleculemodel.cpp
+++ b/avogadro/qtgui/moleculemodel.cpp
@@ -30,9 +30,13 @@ QModelIndex MoleculeModel::parent(const QModelIndex&) const
 void MoleculeModel::loadIcons(bool darkMode)
 {
   QString iconPath = ":icons/fallback/32x32/";
-  QString plusIconPath = iconPath + (darkMode ? "plus-dark.png" : "plus-light.png");
+  QString plusIconPath =
+    iconPath + (darkMode ? "plus-dark.png" : "plus-light.png");
+  QString closeIconPath =
+    iconPath + (darkMode ? "cross-dark.png" : "cross-light.png");
 
   m_plusIcon = QIcon(plusIconPath);
+  m_closeIcon = QIcon(closeIconPath);
 }
 
 int MoleculeModel::rowCount(const QModelIndex& p) const
@@ -100,8 +104,8 @@ QVariant MoleculeModel::data(const QModelIndex& idx, int role) const
   auto* object = static_cast<QObject*>(idx.internalPointer());
   auto* mol = qobject_cast<Molecule*>(object);
 
-  if (idx.row() == m_molecules.size()){
-    if (idx.column() == 0 && role==Qt::DecorationRole) {
+  if (idx.row() == m_molecules.size()) {
+    if (idx.column() == 0 && role == Qt::DecorationRole) {
       return m_plusIcon;
     }
     return QVariant();
@@ -150,7 +154,7 @@ QVariant MoleculeModel::data(const QModelIndex& idx, int role) const
     }
   } else if (idx.column() == 1) {
     if (role == Qt::DecorationRole)
-      return QIcon(":/icons/fallback/32x32/document-close.png");
+      return m_closeIcon;
   }
   return QVariant();
 }
@@ -162,9 +166,9 @@ QModelIndex MoleculeModel::index(int row, int column,
     if (row >= 0 && row < m_molecules.size()) {
       return createIndex(row, column, m_molecules[row]);
     }
-    if (row == m_molecules.size()) {
-      return createIndex(row, column, nullptr);
-    }
+  if (row == m_molecules.size()) {
+    return createIndex(row, column, nullptr);
+  }
   return QModelIndex();
 }
 

--- a/avogadro/qtgui/moleculemodel.h
+++ b/avogadro/qtgui/moleculemodel.h
@@ -74,6 +74,7 @@ private:
   QList<Molecule*> m_molecules;
   QObject* m_activeMolecule;
   QIcon m_plusIcon;
+  QIcon m_closeIcon;
 };
 
 } // namespace QtGui


### PR DESCRIPTION
More consistent with the rest of the UI

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
