### PR TITLE
Change occupancy guess for unrestricted jobs

### DIFF
--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -251,8 +251,13 @@ inline unsigned int BasisSet::lumo(ElectronType type) const
       }
     }
   }
-  // fall back to electron count
-  return m_electrons[0] / 2 + 1;
+  // fall back to electron count 
+  // (supports odd number of electrons))
+  if (type == Beta) {
+    return m_electrons[0] / 2 + 1;
+  } else {
+    return m_electrons[0] / 2 + (m_electrons[0] % 2) + 1;
+  }
 }
 
 inline void BasisSet::setElectronCount(unsigned int n, ElectronType type)

--- a/avogadro/qtplugins/surfaces/orbitaltablemodel.cpp
+++ b/avogadro/qtplugins/surfaces/orbitaltablemodel.cpp
@@ -256,6 +256,50 @@ bool OrbitalTableModel::setOrbitals(const Core::BasisSet* basis)
       basis->molecularOrbitalCount(Core::BasisSet::Alpha);
     unsigned int betaCount = basis->molecularOrbitalCount(Core::BasisSet::Beta);
 
+    // Generate orbital occupation from energy order if no occupancy is set
+    if (alphaOccupancy.empty() && betaOccupancy.empty()) {
+    
+      const unsigned int nElec = alphaHomo + betaHomo; // total electrons
+      alphaOccupancy.assign(alphaCount, 0.0);
+      betaOccupancy.assign(betaCount, 0.0);
+    
+      unsigned int ia = 0;
+      unsigned int ib = 0;
+    
+      // Fill the lowest-energy orbitals across alpha/beta ("merge" two sorted lists)
+      for (unsigned int e = 0; e < nElec; ++e) {
+    
+        // Compare next orbital energies (assumed already sorted by index)
+        const double ea = (ia < alphaEnergies.size()) ? alphaEnergies[ia]
+                                                      : std::numeric_limits<double>::infinity();
+        const double eb = (ib < betaEnergies.size())  ? betaEnergies[ib]
+                                                      : std::numeric_limits<double>::infinity();
+    
+        if (ea < eb) {
+          alphaOccupancy[ia] = 1.0;
+          ++ia;
+        } else if (eb < ea) {
+          betaOccupancy[ib] = 1.0;
+          ++ib;
+        } else {
+          // Fill less occupied spin orbitals if degenrate. In same conditions, alpha first 
+          if (ia <= ib) {
+            alphaOccupancy[ia] = 1.0;
+            ++ia;
+          } else {
+            betaOccupancy[ib] = 1.0;
+            ++ib;
+          }
+        }
+      }
+
+      // Update HOMO/LUMO consistent with the generated occupations.
+      alphaHomo = ia;
+      betaHomo  = ib;
+      alphaLumo = ia + 1;
+      betaLumo  = ib + 1;
+    }
+
     // Create alpha orbitals
     for (unsigned int i = 0; i < alphaCount; i++) {
       Orbital* orb = new Orbital;


### PR DESCRIPTION
When no occupancy is read from QM output, it is now guessed based on energy ordering of the orbitals
(should work for ground state)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
