### PR TITLE
Fixed color gradient for labeling by atomic index

### DIFF
--- a/avogadro/qtplugins/applycolors/applycolors.cpp
+++ b/avogadro/qtplugins/applycolors/applycolors.cpp
@@ -227,7 +227,7 @@ void ApplyColors::applyIndexColors()
     if (isSelection && !m_molecule->atomSelected(i))
       continue;
 
-    float indexFraction = float(i) / float(numAtoms);
+    float indexFraction = float(i) / (float(numAtoms) - 1);
 
     m_molecule->atom(i).setColor(rainbowGradient(indexFraction, type));
   }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

## Google's `turbo` colormap
<img width="1782" height="1118" alt="image" src="https://github.com/user-attachments/assets/bb3a6121-98f8-48ec-b18d-fce3e681c54d" />

## Old Coloring
<img width="3280" height="1796" alt="image" src="https://github.com/user-attachments/assets/1b9771df-ecbb-4ad9-bed4-5d4b4f32a990" />

## New Coloring
<img width="3280" height="1796" alt="image" src="https://github.com/user-attachments/assets/e3e88168-6980-4a77-a176-7bda7392939d" />
