### PR TITLE
Fix off-by-one MO rendering bug with MOPAC orbitals

### DIFF
--- a/avogadro/core/slaterset.cpp
+++ b/avogadro/core/slaterset.cpp
@@ -139,8 +139,19 @@ void SlaterSet::initCalculation()
 
 inline unsigned int SlaterSet::factorial(unsigned int n)
 {
-  if (n <= 1)
-    return n;
+  switch (n) {
+    case 0:
+    case 1:
+      return 1;
+    case 2:
+      return 2;
+    case 3:
+      return 6;
+    case 4:
+      return 24;
+    case 5:
+      return 120;
+  }
   return (n * factorial(n - 1));
 }
 

--- a/avogadro/core/slaterset.h
+++ b/avogadro/core/slaterset.h
@@ -130,7 +130,7 @@ public:
   void initCalculation();
 
   /**
-   * Accessors for the various properties of the GaussianSet.
+   * Accessors for the various properties of the SlaterSet.
    */
   std::vector<int>& slaterIndices() { return m_slaterIndices; }
   std::vector<int>& slaterTypes() { return m_slaterTypes; }

--- a/avogadro/core/slatersettools.cpp
+++ b/avogadro/core/slatersettools.cpp
@@ -26,7 +26,7 @@ double SlaterSetTools::calculateMolecularOrbital(const Vector3& position,
 
   const MatrixX& matrix = m_basis->normalizedMatrix();
   int matrixSize(static_cast<int>(matrix.rows()));
-  int indexMO(mo - 1);
+  int indexMO(mo);
 
   // Now calculate the value of the density at this point in space
   double result(0.0);


### PR DESCRIPTION
Thanks to tsubomura for reporting the bug

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
