### PR TITLE
[skip ci] Tweak release drafter to skip dependencies

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,7 @@ categories:
       - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
+      - 'crash'
       - 'fix'
       - 'bugfix'
       - 'bug'
@@ -34,6 +35,13 @@ autolabeler:
   - label: 'i18n'
     branch:
       - '/weblate\/.+/'
+    title:
+      - '/Hosted Weblate/i'
+  - label: 'i18n'
+    title:
+      - '/Automated translation updates/i'
+exclude-labels:
+  - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -55,4 +63,3 @@ template: |
   ## Credits
 
   Thanks to many contributors, including: $CONTRIBUTORS
-  


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
