### PR TITLE
Add support for reading from a filename (e.g., hd5 file)

### DIFF
--- a/avogadro/io/fileformat.h
+++ b/avogadro/io/fileformat.h
@@ -142,7 +142,7 @@ public:
    * @param molecule The molecule the data will be read into.
    * @return True on success, false on failure.
    */
-  bool readFile(const std::string& fileName, Core::Molecule& molecule);
+  virtual bool readFile(const std::string& fileName, Core::Molecule& molecule);
 
   /**
    * @brief Write to the given @p fileName the contents of @p molecule.
@@ -150,7 +150,8 @@ public:
    * @param molecule The contents of this molecule will be written to the file.
    * @return True on success, false on failure.
    */
-  bool writeFile(const std::string& fileName, const Core::Molecule& molecule);
+  virtual bool writeFile(const std::string& fileName,
+                         const Core::Molecule& molecule);
 
   /**
    * @brief Read the given @p string and load it into @p molecule.

--- a/avogadro/qtgui/jsonwidget.cpp
+++ b/avogadro/qtgui/jsonwidget.cpp
@@ -42,12 +42,27 @@ JsonWidget::~JsonWidget() {}
 void JsonWidget::setMolecule(QtGui::Molecule* mol)
 {
   if (m_molecule != nullptr) {
-    // update charge and multiplicity if needed
+    // update charge and multiplicity only if those options exist
+    // (command scripts don't have them, unlike input generators)
+    auto hasUserOption = [&](const QString& key) -> bool {
+      if (!m_options.contains("userOptions"))
+        return false;
+      if (m_options["userOptions"].isArray()) {
+        for (const auto& tab : m_options["userOptions"].toArray())
+          if (tab.toObject().contains(key))
+            return true;
+        return false;
+      }
+      return m_options["userOptions"].toObject().contains(key);
+    };
+
     int charge = static_cast<int>(m_molecule->totalCharge());
     int multiplicity = static_cast<int>(m_molecule->totalSpinMultiplicity());
 
-    setOption("Charge", charge);
-    setOption("Multiplicity", multiplicity);
+    if (hasUserOption("Charge"))
+      setOption("Charge", charge);
+    if (hasUserOption("Multiplicity"))
+      setOption("Multiplicity", multiplicity);
 
     // check the molecule for "inputParameters" from CJSON
     // e.g.

--- a/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
+++ b/avogadro/qtplugins/scriptfileformats/CMakeLists.txt
@@ -13,11 +13,3 @@ avogadro_plugin(ScriptFileFormats
 )
 
 target_link_libraries(ScriptFileFormats PRIVATE Avogadro::QuantumIO)
-
-# Bundled format scripts:
-set(format_scripts
-  formatScripts/zyx.py
-)
-
-install(PROGRAMS ${format_scripts}
-  DESTINATION "${INSTALL_LIBRARY_DIR}/avogadro2/scripts/formatScripts/")

--- a/avogadro/qtplugins/scriptfileformats/fileformatscript.cpp
+++ b/avogadro/qtplugins/scriptfileformats/fileformatscript.cpp
@@ -25,7 +25,7 @@ namespace Avogadro::QtPlugins {
 
 FileFormatScript::FileFormatScript(const QString& scriptFileName_)
   : m_interpreter(new QtGui::PythonScript(scriptFileName_)), m_valid(false),
-    m_bondOnRead(false), m_fileModeRead(false), m_fileModeWrite(false),
+    m_bondOnRead(false), m_inputModeFile(false), m_outputModeFile(false),
     m_inputFormat(NotUsed), m_outputFormat(NotUsed)
 {
 }
@@ -58,21 +58,16 @@ void FileFormatScript::readMetaData(const QVariantMap& metadata)
     m_operations |= Io::FileFormat::Read;
   if (support.value("write", false).toBool())
     m_operations |= Io::FileFormat::Write;
-  // Parse file-mode: "read", "write", or ["read", "write"]
-  if (metadata.contains("file-mode")) {
-    QVariant fileModeVar = metadata.value("file-mode");
-    QStringList fileModes;
-    if (fileModeVar.type() == QVariant::List) {
-      for (const auto& v : fileModeVar.toList())
-        fileModes << v.toString();
-    } else {
-      fileModes << fileModeVar.toString();
-    }
-    m_fileModeRead = fileModes.contains("read");
-    m_fileModeWrite = fileModes.contains("write");
-  }
+  // Parse input-mode / output-mode: "string" (default) or "file"
+  m_inputModeFile = metadata.value("input-mode")
+                      .toString()
+                      .compare(QLatin1String("file"), Qt::CaseInsensitive) == 0;
+  m_outputModeFile =
+    metadata.value("output-mode")
+      .toString()
+      .compare(QLatin1String("file"), Qt::CaseInsensitive) == 0;
 
-  if (m_fileModeRead || m_fileModeWrite)
+  if (m_inputModeFile || m_outputModeFile)
     m_operations |= Io::FileFormat::File;
   else
     m_operations |=
@@ -135,14 +130,14 @@ void FileFormatScript::copyMetaDataFrom(const FileFormatScript& other)
   m_fileExtensions = other.m_fileExtensions;
   m_mimeTypes = other.m_mimeTypes;
   m_bondOnRead = other.m_bondOnRead;
-  m_fileModeRead = other.m_fileModeRead;
-  m_fileModeWrite = other.m_fileModeWrite;
+  m_inputModeFile = other.m_inputModeFile;
+  m_outputModeFile = other.m_outputModeFile;
   m_valid = other.m_valid;
 }
 
 bool FileFormatScript::read(std::istream& in, Core::Molecule& molecule)
 {
-  if (m_fileModeRead) {
+  if (m_inputModeFile) {
     appendError("This format requires a file path and cannot be read from a "
                 "stream.");
     return false;
@@ -193,7 +188,7 @@ bool FileFormatScript::read(std::istream& in, Core::Molecule& molecule)
 
 bool FileFormatScript::write(std::ostream& out, const Core::Molecule& molecule)
 {
-  if (m_fileModeWrite) {
+  if (m_outputModeFile) {
     appendError("This format requires a file path and cannot be written to a "
                 "stream.");
     return false;
@@ -270,7 +265,7 @@ std::string FileFormatScript::formatToString(Format fmt)
 bool FileFormatScript::readFile(const std::string& fileName,
                                 Core::Molecule& molecule)
 {
-  if (!m_fileModeRead)
+  if (!m_inputModeFile)
     return FileFormat::readFile(fileName, molecule);
 
   QScopedPointer<FileFormat> format(createFileFormat(m_outputFormat));
@@ -309,7 +304,7 @@ bool FileFormatScript::readFile(const std::string& fileName,
 bool FileFormatScript::writeFile(const std::string& fileName,
                                  const Core::Molecule& molecule)
 {
-  if (!m_fileModeWrite)
+  if (!m_outputModeFile)
     return FileFormat::writeFile(fileName, molecule);
 
   QScopedPointer<FileFormat> format(createFileFormat(m_inputFormat));
@@ -368,8 +363,8 @@ void FileFormatScript::resetMetaData()
   m_operations = Io::FileFormat::None;
   m_valid = false;
   m_bondOnRead = false;
-  m_fileModeRead = false;
-  m_fileModeWrite = false;
+  m_inputModeFile = false;
+  m_outputModeFile = false;
   m_inputFormat = NotUsed;
   m_identifier.clear();
   m_name.clear();

--- a/avogadro/qtplugins/scriptfileformats/fileformatscript.cpp
+++ b/avogadro/qtplugins/scriptfileformats/fileformatscript.cpp
@@ -16,23 +16,18 @@
 #include <avogadro/io/xyzformat.h>
 
 #include <QtCore/QDebug>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
 #include <QtCore/QScopedPointer>
-
-#include <qjsonarray.h>
-#include <qjsondocument.h>
-#include <qjsonobject.h>
-#include <qjsonvalue.h>
-
-using namespace std::string_literals;
 
 namespace Avogadro::QtPlugins {
 
 FileFormatScript::FileFormatScript(const QString& scriptFileName_)
   : m_interpreter(new QtGui::PythonScript(scriptFileName_)), m_valid(false),
-    m_bondOnRead(false), m_inputFormat(NotUsed), m_outputFormat(NotUsed)
+    m_bondOnRead(false), m_fileModeRead(false), m_fileModeWrite(false),
+    m_inputFormat(NotUsed), m_outputFormat(NotUsed)
 {
-  if (!scriptFileName_.isEmpty())
-    readMetaData();
 }
 
 FileFormatScript::~FileFormatScript()
@@ -63,8 +58,25 @@ void FileFormatScript::readMetaData(const QVariantMap& metadata)
     m_operations |= Io::FileFormat::Read;
   if (support.value("write", false).toBool())
     m_operations |= Io::FileFormat::Write;
-  m_operations |=
-    Io::FileFormat::File | Io::FileFormat::Stream | Io::FileFormat::String;
+  // Parse file-mode: "read", "write", or ["read", "write"]
+  if (metadata.contains("file-mode")) {
+    QVariant fileModeVar = metadata.value("file-mode");
+    QStringList fileModes;
+    if (fileModeVar.type() == QVariant::List) {
+      for (const auto& v : fileModeVar.toList())
+        fileModes << v.toString();
+    } else {
+      fileModes << fileModeVar.toString();
+    }
+    m_fileModeRead = fileModes.contains("read");
+    m_fileModeWrite = fileModes.contains("write");
+  }
+
+  if (m_fileModeRead || m_fileModeWrite)
+    m_operations |= Io::FileFormat::File;
+  else
+    m_operations |=
+      Io::FileFormat::File | Io::FileFormat::Stream | Io::FileFormat::String;
 
   if (m_operations & Io::FileFormat::Write) {
     QString inputFmt = metadata.value("input-format").toString();
@@ -123,11 +135,19 @@ void FileFormatScript::copyMetaDataFrom(const FileFormatScript& other)
   m_fileExtensions = other.m_fileExtensions;
   m_mimeTypes = other.m_mimeTypes;
   m_bondOnRead = other.m_bondOnRead;
+  m_fileModeRead = other.m_fileModeRead;
+  m_fileModeWrite = other.m_fileModeWrite;
   m_valid = other.m_valid;
 }
 
 bool FileFormatScript::read(std::istream& in, Core::Molecule& molecule)
 {
+  if (m_fileModeRead) {
+    appendError("This format requires a file path and cannot be read from a "
+                "stream.");
+    return false;
+  }
+
   // Create intermediate format reader
   QScopedPointer<FileFormat> format(createFileFormat(m_outputFormat));
 
@@ -173,6 +193,12 @@ bool FileFormatScript::read(std::istream& in, Core::Molecule& molecule)
 
 bool FileFormatScript::write(std::ostream& out, const Core::Molecule& molecule)
 {
+  if (m_fileModeWrite) {
+    appendError("This format requires a file path and cannot be written to a "
+                "stream.");
+    return false;
+  }
+
   // Create the intermediate format writer
   std::string intermediate;
   QScopedPointer<FileFormat> format(createFileFormat(m_inputFormat));
@@ -221,6 +247,101 @@ FileFormatScript::Format FileFormatScript::stringToFormat(
   return NotUsed;
 }
 
+std::string FileFormatScript::formatToString(Format fmt)
+{
+  switch (fmt) {
+    case Cjson:
+      return "cjson";
+    case Cml:
+      return "cml";
+    case Mdl:
+      return "mdl";
+    case Pdb:
+      return "pdb";
+    case Sdf:
+      return "sdf";
+    case Xyz:
+      return "xyz";
+    default:
+      return "";
+  }
+}
+
+bool FileFormatScript::readFile(const std::string& fileName,
+                                Core::Molecule& molecule)
+{
+  if (!m_fileModeRead)
+    return FileFormat::readFile(fileName, molecule);
+
+  QScopedPointer<FileFormat> format(createFileFormat(m_outputFormat));
+  if (format.isNull()) {
+    appendError("Invalid intermediate format enum value.");
+    return false;
+  }
+
+  QJsonObject payload;
+  payload["operation"] = QLatin1String("read");
+  payload["filename"] = QString::fromStdString(fileName);
+  QByteArray input = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+
+  QByteArray result = m_interpreter->execute(QStringList() << "--read", input);
+
+  if (m_interpreter->hasErrors()) {
+    foreach (const QString& err, m_interpreter->errorList())
+      appendError(err.toStdString());
+    return false;
+  }
+
+  if (!format->readString(std::string(result.constData(), result.size()),
+                          molecule)) {
+    appendError(format->error(), false);
+    return false;
+  }
+
+  if (m_bondOnRead) {
+    molecule.perceiveBondsSimple();
+    molecule.perceiveBondOrders();
+  }
+
+  return true;
+}
+
+bool FileFormatScript::writeFile(const std::string& fileName,
+                                 const Core::Molecule& molecule)
+{
+  if (!m_fileModeWrite)
+    return FileFormat::writeFile(fileName, molecule);
+
+  QScopedPointer<FileFormat> format(createFileFormat(m_inputFormat));
+  if (format.isNull()) {
+    appendError("Invalid intermediate format enum value.");
+    return false;
+  }
+
+  std::string intermediate;
+  if (!format->writeString(intermediate, molecule)) {
+    appendError(format->error(), false);
+    return false;
+  }
+
+  QJsonObject payload;
+  payload["operation"] = QLatin1String("write");
+  payload["filename"] = QString::fromStdString(fileName);
+  payload[QString::fromStdString(formatToString(m_inputFormat))] =
+    QString::fromStdString(intermediate);
+  QByteArray input = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+
+  m_interpreter->execute(QStringList() << "--write", input);
+
+  if (m_interpreter->hasErrors()) {
+    foreach (const QString& err, m_interpreter->errorList())
+      appendError(err.toStdString());
+    return false;
+  }
+
+  return true;
+}
+
 Io::FileFormat* FileFormatScript::createFileFormat(FileFormatScript::Format fmt)
 {
   switch (fmt) {
@@ -247,6 +368,8 @@ void FileFormatScript::resetMetaData()
   m_operations = Io::FileFormat::None;
   m_valid = false;
   m_bondOnRead = false;
+  m_fileModeRead = false;
+  m_fileModeWrite = false;
   m_inputFormat = NotUsed;
   m_identifier.clear();
   m_name.clear();
@@ -254,191 +377,6 @@ void FileFormatScript::resetMetaData()
   m_specificationUrl.clear();
   m_fileExtensions.clear();
   m_mimeTypes.clear();
-}
-
-void FileFormatScript::readMetaData()
-{
-  resetMetaData();
-
-  QByteArray output(m_interpreter->execute(QStringList() << "--metadata"));
-
-  if (m_interpreter->hasErrors()) {
-    qWarning() << "Error retrieving metadata for file format script:"
-               << scriptFilePath() << "\n"
-               << m_interpreter->errorList();
-    return;
-  }
-
-  QJsonParseError parseError;
-  QJsonDocument doc(QJsonDocument::fromJson(output, &parseError));
-  if (parseError.error != QJsonParseError::NoError) {
-    qWarning() << "Error parsing metadata for file format script:"
-               << scriptFilePath() << "\n"
-               << parseError.errorString() << "(at offset" << parseError.offset
-               << ")";
-    return;
-  }
-
-  if (!doc.isObject()) {
-    qWarning() << "Error parsing metadata for file format script:"
-               << scriptFilePath() << "\nResult is not a JSON object:\n"
-               << output;
-    return;
-  }
-
-  const QJsonObject metaData(doc.object());
-
-  // Read required inputs first.
-  std::vector<std::string> opStringsTmp;
-  if (!parseStringArray(metaData, "operations", opStringsTmp)) {
-    qWarning() << "Error parsing metadata for file format script:"
-               << scriptFilePath() << "\n"
-               << "Error parsing required member 'operations'"
-               << "\n"
-               << output;
-    return;
-  }
-
-  // validate operations:
-  Operations operationsTmp = Io::FileFormat::None;
-  for (auto& it : opStringsTmp) {
-    if (it == "read")
-      operationsTmp |= Io::FileFormat::Read;
-    else if (it == "write")
-      operationsTmp |= Io::FileFormat::Write;
-    else {
-      qWarning() << "Error parsing metadata for file format script:"
-                 << scriptFilePath() << "\n"
-                 << "Unrecognized operation:" << it.c_str() << "\n"
-                 << output;
-      return;
-    }
-  }
-
-  std::string identifierTmp;
-  if (!parseString(metaData, "identifier", identifierTmp)) {
-    qWarning() << "Error parsing metadata for file format script:"
-               << scriptFilePath() << "\n"
-               << "Error parsing required member 'operations'"
-               << "\n"
-               << output;
-    return;
-  }
-
-  std::string nameTmp;
-  if (!parseString(metaData, "name", nameTmp)) {
-    qWarning() << "Error parsing metadata for file format script:"
-               << scriptFilePath() << "\n"
-               << "Error parsing required member 'name'"
-               << "\n"
-               << output;
-    return;
-  }
-
-  // input format is required if write operations are supported:
-  Format inputFormatTmp = NotUsed;
-  if (operationsTmp & Io::FileFormat::Write) {
-    std::string inputFormatStrTmp;
-    if (!parseString(metaData, "inputFormat", inputFormatStrTmp)) {
-      qWarning() << "Error parsing metadata for file format script:"
-                 << scriptFilePath() << "\n"
-                 << "Member 'inputFormat' required for writable formats."
-                 << "\n"
-                 << output;
-      return;
-    }
-
-    // Validate the input format
-    inputFormatTmp = stringToFormat(inputFormatStrTmp);
-    if (inputFormatTmp == NotUsed) {
-      qWarning() << "Error parsing metadata for file format script:"
-                 << scriptFilePath() << "\n"
-                 << "Member 'inputFormat' not recognized:"
-                 << inputFormatStrTmp.c_str()
-                 << "\nValid values are cjson, cml, mdl/sdf, pdb, or xyz.\n"
-                 << output;
-      return;
-    }
-  }
-
-  // output format is required if read operations are supported:
-  Format outputFormatTmp = NotUsed;
-  if (operationsTmp & Io::FileFormat::Read) {
-    std::string outputFormatStrTmp;
-    if (!parseString(metaData, "outputFormat", outputFormatStrTmp)) {
-      qWarning() << "Error parsing metadata for file format script:"
-                 << scriptFilePath() << "\n"
-                 << "Member 'outputFormat' required for readable formats."
-                 << "\n"
-                 << output;
-      return;
-    }
-
-    // Validate the output format
-    outputFormatTmp = stringToFormat(outputFormatStrTmp);
-    if (outputFormatTmp == NotUsed) {
-      qWarning() << "Error parsing metadata for file format script:"
-                 << scriptFilePath() << "\n"
-                 << "Member 'outputFormat' not recognized:"
-                 << outputFormatStrTmp.c_str()
-                 << "\nValid values are cjson, cml, mdl/sdf, pdb, or xyz.\n"
-                 << output;
-      return;
-    }
-  }
-
-  // If all required data is present, go ahead and set the member vars:
-  m_operations = operationsTmp | Io::FileFormat::File | Io::FileFormat::Stream |
-                 Io::FileFormat::String;
-  m_inputFormat = inputFormatTmp;
-  m_outputFormat = outputFormatTmp;
-  m_identifier = "User Script: "s + identifierTmp;
-  m_name = nameTmp;
-
-  // check if we should bond on read:
-  if (metaData["bond"].isBool()) {
-    m_bondOnRead = metaData["bond"].toBool();
-  }
-
-  // Everything else is optional:
-  parseString(metaData, "description", m_description);
-  parseString(metaData, "specificationUrl", m_specificationUrl);
-  parseStringArray(metaData, "fileExtensions", m_fileExtensions);
-  parseStringArray(metaData, "mimeTypes", m_mimeTypes);
-  m_valid = true;
-}
-
-bool FileFormatScript::parseString(const QJsonObject& ob, const QString& key,
-                                   std::string& str)
-{
-  if (!ob[key].isString())
-    return false;
-
-  str = ob[key].toString().toStdString();
-
-  return !str.empty();
-}
-
-bool FileFormatScript::parseStringArray(const QJsonObject& ob,
-                                        const QString& key,
-                                        std::vector<std::string>& array)
-{
-  array.clear();
-
-  if (!ob[key].isArray())
-    return false;
-
-  foreach (const QJsonValue& val, ob[key].toArray()) {
-    if (!val.isString())
-      return false;
-
-    array.push_back(val.toString().toStdString());
-
-    if (array.back().empty())
-      return false;
-  }
-
-  return !array.empty();
 }
 
 } // namespace Avogadro::QtPlugins

--- a/avogadro/qtplugins/scriptfileformats/fileformatscript.h
+++ b/avogadro/qtplugins/scriptfileformats/fileformatscript.h
@@ -186,8 +186,8 @@ private:
   QtGui::PythonScript* m_interpreter;
   bool m_valid;
   bool m_bondOnRead;
-  bool m_fileModeRead;
-  bool m_fileModeWrite;
+  bool m_inputModeFile;
+  bool m_outputModeFile;
   Operations m_operations;
   Format m_inputFormat;
   Format m_outputFormat;

--- a/avogadro/qtplugins/scriptfileformats/fileformatscript.h
+++ b/avogadro/qtplugins/scriptfileformats/fileformatscript.h
@@ -13,8 +13,6 @@
 #include <QtCore/QString>
 #include <QtCore/QVariantMap>
 
-class QJsonObject;
-
 namespace Avogadro {
 namespace QtGui {
 class PythonScript;
@@ -155,6 +153,11 @@ public:
 
   bool write(std::ostream& out, const Core::Molecule& molecule) override;
 
+  bool readFile(const std::string& fileName, Core::Molecule& molecule) override;
+
+  bool writeFile(const std::string& fileName,
+                 const Core::Molecule& molecule) override;
+
   Operations supportedOperations() const override { return m_operations; }
 
   std::string identifier() const override { return m_identifier; }
@@ -174,18 +177,17 @@ public:
 
 private:
   static Format stringToFormat(const std::string& str);
+  static std::string formatToString(Format fmt);
   static Io::FileFormat* createFileFormat(Format fmt);
   void resetMetaData();
-  void readMetaData();
-  bool parseString(const QJsonObject& ob, const QString& key, std::string& str);
-  bool parseStringArray(const QJsonObject& ob, const QString& key,
-                        std::vector<std::string>& array);
   void copyMetaDataFrom(const FileFormatScript& other);
 
 private:
   QtGui::PythonScript* m_interpreter;
   bool m_valid;
   bool m_bondOnRead;
+  bool m_fileModeRead;
+  bool m_fileModeWrite;
   Operations m_operations;
   Format m_inputFormat;
   Format m_outputFormat;


### PR DESCRIPTION
Currently used as:
file-mode = "read" or file-mode = ["read", "write"]

Default is stream-mode

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
