### PR TITLE
Check VASP export to ignore translational duplicate atoms

### DIFF
--- a/avogadro/core/spacegroups.h
+++ b/avogadro/core/spacegroups.h
@@ -138,6 +138,17 @@ public:
   static void reduceToAsymmetricUnit(Molecule& mol, unsigned short hallNumber,
                                      double cartTol = 1e-5);
 
+  /**
+   * Get indices of translationally unique atoms, filtering out duplicates.
+   * Atoms with fractional coordinates near 1.0 that duplicate atoms near 0.0
+   * (due to periodic boundary conditions) are excluded.
+   * @param mol The molecule with a unit cell
+   * @param tolerance Fractional coordinate tolerance for duplicate detection
+   * @return Array of atom indices to include (empty if no unit cell)
+   */
+  static Array<Index> translationalUniqueAtoms(const Molecule& mol,
+                                               double tolerance = 0.001);
+
 private:
   /**
    * Get the transforms string stored in the database.


### PR DESCRIPTION
Fix #2588

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filtering of translationally duplicate atoms in periodic structures when exporting to LAMMPS, Turbomole, and VASP file formats, ensuring cleaner output files with accurate unit cell representation.

* **Improvements**
  * Periodic structures now identify and remove redundant atoms caused by translational symmetry during file export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->