### PR TITLE
fix: Add symmetry labels for vibrations and orbitals

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -1142,6 +1142,16 @@ void Molecule::setVibrationLx(const Array<Array<Vector3>>& lx)
   m_vibrationLx = lx;
 }
 
+Array<std::string> Molecule::vibrationSymmetryLabels() const
+{
+  return m_vibrationSymmetryLabels;
+}
+
+void Molecule::setVibrationSymmetryLabels(const Array<std::string>& labels)
+{
+  m_vibrationSymmetryLabels = labels;
+}
+
 void Molecule::perceiveBondOrders()
 {
   // check for coordinates and that there are some bonds

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -627,6 +627,12 @@ public:
   void setVibrationRamanIntensities(const Array<double>& intensities);
   Array<Vector3> vibrationLx(int mode) const;
   void setVibrationLx(const Array<Array<Vector3>>& lx);
+  /**
+   * Get the symmetry labels for vibrational modes (e.g., A1, B2, Eu)
+   * Returns an empty array if no symmetry labels are available.
+   */
+  Array<std::string> vibrationSymmetryLabels() const;
+  void setVibrationSymmetryLabels(const Array<std::string>& labels);
 
   /**
    * Perceives bonds in the molecule based on the 3D coordinates of the atoms.
@@ -987,6 +993,7 @@ protected:
   Array<double> m_vibrationIRIntensities;
   Array<double> m_vibrationRamanIntensities;
   Array<Array<Vector3>> m_vibrationLx;
+  Array<std::string> m_vibrationSymmetryLabels;
 
   // Array declaring whether atoms are selected or not.
   std::vector<bool> m_selectedAtoms;

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -788,6 +788,16 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
       }
       molecule.setVibrationRamanIntensities(intens);
     }
+    json symLabels = vibrations["symmetryLabels"];
+    if (symLabels.is_array()) {
+      Array<std::string> labels;
+      for (auto& label : symLabels) {
+        if (label.is_string()) {
+          labels.push_back(label.get<std::string>());
+        }
+      }
+      molecule.setVibrationSymmetryLabels(labels);
+    }
     json displacements = vibrations["eigenVectors"];
     if (displacements.is_array()) {
       Array<Array<Vector3>> disps;
@@ -1731,6 +1741,14 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
     if (molecule.vibrationRamanIntensities().size() > 0)
       vibrations["ramanIntensities"] = raman;
     vibrations["eigenVectors"] = eigenVectors;
+    // Write vibration symmetry labels if available
+    if (molecule.vibrationSymmetryLabels().size() > 0) {
+      json symLabels;
+      for (const auto& label : molecule.vibrationSymmetryLabels()) {
+        symLabels.push_back(label);
+      }
+      vibrations["symmetryLabels"] = symLabels;
+    }
     root["vibrations"] = vibrations;
   }
 

--- a/avogadro/qtplugins/surfaces/orbitalwidget.cpp
+++ b/avogadro/qtplugins/surfaces/orbitalwidget.cpp
@@ -114,6 +114,16 @@ void OrbitalWidget::fillTable(Core::BasisSet* basis)
   // Populate the model
   m_tableModel->setOrbitals(basis);
 
+  // Show symmetry column only if symmetry labels are available
+  auto symLabels = basis->symmetryLabels(Core::BasisSet::Paired);
+  bool hasSymmetry = !symLabels.empty();
+  // For open-shell, also check alpha/beta labels
+  if (!hasSymmetry) {
+    auto alphaSym = basis->symmetryLabels(Core::BasisSet::Alpha);
+    hasSymmetry = !alphaSym.empty();
+  }
+  ui.table->setColumnHidden(OrbitalTableModel::C_Symmetry, !hasSymmetry);
+
   ui.table->horizontalHeader()->sectionResizeMode(
     QHeaderView::ResizeToContents);
 

--- a/avogadro/qtplugins/vibrations/vibrationmodel.cpp
+++ b/avogadro/qtplugins/vibrations/vibrationmodel.cpp
@@ -10,7 +10,7 @@
 namespace Avogadro::QtPlugins {
 
 VibrationModel::VibrationModel(QObject* p)
-  : QAbstractItemModel(p), m_molecule(nullptr), m_hasRaman(false)
+  : QAbstractItemModel(p), m_molecule(nullptr), m_hasRaman(false), m_hasSymmetry(false)
 {
 }
 
@@ -29,11 +29,15 @@ int VibrationModel::rowCount(const QModelIndex& p) const
 
 int VibrationModel::columnCount(const QModelIndex&) const
 {
-  // do we have raman data?
+  // Base columns: Frequency, Intensity
+  int count = 2;
+  // Add Raman column if we have Raman data
   if (m_molecule && m_hasRaman)
-    return 3;
-
-  return 2;
+    count++;
+  // Add Symmetry column if we have symmetry labels
+  if (m_molecule && m_hasSymmetry)
+    count++;
+  return count;
 }
 
 Qt::ItemFlags VibrationModel::flags(const QModelIndex&) const
@@ -45,6 +49,7 @@ void VibrationModel::setMolecule(QtGui::Molecule* mol)
 {
   m_molecule = mol;
   m_hasRaman = mol->vibrationRamanIntensities().size() > 0;
+  m_hasSymmetry = mol->vibrationSymmetryLabels().size() > 0;
 }
 
 QVariant VibrationModel::headerData(int section, Qt::Orientation orientation,
@@ -52,13 +57,21 @@ QVariant VibrationModel::headerData(int section, Qt::Orientation orientation,
 {
   if (role == Qt::DisplayRole) {
     if (orientation == Qt::Horizontal) {
-      switch (section) {
-        case 0:
-          return QString("Frequency (cm⁻¹)");
-        case 1:
-          return QString("Intensity (km/mol)");
-        case 2:
+      int col = 0;
+      if (section == col)
+        return QString("Frequency (cm⁻¹)");
+      col++;
+      if (section == col)
+        return QString("Intensity (km/mol)");
+      col++;
+      if (m_hasRaman) {
+        if (section == col)
           return QString("Raman Intensity (a.u.)");
+        col++;
+      }
+      if (m_hasSymmetry) {
+        if (section == col)
+          return QString("Symmetry");
       }
     } else if (orientation == Qt::Vertical) {
       return QString::number(section + 1);
@@ -74,35 +87,58 @@ bool VibrationModel::setData(const QModelIndex&, const QVariant&, int)
 
 QVariant VibrationModel::data(const QModelIndex& idx, int role) const
 {
-  if (!idx.isValid() || idx.column() > 2 || !m_molecule ||
+  if (!idx.isValid() || !m_molecule ||
       static_cast<int>(m_molecule->vibrationFrequencies().size()) <=
         idx.row()) {
     return QVariant();
   }
 
   if (role == Qt::DisplayRole) {
-    switch (idx.column()) {
-      case 0:
-        if (static_cast<int>(m_molecule->vibrationFrequencies().size()) >
-            idx.row())
-          return m_molecule->vibrationFrequencies()[idx.row()];
-        else
-          return "No value";
-      case 1:
-        if (static_cast<int>(m_molecule->vibrationIRIntensities().size()) >
-            idx.row())
-          return m_molecule->vibrationIRIntensities()[idx.row()];
-        else
-          return "No value";
-      case 2:
+    int col = 0;
+    // Frequency column
+    if (idx.column() == col) {
+      if (static_cast<int>(m_molecule->vibrationFrequencies().size()) >
+          idx.row())
+        return m_molecule->vibrationFrequencies()[idx.row()];
+      else
+        return "No value";
+    }
+    col++;
+    
+    // Intensity column
+    if (idx.column() == col) {
+      if (static_cast<int>(m_molecule->vibrationIRIntensities().size()) >
+          idx.row())
+        return m_molecule->vibrationIRIntensities()[idx.row()];
+      else
+        return "No value";
+    }
+    col++;
+    
+    // Raman column (if present)
+    if (m_hasRaman) {
+      if (idx.column() == col) {
         if (static_cast<int>(m_molecule->vibrationRamanIntensities().size()) >
             idx.row())
           return m_molecule->vibrationRamanIntensities()[idx.row()];
         else
           return "No value";
-      default:
-        return "Invalid";
+      }
+      col++;
     }
+    
+    // Symmetry column (if present)
+    if (m_hasSymmetry) {
+      if (idx.column() == col) {
+        auto labels = m_molecule->vibrationSymmetryLabels();
+        if (static_cast<int>(labels.size()) > idx.row())
+          return QString::fromStdString(labels[idx.row()]);
+        else
+          return QString();
+      }
+    }
+    
+    return "Invalid";
   }
 
   return QVariant();

--- a/avogadro/qtplugins/vibrations/vibrationmodel.h
+++ b/avogadro/qtplugins/vibrations/vibrationmodel.h
@@ -46,6 +46,7 @@ public slots:
 private:
   QtGui::Molecule* m_molecule;
   bool m_hasRaman;
+  bool m_hasSymmetry;
 };
 } // namespace QtPlugins
 } // namespace Avogadro


### PR DESCRIPTION
This commit adds support for displaying symmetry labels for both vibrational modes and molecular orbitals:

- For orbitals: The symmetry column is now shown conditionally only when symmetry labels are available (e.g., from Molden files)

- For vibrations: Added new infrastructure to store and display symmetry labels for vibrational modes:
  - Added vibrationSymmetryLabels() to Molecule class
  - Added Symmetry column to VibrationModel
  - Updated CJSON format to read/write vibration symmetry labels

This restores functionality from Avogadro v1 where symmetric molecules like water or benzene would show symmetry labels for vibrations and orbitals.

Fixes openchemistry/avogadrolibs#2630

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
