### PR TITLE
migrate GitHub Actions to use SHA revisions for security

### DIFF
--- a/.github/workflows/add_artifact_urls.yml
+++ b/.github/workflows/add_artifact_urls.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: add artifact links to pull request step
-        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        uses: tonyhallett/artifacts-url-comments@65d67ea19293bf61dc25e7129b14f7a7ff5e36dc # v1.1.0
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -23,62 +23,62 @@ jobs:
       # See https://github.com/flatpak/flatpak-builder/issues/495
 
     - name: Checkout openchemistry
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/openchemistry
         submodules: false
         path: openchemistry
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadroapp
         path: openchemistry/avogadroapp
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         path: openchemistry/avogadrolibs
 
     - name: Checkout i18n
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadro-i18n
         path: openchemistry/avogadro-i18n
 
     - name: Checkout avogadrogenerators
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogenerators
         path: openchemistry/avogadrogenerators
 
     - name: Checkout crystals
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/crystals
         path: openchemistry/crystals
 
     - name: Checkout fragments
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/fragments
         path: openchemistry/fragments
 
     - name: Checkout molecules
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/molecules
         path: openchemistry/molecules
 
     - name: Checkout Flathub shared-modules
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: flathub/shared-modules
         path: shared-modules
 
     - name: Set up tmate session
       if: failure()
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3
       timeout-minutes: 60
 
     - name: Move manifest
@@ -91,7 +91,7 @@ jobs:
       run: flatpak build-bundle repo Avogadro2.flatpak org.openchemistry.Avogadro2 test
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         path: Avogadro2.flatpak
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -87,55 +87,55 @@ jobs:
         sudo apt-get -qq install libfuse2
 
     - name: Checkout openchemistry
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/openchemistry
         submodules: recursive
         path: openchemistry
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadroapp
         path: openchemistry/avogadroapp
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         path: openchemistry/avogadrolibs
 
     - name: Checkout i18n
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadro-i18n
         path: openchemistry/avogadro-i18n
 
     - name: Checkout avogadrogenerators
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogenerators
         path: openchemistry/avogadrogenerators
 
     - name: Checkout crystals
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/crystals
         path: openchemistry/crystals
 
     - name: Checkout fragments
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/fragments
         path: openchemistry/fragments
 
     - name: Checkout molecules
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/molecules
         path: openchemistry/molecules
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4
       with:
         version: ${{ env.QT_VERSION }}
 
@@ -199,12 +199,12 @@ jobs:
 
     - name: Upload
       if: matrix.config.artifact != 0
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         path: ${{ runner.workspace }}/build/avogadroapp/Avogadro2*.*
         name: ${{ matrix.config.artifact }}
 
     - name: Setup tmate session
       if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3
       timeout-minutes: 60

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -44,60 +44,60 @@ jobs:
         brew install eigen glew pixi create-dmg
 
     - name: Checkout openchemistry
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/openchemistry
         submodules: recursive
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         path: avogadrolibs
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/avogadroapp
         path: avogadroapp
 
     - name: Checkout molecules
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/molecules
         path: molecules
 
     - name: Checkout fragments
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/fragments
         path: fragments
 
     - name: Checkout crystals
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/crystals
         path: crystals
 
     - name: Checkout i18n
-      uses: actions/checkout@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
       with:
         repository: openchemistry/avogadro-i18n
         path: avogadro-i18n
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4
       with:
         version: ${{ env.QT_VERSION }}
 
     - name: Grab cache files
-      uses: actions/cache@v4
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
       with:
         path: |
           ${{ runner.workspace }}/build/Downloads
         key: ${{ matrix.config.name }}-downloads
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@main
+      uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # main
 
     - name: Configure
       run: |
@@ -249,12 +249,12 @@ jobs:
 
     - name: Upload
       if: matrix.config.artifact != 0
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         path: ${{ runner.workspace }}/build/Avogadro2*.*
         name: ${{ matrix.config.artifact }}
 
     - name: Setup tmate session
       if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3
       timeout-minutes: 60

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -79,7 +79,7 @@ jobs:
           #  platform: pyodide
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
         with:
           # Grab the whole history so that setuptools-scm can see the tags and
           # give it a correct version even on non-tag push.
@@ -89,12 +89,12 @@ jobs:
         run: . ./scripts/github-actions/install.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@f1859528322d7b29d4493ee241a167807661dfb4 # v3.2.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -103,7 +103,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5
         with:
           # Grab the whole history so that setuptools-scm can see the tags and
           # give it a correct version even on non-tag push.
@@ -112,7 +112,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -130,13 +130,13 @@ jobs:
     # for now, we're testing
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # release/v1
         with:
           password: ${{ secrets.pypi_api_token }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -39,54 +39,54 @@ jobs:
     steps:
 
     - name: Checkout openchemistry
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/openchemistry
         submodules: recursive
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadroapp
         path: avogadroapp
 
     - name: Checkout molecules
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/molecules
         path: molecules
 
     - name: Checkout fragments
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/fragments
         path: fragments
 
     - name: Checkout crystals
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/crystals
         path: crystals
 
     - name: Checkout i18n
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadro-i18n
         path: avogadro-i18n
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         path: avogadrolibs
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4
       with:
         version: ${{ env.QT_VERSION }}
 
     - name: Configure MSVC Command Prompt
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       with:
         arch: x64
 
@@ -143,7 +143,7 @@ jobs:
 
     - name: Upload
       if: matrix.config.artifact != 0
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         path: ${{ runner.workspace }}/build/Avogadro2*.*
         name: ${{ matrix.config.artifact }}

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -10,7 +10,7 @@ jobs:
     - name: 'Install clang-format'
       run: sudo apt-get -qq install clang-format
 
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
 
     - name: 'Run clang-format-diff'
       run: |
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         path: ${{ runner.workspace }}/clang-format.diff
         name: clang-format.diff

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -35,31 +35,31 @@ jobs:
         sudo apt-get -qq install clang-tidy
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@f9e0410eb4c0f1f9af7cf358b144d1488c42ccc0 # v3
       with:
         cache: true
         version: ${{ env.QT_VERSION }}
 
     - name: Checkout openchemistry
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/openchemistry
         submodules: recursive
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadroapp
         path: avogadroapp
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         path: avogadrolibs
         fetch-depth: 2
 
     - name: Grab cache files
-      uses: actions/cache@v4
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
       if: runner.os != 'Windows'
       with:
         path: |
@@ -103,11 +103,11 @@ jobs:
         echo ${{ github.event.pull_request.head.repo.full_name }} > ${{ runner.workspace }}/clang-tidy-result/pr-head-repo.txt
         echo ${{ github.event.pull_request.head.ref }} > ${{ runner.workspace }}/clang-tidy-result/pr-head-ref.txt
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       with:
         name: clang-tidy-result
         path: ${{ runner.workspace }}/clang-tidy-result/
         
     - name: Setup tmate session
       if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -39,11 +39,11 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@master
+        uses: codacy/codacy-analysis-cli-action@e52d1b30d1b797b061c343be0a88eff25a8bc37f # master
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
@@ -64,6 +64,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v4
         with:
           sarif_file: filtered.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,19 +48,19 @@ jobs:
 
     steps:
     - name: Checkout openchemistry
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/openchemistry
         submodules: recursive
 
     - name: Checkout avogadroapp
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         repository: openchemistry/avogadroapp
         path: avogadroapp
 
     - name: Checkout avogadrolibs
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
       with:
         path: avogadrolibs
 
@@ -72,13 +72,13 @@ jobs:
         sudo apt-get -qq install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5x11extras5-dev libqt5svg5-dev
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@f9e0410eb4c0f1f9af7cf358b144d1488c42ccc0 # v3
       with:
         cache: True
         version: ${{ env.QT_VERSION }}
 
     - name: Grab cache files
-      uses: actions/cache@v4
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
       with:
         path: |
           ${{ runner.workspace }}/build/thirdparty
@@ -92,7 +92,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v4
       with:
         languages: ${{ matrix.language }}
         source-root: ${{ github.workspace }}/avogadrolibs
@@ -105,7 +105,7 @@ jobs:
       shell: bash
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v4
       with:
         category: "/language:${{matrix.language}}"
         checkout_path: ${{ github.workspace }}/avogadrolibs

--- a/.github/workflows/misspell-fixer.yml
+++ b/.github/workflows/misspell-fixer.yml
@@ -6,8 +6,8 @@ jobs:
     name: Spelling Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
     - name: misspell-fixer check for code and comments
-      uses: sobolevn/misspell-fixer-action@master
+      uses: sobolevn/misspell-fixer-action@7f96ed2c214e5c8160d61ddbbb56be8df0e76929 # master
       with:
         options: '-rsnuRVd avogadro/'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/update-i18n-templates.yml
+++ b/.github/workflows/update-i18n-templates.yml
@@ -13,7 +13,7 @@ jobs:
     name: Update translation templates
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.0.0
 
     - name: Install packages
       run: |
@@ -25,7 +25,7 @@ jobs:
         sh scripts/extract-messages.sh
 
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7
       with:
         commit-message: "Automated translation updates"
         signoff: true


### PR DESCRIPTION
Migrate all GitHub Actions workflows to use specific SHA commit hashes instead of version tags, following security best practices to prevent potential supply chain attacks.

Changes:
- Pin all action references to their specific SHA revisions
- Add inline comments with version tags for readability (e.g., # v5.0.0)
- Enable Dependabot to properly update SHA-pinned actions

Updated workflows:
- add_artifact_urls.yml
- build_linux.yml
- build_mac.yml
- build_windows.yml
- build_wheels.yml
- build_flatpak.yml
- clang-format-check.yml
- clang-tidy.yml
- codeql.yml
- codacy.yml
- misspell-fixer.yml
- release-drafter.yml
- update-i18n-templates.yml

Key actions updated:
- actions/checkout@v5.0.0 → @11bd71901bbe5b1630ceea73d27597364c9af683
- actions/upload-artifact@v4 → @b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
- actions/cache@v4 → @6849a6489940f00c2f30c0fb92c6274307ccb58a
- jurplel/install-qt-action@v4 → @d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005
- jurplel/install-qt-action@v3 → @f9e0410eb4c0f1f9af7cf358b144d1488c42ccc0
- github/codeql-action/*@v4 → @df409f7d9260372bd5f19e5b04e83cb3c43714ae
- ilammy/msvc-dev-cmd@v1 → @0b201ec74fa43914dc39ae48a89fd1d8cb592756
- mozilla-actions/sccache-action@main → @9e326ebed976843c9932b3aa0e021c6f50310eb4
- mxschmitt/action-tmate@v3 → @a283f9441d2d96eb62436dc46d7014f5d357ac22
- peter-evans/create-pull-request@v7 → @5e914681df9dc83aa4e4905692ca88beb2f9e91f
- release-drafter/release-drafter@v6 → @3f0f87098bd6b5c5b9a36d49c41d998ea58f9348
- pypa/cibuildwheel@v3.2.1 → @f1859528322d7b29d4493ee241a167807661dfb4
- actions/download-artifact@v5 → @fa0a91b85d4f404e444e00e005971372dc801d16
- pypa/gh-action-pypi-publish@release/v1 → @f7600683efdcb7656dec5b29656edb7bc586e597
- codacy/codacy-analysis-cli-action@master → @e52d1b30d1b797b061c343be0a88eff25a8bc37f
- tonyhallett/artifacts-url-comments@v1.1.0 → @65d67ea19293bf61dc25e7129b14f7a7ff5e36dc
- sobolevn/misspell-fixer-action@master → @7f96ed2c214e5c8160d61ddbbb56be8df0e76929

Benefits:
- Prevents unexpected breaking changes from automatic action updates
- Protects against compromised action versions
- Maintains compatibility with Dependabot security updates
- Improves audit trail and reproducibility

Fixes #2306

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
