### PR TITLE
Switch Turbomole export to default to using Bohr coords

### DIFF
--- a/avogadro/io/turbomoleformat.cpp
+++ b/avogadro/io/turbomoleformat.cpp
@@ -377,7 +377,8 @@ bool TurbomoleFormat::write(std::ostream& outStream, const Core::Molecule& mol)
       uniqueIndices.push_back(i);
   }
 
-  outStream << "$coord angs\n";
+  // convert to Bohr because some programs can't handle Angstrom
+  outStream << "$coord\n";
 
   // print $isosub only when an isotope exists
   std::ostringstream isosub;
@@ -393,12 +394,12 @@ bool TurbomoleFormat::write(std::ostream& outStream, const Core::Molecule& mol)
     std::string symbol = Elements::symbol(atom.atomicNumber());
     symbol[0] = tolower(symbol[0]);
 
+    Vector3 position = atom.position3d() * ANGSTROM_TO_BOHR;
     outStream << " " << std::setw(18) << std::right << std::fixed
-              << std::setprecision(10) << atom.position3d().x() << " "
-              << std::setw(18) << std::right << std::fixed
-              << std::setprecision(10) << atom.position3d().y() << " "
-              << std::setw(18) << std::right << std::fixed
-              << std::setprecision(10) << atom.position3d().z() << " "
+              << std::setprecision(10) << position.x() << " " << std::setw(18)
+              << std::right << std::fixed << std::setprecision(10)
+              << position.y() << " " << std::setw(18) << std::right
+              << std::fixed << std::setprecision(10) << position.z() << " "
               << std::setw(5) << std::right << symbol << "\n";
     auto iso = mol.isotope(atomIdx);
     if (iso > 0)

--- a/tests/io/turbomoletest.cpp
+++ b/tests/io/turbomoletest.cpp
@@ -13,6 +13,8 @@
 #include <avogadro/core/vector.h>
 #include <avogadro/io/turbomoleformat.h>
 
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 using Avogadro::ANGSTROM_TO_BOHR;
@@ -162,8 +164,20 @@ TEST(TurbomoleTest, readCellParameters)
 
 TEST(TurbomoleTest, writeString)
 {
+  // Helper to format one atom line exactly as the writer does
+  auto formatAtomLine = [](double x, double y, double z,
+                           const std::string& sym) -> std::string {
+    std::ostringstream oss;
+    oss << " " << std::setw(18) << std::right << std::fixed
+        << std::setprecision(10) << x << " " << std::setw(18) << std::right
+        << std::fixed << std::setprecision(10) << y << " " << std::setw(18)
+        << std::right << std::fixed << std::setprecision(10) << z << " "
+        << std::setw(5) << std::right << sym << "\n";
+    return oss.str();
+  };
+
   {
-    // N2
+    // N2 — coordinates written in Bohr (default, no "angs" suffix)
     Molecule molecule;
     molecule.addAtom(7);
     molecule.setAtomPosition3d(0, { 0.0, 0.0, 0.0 });
@@ -173,15 +187,13 @@ TEST(TurbomoleTest, writeString)
     TurbomoleFormat tmol;
     std::string out;
     ASSERT_TRUE(tmol.writeString(out, molecule));
-    EXPECT_EQ(out, R"($coord angs
-       0.0000000000       0.0000000000       0.0000000000     n
-       1.4200000000       0.0000000000       0.0000000000     n
-$end
-)");
+    EXPECT_EQ(out, "$coord\n"s + formatAtomLine(0.0, 0.0, 0.0, "n") +
+                     formatAtomLine(1.42 * ANGSTROM_TO_BOHR, 0.0, 0.0, "n") +
+                     "$end\n");
   }
 
   {
-    // THO
+    // THO — tritium isotope label, coordinates in Bohr
     Molecule molecule;
     molecule.addAtom(1);
     molecule.setIsotope(0, 3);
@@ -194,13 +206,12 @@ $end
     TurbomoleFormat tmol;
     std::string out;
     ASSERT_TRUE(tmol.writeString(out, molecule));
-    EXPECT_EQ(out, R"($coord angs
-      -0.7600000000      -0.6000000000       0.0000000000     h
-       0.7600000000      -0.6000000000       0.0000000000     h
-       0.0000000000       0.0000000000       0.0000000000     o
-$isosub
-1  3
-$end
-)");
+    EXPECT_EQ(out, "$coord\n"s +
+                     formatAtomLine(-0.76 * ANGSTROM_TO_BOHR,
+                                    -0.6 * ANGSTROM_TO_BOHR, 0.0, "h") +
+                     formatAtomLine(0.76 * ANGSTROM_TO_BOHR,
+                                    -0.6 * ANGSTROM_TO_BOHR, 0.0, "h") +
+                     formatAtomLine(0.0, 0.0, 0.0, "o") + "$isosub\n1  3\n" +
+                     "$end\n");
   }
 }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
