### PR TITLE
Fix incorrect usage of .empty method when .clear() was intended

### DIFF
--- a/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
@@ -349,19 +349,19 @@ QTAIMCriticalPointLocator::QTAIMCriticalPointLocator(QTAIMWavefunction& wfn)
 {
   m_wfn = &wfn;
 
-  m_nuclearCriticalPoints.empty();
-  m_bondCriticalPoints.empty();
-  m_ringCriticalPoints.empty();
-  m_cageCriticalPoints.empty();
+  m_nuclearCriticalPoints.clear();
+  m_bondCriticalPoints.clear();
+  m_ringCriticalPoints.clear();
+  m_cageCriticalPoints.clear();
 
-  m_laplacianAtBondCriticalPoints.empty();
-  m_ellipticityAtBondCriticalPoints.empty();
+  m_laplacianAtBondCriticalPoints.clear();
+  m_ellipticityAtBondCriticalPoints.clear();
 
-  m_bondPaths.empty();
-  m_bondedAtoms.empty();
+  m_bondPaths.clear();
+  m_bondedAtoms.clear();
 
-  m_electronDensitySources.empty();
-  m_electronDensitySinks.empty();
+  m_electronDensitySources.clear();
+  m_electronDensitySinks.clear();
 }
 
 void QTAIMCriticalPointLocator::locateNuclearCriticalPoints()
@@ -479,7 +479,7 @@ void QTAIMCriticalPointLocator::locateBondCriticalPoints()
         inputList.append(input);
       }
     } // end N
-  } // end M
+  }   // end M
 
   m_wfn->saveToBinaryFile(tempFileName);
 

--- a/avogadro/qtplugins/qtaim/qtaimlsodaintegrator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimlsodaintegrator.cpp
@@ -46,7 +46,7 @@ QTAIMLSODAIntegrator::QTAIMLSODAIntegrator(QTAIMWavefunctionEvaluator& eval,
                                            const qint64 mode)
   : m_eval(&eval), m_mode(mode), m_associatedSphere(0)
 {
-  m_betaSpheres.empty();
+  m_betaSpheres.clear();
 }
 
 QVector3D QTAIMLSODAIntegrator::integrate(QVector3D x0y0z0)
@@ -1019,7 +1019,7 @@ void QTAIMLSODAIntegrator::lsoda(int neq, double* y, double* t, double tout,
         return;
       }
     } /*   end else   */ /*   end iopt = 1   */
-  } /*   end if ( *istate == 1 || *istate == 3 )   */
+  }                      /*   end if ( *istate == 1 || *istate == 3 )   */
   /*
    If *istate = 1, meth is initialized to 1.
 
@@ -1123,7 +1123,7 @@ void QTAIMLSODAIntegrator::lsoda(int neq, double* y, double* t, double tout,
         return;
       }
     } /*   end for   */
-  } /*   end if ( *istate == 1 || *istate == 3 )   */
+  }   /*   end if ( *istate == 1 || *istate == 3 )   */
   /*
    If *istate = 3, set flag to signal parameter changes to stoda.
 */
@@ -1353,7 +1353,7 @@ void QTAIMLSODAIntegrator::lsoda(int neq, double* y, double* t, double tout,
           jstart = -2;
         break;
     } /*   end switch   */
-  } /*   end if ( *istate == 2 || *istate == 3 )   */
+  }   /*   end if ( *istate == 2 || *istate == 3 )   */
 
   /*
    Block e.
@@ -1555,7 +1555,7 @@ void QTAIMLSODAIntegrator::lsoda(int neq, double* y, double* t, double tout,
       terminate2(y, t);
       return;
     } /*   end if ( kflag == -1 || kflag == -2 )   */
-  } /*   end while   */
+  }   /*   end while   */
 
 } /*   end lsoda   */
 
@@ -1897,8 +1897,8 @@ void QTAIMLSODAIntegrator::stoda(int neq, double* y)
           continue;
         }
       } /*   end else -- kflag <= -3 */
-    } /*   end error failure handling   */
-  } /*   end outer while   */
+    }   /*   end error failure handling   */
+  }     /*   end outer while   */
 
 } /*   end stoda   */
 

--- a/avogadro/qtplugins/qtaim/qtaimodeintegrator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimodeintegrator.cpp
@@ -28,7 +28,7 @@ QTAIMODEIntegrator::QTAIMODEIntegrator(QTAIMWavefunctionEvaluator& eval,
                                        const qint64 mode)
   : m_eval(&eval), m_mode(mode), m_associatedSphere(0)
 {
-  m_betaSpheres.empty();
+  m_betaSpheres.clear();
 }
 
 QVector3D QTAIMODEIntegrator::integrate(QVector3D x0y0z0)


### PR DESCRIPTION
Fixes #2144

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
