### PR TITLE
Use --as-is flag for pixi run to avoid environment updates

### DIFF
--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -140,6 +140,8 @@ QByteArray PythonScript::execute(const QStringList& args,
       realArgs.prepend("python");
     } // otherwise hope pixi knows how to run this
 
+    realArgs.prepend("--as-is");
+
     // check if the script is in the plugin directory
     if (!pluginDir.isEmpty() && defaultManifest &&
         !m_scriptFilePath.startsWith(pluginDir)) {
@@ -157,7 +159,6 @@ QByteArray PythonScript::execute(const QStringList& args,
     }
 
     realArgs.prepend("run");
-    realArgs.insert(1, "--as-is");
 
 #ifdef Q_OS_WIN
     QString pixi(m_pixi + "/pixi.exe");


### PR DESCRIPTION
Fixes #2469

### Changes
This PR adds the `--as-is` flag to the `pixi run` command within `PythonScript::execute`.

### Reason
By default, `pixi run` checks for environment updates and lockfile consistency. Adding `--as-is` ensures that:
1.  The command runs using the existing environment without attempting any updates or installations.
2.  Execution is faster and avoids potential side effects from implicit environment modifications.

I have signed off on the commit as required.