### PR TITLE
fix: do not discard return value of QFile::open()

### DIFF
--- a/avogadro/qtgui/scriptloader.cpp
+++ b/avogadro/qtgui/scriptloader.cpp
@@ -81,7 +81,9 @@ QMultiMap<QString, QString> ScriptLoader::scriptList(const QString& type)
           if (jsonManifest.isReadable()) {
             // load the JSON
             QFile jsonFile(jsonManifest.absoluteFilePath());
-            jsonFile.open(QIODevice::ReadOnly | QIODevice::Text);
+            if (!jsonFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+              continue;
+            }
             QByteArray data = jsonFile.readAll();
             jsonFile.close();
             QJsonDocument d = QJsonDocument::fromJson(data);

--- a/avogadro/qtplugins/apbs/apbsdialog.cpp
+++ b/avogadro/qtplugins/apbs/apbsdialog.cpp
@@ -185,7 +185,11 @@ void ApbsDialog::saveInputFile(const QString& fileName)
   QString contents = m_inputGenerator->fileContents("apbs.in");
 
   QFile file(fileName);
-  file.open(QFile::WriteOnly);
+  if (!file.open(QFile::WriteOnly)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Cannot save file %1.").arg(fileName));
+    return;
+  }
   file.write(contents.toLocal8Bit());
   file.close();
 }

--- a/avogadro/qtplugins/fetchpdb/fetchpdb.cpp
+++ b/avogadro/qtplugins/fetchpdb/fetchpdb.cpp
@@ -139,7 +139,11 @@ void FetchPDB::replyFinished(QNetworkReply* reply)
   m_tempFileName =
     QDir::tempPath() + QDir::separator() + m_moleculeName + ".pdb";
   QFile out(m_tempFileName);
-  out.open(QIODevice::WriteOnly);
+  if (!out.open(QIODevice::WriteOnly)) {
+    QMessageBox::warning(qobject_cast<QWidget*>(parent()), tr("Error"),
+                         tr("Cannot save file %1.").arg(m_tempFileName));
+    return;
+  }
   out.write(m_moleculeData);
   out.close();
 

--- a/avogadro/qtplugins/openbabel/obfileformat.cpp
+++ b/avogadro/qtplugins/openbabel/obfileformat.cpp
@@ -165,7 +165,10 @@ bool OBFileFormat::read(std::istream& in, Core::Molecule& molecule)
 
       QTemporaryFile tmpFile;
       tmpFile.setAutoRemove(false);
-      tmpFile.open();
+      if (!tmpFile.open()) {
+        appendError("Internal error -- failed to create a temporary file");
+        return false;
+      }
       tmpFile.write(input.data());
       tmpFile.close();
       filename = tmpFile.fileName();

--- a/avogadro/qtplugins/plugindownloader/downloaderwidget.cpp
+++ b/avogadro/qtplugins/plugindownloader/downloaderwidget.cpp
@@ -404,7 +404,11 @@ void DownloaderWidget::unzipPlugin()
     tr("Downloading %1 to %2\n").arg(filename).arg(m_filePath));
 
   QFile out(absolutePath);
-  out.open(QIODevice::WriteOnly);
+  if (!out.open(QIODevice::WriteOnly)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Cannot save file %1.").arg(absolutePath));
+    return;
+  }
   out.write(fileData);
   out.close();
 

--- a/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
+++ b/avogadro/qtplugins/qtaim/qtaimcriticalpointlocator.cpp
@@ -157,7 +157,12 @@ QList<QVariant> QTAIMLocateBondCriticalPoint(QList<QVariant> input)
 
   QList<QVector3D> nuclearCriticalPoints;
   QFile nuclearCriticalPointsFile(nuclearCriticalPointsFileName);
-  nuclearCriticalPointsFile.open(QIODevice::ReadOnly);
+  if (!nuclearCriticalPointsFile.open(QIODevice::ReadOnly)) {
+    QMessageBox::critical(
+      nullptr, QObject::tr("Error"),
+      QObject::tr("Cannot read file %1.").arg(nuclearCriticalPointsFileName));
+    return {};
+  }
   QDataStream nuclearCriticalPointsFileIn(&nuclearCriticalPointsFile);
   nuclearCriticalPointsFileIn >> nuclearCriticalPoints;
   nuclearCriticalPointsFile.close();
@@ -441,7 +446,11 @@ void QTAIMCriticalPointLocator::locateBondCriticalPoints()
   QString nuclearCriticalPointsFileName =
     QTAIMCriticalPointLocator::temporaryFileName();
   QFile nuclearCriticalPointsFile(nuclearCriticalPointsFileName);
-  nuclearCriticalPointsFile.open(QIODevice::WriteOnly);
+  if (!nuclearCriticalPointsFile.open(QIODevice::WriteOnly)) {
+    QMessageBox::critical(nullptr, QObject::tr("Error"),
+                          QObject::tr("Failed to create a temporary file."));
+    return;
+  }
   QDataStream nuclearCriticalPointsOut(&nuclearCriticalPointsFile);
   nuclearCriticalPointsOut << m_nuclearCriticalPoints;
   nuclearCriticalPointsFile.close();

--- a/avogadro/qtplugins/qtaim/qtaimwavefunction.h
+++ b/avogadro/qtplugins/qtaim/qtaimwavefunction.h
@@ -27,6 +27,7 @@
 #include <QDataStream>
 #include <QFile>
 #include <QIODevice>
+#include <QMessageBox>
 
 #include <QVariant>
 #include <QVariantList>
@@ -42,7 +43,12 @@ public:
   void saveToBinaryFile(const QString& fileName)
   {
     QFile file(fileName);
-    file.open(QIODevice::WriteOnly);
+    if (!file.open(QIODevice::WriteOnly)) {
+      QMessageBox::critical(
+        nullptr, QObject::tr("Error"),
+        QObject::tr("Cannot save file %1.").arg(file.fileName()));
+      return;
+    }
     QDataStream out(&file);
     out << m_fileName;
     out << m_comment;
@@ -70,7 +76,12 @@ public:
   void loadFromBinaryFile(const QString& fileName)
   {
     QFile file(fileName);
-    file.open(QIODevice::ReadOnly);
+    if (!file.open(QIODevice::ReadOnly)) {
+      QMessageBox::critical(
+        nullptr, QObject::tr("Error"),
+        QObject::tr("Cannot read file %1.").arg(file.fileName()));
+      return;
+    }
     QDataStream in(&file);
     in >> m_fileName;
     in >> m_comment;


### PR DESCRIPTION
`QFile::open` is declared as nodiscard, which returns whether file opening is successful.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
