### PR TITLE
Reject invalid bond orders in cjson

### DIFF
--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -344,7 +344,13 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
         if (isNumericArray(order)) {
           for (unsigned int i = 0; i < molecule.bondCount() && i < order.size();
                ++i) {
-            molecule.bond(i).setOrder(static_cast<int>(order[i]));
+            int bondOrder = static_cast<int>(order[i]);
+            if (bondOrder < 1 || bondOrder > 6) {
+              appendError("Error: bond order is invalid.");
+              return false;
+            }
+
+            molecule.bond(i).setOrder(bondOrder);
           }
         }
       }

--- a/tests/io/cjsontest.cpp
+++ b/tests/io/cjsontest.cpp
@@ -69,6 +69,23 @@ TEST(CjsonTest, atomicNumberEdgeCase)
   }
 }
 
+TEST(CjsonTest, readNegativeBond)
+{
+  CjsonFormat cjson;
+  Molecule molecule;
+  EXPECT_FALSE(cjson.readString(R"({"chemicalJson": 1,
+  "atoms": {
+    "coords": { "3d": [ 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 ] },
+    "elements": { "number": [ 1, 9 ] }
+  },
+  "bonds": {
+    "connections": { "index": [ 0, 1 ] },
+    "order": [ -1 ]
+}})",
+                                molecule));
+  EXPECT_EQ(cjson.error(), "Error: bond order is invalid.\n");
+}
+
 TEST(CjsonTest, readInvalidPeriodicFile)
 {
   const auto error_cell_params =


### PR DESCRIPTION
Fixes #2372

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
