### PR TITLE
[skip ci] Fix tooltip strings for packagemanager

### DIFF
--- a/avogadro/qtplugins/packageinstaller/packagemodel.cpp
+++ b/avogadro/qtplugins/packageinstaller/packagemodel.cpp
@@ -560,13 +560,13 @@ QString PackageModel::displayName(const QString& name)
 QString PackageModel::featureTypeLabel(const QString& featureType)
 {
   if (featureType == QLatin1String("electrostatic-models"))
-    return tr("Electrostatic");
+    return tr("Electrostatics");
   if (featureType == QLatin1String("energy-models"))
-    return tr("Energy");
+    return tr("Energy Models");
   if (featureType == QLatin1String("file-formats"))
     return tr("File Formats");
   if (featureType == QLatin1String("input-generators"))
-    return tr("Input Gen.");
+    return tr("Input Generators");
   if (featureType == QLatin1String("menu-commands"))
     return tr("Commands");
   // Unknown feature type — return as-is (capitalised for readability)


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
