### PR TITLE
Fix selection of atoms in orthographic projection

### DIFF
--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -84,13 +84,11 @@ void GLWidget::updateScene()
     Rendering::GroupNode& node = m_renderer.scene().rootNode();
     node.clear();
     auto* moleculeNode = new Rendering::GroupNode(&node);
-    QtGui::RWMolecule* rwmol = mol->undoMolecule();
 
     foreach (QtGui::ScenePlugin* scenePlugin,
              m_scenePlugins.activeScenePlugins()) {
       auto* engineNode = new Rendering::GroupNode(moleculeNode);
       scenePlugin->process(*mol, *engineNode);
-      scenePlugin->processEditable(*rwmol, *engineNode);
     }
 
     // Let the tools perform any drawing they need to do.

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -320,6 +320,7 @@ Array<Identifier> GLRenderer::hits(int x1, int y1, int x2, int y2) const
 {
   // Figure out where the corners of our rectangle are.
   Frustrum f;
+
   f.points[0] = m_camera.unProject(
     Vector3f(static_cast<float>(x1), static_cast<float>(y1), 0.f));
   f.points[1] = m_camera.unProject(
@@ -337,11 +338,18 @@ Array<Identifier> GLRenderer::hits(int x1, int y1, int x2, int y2) const
   f.points[7] = m_camera.unProject(
     Vector3f(static_cast<float>(x2), static_cast<float>(y1), 1.f));
 
-  // Define a frustrum for testing if things are within it.
-  f.planes[0] = (f.points[0] - f.points[1]).cross(f.points[2] - f.points[3]);
-  f.planes[1] = (f.points[2] - f.points[3]).cross(f.points[4] - f.points[5]);
-  f.planes[2] = (f.points[4] - f.points[5]).cross(f.points[6] - f.points[7]);
-  f.planes[3] = (f.points[6] - f.points[7]).cross(f.points[0] - f.points[1]);
+  if (m_camera.projectionType() == Perspective) {
+    f.planes[0] = (f.points[0] - f.points[1]).cross(f.points[2] - f.points[3]);
+    f.planes[1] = (f.points[2] - f.points[3]).cross(f.points[4] - f.points[5]);
+    f.planes[2] = (f.points[4] - f.points[5]).cross(f.points[6] - f.points[7]);
+    f.planes[3] = (f.points[6] - f.points[7]).cross(f.points[0] - f.points[1]);
+  } else {
+    // For orthographic, just set planes to zero - we'll use points instead
+    f.planes[0] = Vector3f::Zero();
+    f.planes[1] = Vector3f::Zero();
+    f.planes[2] = Vector3f::Zero();
+    f.planes[3] = Vector3f::Zero();
+  }
 
   return hits(&m_scene.rootNode(), f);
 }

--- a/avogadro/rendering/spheregeometry.cpp
+++ b/avogadro/rendering/spheregeometry.cpp
@@ -256,25 +256,56 @@ std::multimap<float, Identifier> SphereGeometry::hits(
 Array<Identifier> SphereGeometry::areaHits(const Frustrum& f) const
 {
   Array<Identifier> result;
-  // Check for intersection.
-  for (size_t i = 0; i < m_spheres.size(); ++i) {
-    const SphereColor& sphere = m_spheres[i];
+  if (f.planes[0] == Vector3f::Zero()) {
+    // Orthographic: simple axis-aligned AABB test
+    Vector3f minPoint = f.points[0];
+    Vector3f maxPoint = f.points[0];
+    for (int i = 1; i < 8; ++i) {
+      minPoint.x() = std::min(minPoint.x(), f.points[i].x());
+      minPoint.y() = std::min(minPoint.y(), f.points[i].y());
+      minPoint.z() = std::min(minPoint.z(), f.points[i].z());
+      maxPoint.x() = std::max(maxPoint.x(), f.points[i].x());
+      maxPoint.y() = std::max(maxPoint.y(), f.points[i].y());
+      maxPoint.z() = std::max(maxPoint.z(), f.points[i].z());
+    }
 
-    int in = 0;
-    for (in = 0; in < 4; ++in) {
-      float dist = (sphere.center - f.points[2 * in]).dot(f.planes[in]);
-      if (dist > 0.0f) {
-        // Outside of our frustrum, break.
-        break;
+    for (size_t i = 0; i < m_spheres.size(); ++i) {
+      const SphereColor& sphere = m_spheres[i];
+      if (sphere.center.x() >= minPoint.x() &&
+          sphere.center.x() <= maxPoint.x() &&
+          sphere.center.y() >= minPoint.y() &&
+          sphere.center.y() <= maxPoint.y() &&
+          sphere.center.z() >= minPoint.z() &&
+          sphere.center.z() <= maxPoint.z()) {
+        Identifier id;
+        id.molecule = m_identifier.molecule;
+        id.type = m_identifier.type;
+        id.index = m_indices[i];
+        result.push_back(id);
       }
     }
-    if (in == 4) {
-      // The center is within the four planes that make our frustrum - hit.
-      Identifier id;
-      id.molecule = m_identifier.molecule;
-      id.type = m_identifier.type;
-      id.index = m_indices[i];
-      result.push_back(id);
+  } else { // perspective
+
+    // Check for intersection.
+    for (size_t i = 0; i < m_spheres.size(); ++i) {
+      const SphereColor& sphere = m_spheres[i];
+
+      int in = 0;
+      for (in = 0; in < 4; ++in) {
+        float dist = (sphere.center - f.points[2 * in]).dot(f.planes[in]);
+        if (dist > 0.0f) {
+          // Outside of our frustrum, break.
+          break;
+        }
+      }
+      if (in == 4) {
+        // The center is within the four planes that make our frustrum - hit.
+        Identifier id;
+        id.molecule = m_identifier.molecule;
+        id.type = m_identifier.type;
+        id.index = m_indices[i];
+        result.push_back(id);
+      }
     }
   }
   return result;


### PR DESCRIPTION
Planes in the orthographic projection aren't useful Determine hits based on Frustrum points

Fix #2291
Fix #1129

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
