### PR TITLE
AvogadroLibsConfig.cmake: Find JKQTPlotter6

### DIFF
--- a/cmake/AvogadroLibsConfig.cmake.in
+++ b/cmake/AvogadroLibsConfig.cmake.in
@@ -28,6 +28,7 @@ if (@QT_VERSION@ EQUAL 6)
   find_dependency(Qt6Gui)
   find_dependency(Qt6Network)
   find_dependency(Qt6Concurrent)
+  find_dependency(JKQTPlotter6 REQUIRED)
 endif()
 
 if(NOT TARGET AvogadroCore)


### PR DESCRIPTION
It's in the public link interface of Avogadro::QtGui, so it needs to be found as a dependency here.