### PR TITLE
Allow user-options metadata to be "dynamic" and call the script

### DIFF
--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -308,21 +308,40 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
     }
 
     // check if there are messages for the user
-    if (obj.contains("message")) {
-      QString message;
-
-      if (obj["message"].isString())
-        message = obj["message"].toString();
-      else if (obj["message"].isArray()) {
-        QJsonArray messageList = obj["message"].toArray();
-        for (int i = 0; i < messageList.size(); ++i) {
-          if (messageList[i].isString())
-            message += messageList[i].toString() + "\n";
+    auto extractMessage = [](const QJsonValue& val) -> QString {
+      if (val.isString())
+        return val.toString();
+      if (val.isArray()) {
+        QString result;
+        const QJsonArray arr = val.toArray();
+        for (const auto& item : arr) {
+          if (item.isString())
+            result += item.toString() + '\n';
         }
+        return result;
       }
+      return {};
+    };
+
+    if (obj.contains("message")) {
+      QString message = extractMessage(obj["message"]);
       if (!message.isEmpty()) {
         QMessageBox::information(qobject_cast<QWidget*>(parent()),
                                  tr("%1 Message").arg(m_displayName), message);
+      }
+    }
+    if (obj.contains("warning")) {
+      QString message = extractMessage(obj["warning"]);
+      if (!message.isEmpty()) {
+        QMessageBox::warning(qobject_cast<QWidget*>(parent()),
+                             tr("%1 Warning").arg(m_displayName), message);
+      }
+    }
+    if (obj.contains("error")) {
+      QString message = extractMessage(obj["error"]);
+      if (!message.isEmpty()) {
+        QMessageBox::critical(qobject_cast<QWidget*>(parent()),
+                              tr("%1 Error").arg(m_displayName), message);
       }
     }
   }

--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -101,6 +101,30 @@ void PackageManager::mergeOptionsFromFile(QJsonObject& opts,
     opts.insert(it.key(), it.value());
 }
 
+// Locate an installed console script inside a pixi or venv environment.
+static QString findInstalledScript(const QString& packageDir,
+                                   const QString& scriptName, bool isPixi)
+{
+#ifdef Q_OS_WIN
+  const QString binDir =
+    packageDir + (isPixi ? QStringLiteral("/.pixi/envs/default/Scripts")
+                         : QStringLiteral("/.venv/Scripts"));
+  const QStringList exeSuffixes = { QStringLiteral(".exe"), QString() };
+#else
+  const QString binDir =
+    packageDir + (isPixi ? QStringLiteral("/.pixi/envs/default/bin")
+                         : QStringLiteral("/.venv/bin"));
+  const QStringList exeSuffixes = { QString() };
+#endif
+
+  for (const QString& suffix : exeSuffixes) {
+    const QString candidate = binDir + QLatin1Char('/') + scriptName + suffix;
+    if (QFileInfo(candidate).isExecutable())
+      return candidate;
+  }
+  return {};
+}
+
 QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
                                                   const QString& command)
 {
@@ -174,10 +198,19 @@ QJsonObject PackageManager::resolveUserOptions(const QString& userOptionsValue,
   if (userOptionsValue.isEmpty())
     return {};
 
+  QJsonObject result;
   if (userOptionsValue == QLatin1String("dynamic"))
-    return loadOptionsFromScript(packageDir, command);
+    result = loadOptionsFromScript(packageDir, command);
+  else
+    result = loadOptionsFromFile(packageDir + '/' + userOptionsValue);
 
-  return loadOptionsFromFile(packageDir + '/' + userOptionsValue);
+  // Both loadOptionsFromFile() and loadOptionsFromScript() may wrap a bare
+  // array under "userOptions".  Unwrap so callers can insert under their own
+  // key without double-nesting.
+  if (result.contains(QStringLiteral("userOptions")))
+    return result.value(QStringLiteral("userOptions")).toObject();
+
+  return result;
 }
 
 static bool hasNonExecutablePixiPython(const QString& packageDir)
@@ -276,30 +309,6 @@ static QString readSetupCommand(const QString& packageDir)
         it.key().endsWith(QStringLiteral("-setup")) &&
         isSafeScriptName(it.key()))
       return it.key();
-  }
-  return {};
-}
-
-// Locate an installed console script inside a pixi or venv environment.
-static QString findInstalledScript(const QString& packageDir,
-                                   const QString& scriptName, bool isPixi)
-{
-#ifdef Q_OS_WIN
-  const QString binDir =
-    packageDir + (isPixi ? QStringLiteral("/.pixi/envs/default/Scripts")
-                         : QStringLiteral("/.venv/Scripts"));
-  const QStringList exeSuffixes = { QStringLiteral(".exe"), QString() };
-#else
-  const QString binDir =
-    packageDir + (isPixi ? QStringLiteral("/.pixi/envs/default/bin")
-                         : QStringLiteral("/.venv/bin"));
-  const QStringList exeSuffixes = { QString() };
-#endif
-
-  for (const QString& suffix : exeSuffixes) {
-    const QString candidate = binDir + QLatin1Char('/') + scriptName + suffix;
-    if (QFileInfo(candidate).isExecutable())
-      return candidate;
   }
   return {};
 }

--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -101,6 +101,85 @@ void PackageManager::mergeOptionsFromFile(QJsonObject& opts,
     opts.insert(it.key(), it.value());
 }
 
+QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
+                                                  const QString& command)
+{
+  // Locate pixi or the venv-installed script.
+  QString pixiExe = QStandardPaths::findExecutable(QStringLiteral("pixi"));
+  QProcess proc;
+  proc.setWorkingDirectory(packageDir);
+
+  if (!pixiExe.isEmpty()) {
+    proc.start(pixiExe, { QStringLiteral("run"), QStringLiteral("--as-is"),
+                          command, QStringLiteral("--user-options") });
+  } else {
+    // Try the venv-installed script directly.
+    QString scriptExe = findInstalledScript(packageDir, command, false);
+    if (scriptExe.isEmpty()) {
+      qWarning() << "PackageManager: cannot find pixi or venv script for"
+                 << command << "in" << packageDir;
+      return {};
+    }
+    proc.start(scriptExe, { QStringLiteral("--user-options") });
+  }
+
+  constexpr int timeoutMs = 30000; // 30 seconds
+  if (!proc.waitForStarted(timeoutMs)) {
+    qWarning() << "PackageManager: --user-options script could not start:"
+               << proc.errorString();
+    return {};
+  }
+  if (!proc.waitForFinished(timeoutMs)) {
+    qWarning() << "PackageManager: --user-options script timed out for"
+               << packageDir;
+    proc.kill();
+    return {};
+  }
+  if (proc.exitCode() != 0) {
+    qWarning() << "PackageManager: --user-options script failed for"
+               << packageDir << ":"
+               << QString::fromUtf8(proc.readAllStandardError());
+    return {};
+  }
+
+  const QByteArray output = proc.readAllStandardOutput();
+  QJsonParseError err;
+  const QJsonDocument doc = QJsonDocument::fromJson(output, &err);
+  if (err.error != QJsonParseError::NoError) {
+    qWarning() << "PackageManager: failed to parse --user-options JSON from"
+               << command << ":" << err.errorString();
+    return {};
+  }
+
+  if (doc.isArray()) {
+    QJsonObject wrapped;
+    wrapped.insert(QStringLiteral("userOptions"), doc.array());
+    return wrapped;
+  }
+
+  if (!doc.isObject()) {
+    qWarning() << "PackageManager: --user-options output is not an object or"
+                  " array from"
+               << command;
+    return {};
+  }
+
+  return doc.object();
+}
+
+QJsonObject PackageManager::resolveUserOptions(const QString& userOptionsValue,
+                                               const QString& packageDir,
+                                               const QString& command)
+{
+  if (userOptionsValue.isEmpty())
+    return {};
+
+  if (userOptionsValue == QLatin1String("dynamic"))
+    return loadOptionsFromScript(packageDir, command);
+
+  return loadOptionsFromFile(packageDir + '/' + userOptionsValue);
+}
+
 static bool hasNonExecutablePixiPython(const QString& packageDir)
 {
 #ifdef Q_OS_WIN

--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -126,16 +126,24 @@ static QString findInstalledScript(const QString& packageDir,
 }
 
 QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
-                                                  const QString& command)
+                                                  const QString& command,
+                                                  const QString& identifier)
 {
   // Locate pixi or the venv-installed script.
   QString pixiExe = QStandardPaths::findExecutable(QStringLiteral("pixi"));
   QProcess proc;
   proc.setWorkingDirectory(packageDir);
 
+  QStringList userOptsArgs;
+  if (!identifier.isEmpty())
+    userOptsArgs << identifier;
+  userOptsArgs << QStringLiteral("--user-options");
+
   if (!pixiExe.isEmpty()) {
-    proc.start(pixiExe, { QStringLiteral("run"), QStringLiteral("--as-is"),
-                          command, QStringLiteral("--user-options") });
+    QStringList pixiArgs = { QStringLiteral("run"), QStringLiteral("--as-is"),
+                             command };
+    pixiArgs << userOptsArgs;
+    proc.start(pixiExe, pixiArgs);
   } else {
     // Try the venv-installed script directly.
     QString scriptExe = findInstalledScript(packageDir, command, false);
@@ -144,7 +152,7 @@ QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
                  << command << "in" << packageDir;
       return {};
     }
-    proc.start(scriptExe, { QStringLiteral("--user-options") });
+    proc.start(scriptExe, userOptsArgs);
   }
 
   constexpr int timeoutMs = 30000; // 30 seconds
@@ -193,22 +201,28 @@ QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
 
 QJsonObject PackageManager::resolveUserOptions(const QString& userOptionsValue,
                                                const QString& packageDir,
-                                               const QString& command)
+                                               const QString& command,
+                                               const QString& identifier)
 {
   if (userOptionsValue.isEmpty())
     return {};
 
   QJsonObject result;
   if (userOptionsValue == QLatin1String("dynamic"))
-    result = loadOptionsFromScript(packageDir, command);
+    result = loadOptionsFromScript(packageDir, command, identifier);
   else
     result = loadOptionsFromFile(packageDir + '/' + userOptionsValue);
 
   // Both loadOptionsFromFile() and loadOptionsFromScript() may wrap a bare
   // array under "userOptions".  Unwrap so callers can insert under their own
   // key without double-nesting.
-  if (result.contains(QStringLiteral("userOptions")))
-    return result.value(QStringLiteral("userOptions")).toObject();
+  if (result.contains(QStringLiteral("userOptions"))) {
+    QJsonValue val = result.value(QStringLiteral("userOptions"));
+    if (val.isObject())
+      return val.toObject();
+    // Value is an array; return wrapped form for caller to handle.
+    return result;
+  }
 
   return result;
 }

--- a/avogadro/qtgui/packagemanager.h
+++ b/avogadro/qtgui/packagemanager.h
@@ -76,7 +76,8 @@ public:
    * Returns an empty object on error.
    */
   static QJsonObject loadOptionsFromScript(const QString& packageDir,
-                                           const QString& command);
+                                           const QString& command,
+                                           const QString& identifier);
 
   /**
    * Resolve user-options for a package feature. If @p userOptionsValue is
@@ -87,7 +88,8 @@ public:
    */
   static QJsonObject resolveUserOptions(const QString& userOptionsValue,
                                         const QString& packageDir,
-                                        const QString& command);
+                                        const QString& command,
+                                        const QString& identifier);
 
   // --- Installation ---
 

--- a/avogadro/qtgui/packagemanager.h
+++ b/avogadro/qtgui/packagemanager.h
@@ -70,6 +70,25 @@ public:
   static void mergeOptionsFromFile(QJsonObject& opts,
                                    const QString& userOptionsPath);
 
+  /**
+   * Run the package script with @c --user-options and parse the JSON output.
+   * Uses pixi (preferred) or the venv-installed script as fallback.
+   * Returns an empty object on error.
+   */
+  static QJsonObject loadOptionsFromScript(const QString& packageDir,
+                                           const QString& command);
+
+  /**
+   * Resolve user-options for a package feature. If @p userOptionsValue is
+   * the literal string "dynamic", runs the script with @c --user-options
+   * via loadOptionsFromScript(). Otherwise treats it as a relative file
+   * path and loads via loadOptionsFromFile().
+   * Returns an empty object on error or if @p userOptionsValue is empty.
+   */
+  static QJsonObject resolveUserOptions(const QString& userOptionsValue,
+                                        const QString& packageDir,
+                                        const QString& command);
+
   // --- Installation ---
 
   /**

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -210,7 +210,7 @@ void Command::menuActivated()
         theSender->property("packageUserOptions").toString();
       if (!userOptionsRel.isEmpty()) {
         QJsonObject userOpts = QtGui::PackageManager::resolveUserOptions(
-          userOptionsRel, pkgDir, pkgCmd);
+          userOptionsRel, pkgDir, pkgCmd, pkgId);
         if (!userOpts.isEmpty())
           opts.insert(QStringLiteral("userOptions"), userOpts);
       }

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -202,15 +202,15 @@ void Command::menuActivated()
         opts.insert(QStringLiteral("inputMoleculeFormat"), inputFormat);
 
       // The pyproject.toml [avogadro.X] table may declare a separate
-      // user-options file (JSON or TOML).  Its keys are the user-facing
+      // user-options file (JSON or TOML), or the literal "dynamic" to run
+      // the script with --user-options.  Its keys are the user-facing
       // option definitions and must be wrapped under "userOptions" so that
       // JsonWidget::buildOptionGui() recognises them and builds the dialog.
       QString userOptionsRel =
         theSender->property("packageUserOptions").toString();
       if (!userOptionsRel.isEmpty()) {
-        QString userOptionsPath = pkgDir + '/' + userOptionsRel;
-        QJsonObject userOpts =
-          QtGui::PackageManager::loadOptionsFromFile(userOptionsPath);
+        QJsonObject userOpts = QtGui::PackageManager::resolveUserOptions(
+          userOptionsRel, pkgDir, pkgCmd);
         if (!userOpts.isEmpty())
           opts.insert(QStringLiteral("userOptions"), userOpts);
       }

--- a/avogadro/qtplugins/forcefield/scriptenergy.cpp
+++ b/avogadro/qtplugins/forcefield/scriptenergy.cpp
@@ -148,7 +148,7 @@ void ScriptEnergy::readMetaData(const QVariantMap& metadata)
     if (!userOptionsRel.isEmpty()) {
       m_userOptionsSchema = QtGui::PackageManager::resolveUserOptions(
         userOptionsRel, m_interpreter->packageDir(),
-        m_interpreter->packageCommand());
+        m_interpreter->packageCommand(), m_interpreter->packageIdentifier());
     }
   }
 

--- a/avogadro/qtplugins/forcefield/scriptenergy.cpp
+++ b/avogadro/qtplugins/forcefield/scriptenergy.cpp
@@ -146,12 +146,9 @@ void ScriptEnergy::readMetaData(const QVariantMap& metadata)
   } else {
     const QString userOptionsRel = userOptionsVar.toString();
     if (!userOptionsRel.isEmpty()) {
-      QString userOptionsPath = userOptionsRel;
-      if (!m_interpreter->packageDir().isEmpty()) {
-        userOptionsPath = m_interpreter->packageDir() + '/' + userOptionsRel;
-      }
-      m_userOptionsSchema =
-        QtGui::PackageManager::loadOptionsFromFile(userOptionsPath);
+      m_userOptionsSchema = QtGui::PackageManager::resolveUserOptions(
+        userOptionsRel, m_interpreter->packageDir(),
+        m_interpreter->packageCommand());
     }
   }
 

--- a/avogadro/qtplugins/quantuminput/quantuminput.cpp
+++ b/avogadro/qtplugins/quantuminput/quantuminput.cpp
@@ -201,8 +201,10 @@ void QuantumInput::menuActivated()
       QString userOptionsRel =
         theSender->property("packageUserOptions").toString();
       if (!userOptionsRel.isEmpty()) {
-        QString userOptionsPath = pkgDir + '/' + userOptionsRel;
-        QtGui::PackageManager::mergeOptionsFromFile(opts, userOptionsPath);
+        QJsonObject userOpts = QtGui::PackageManager::resolveUserOptions(
+          userOptionsRel, pkgDir, pkgCmd);
+        for (auto it = userOpts.constBegin(); it != userOpts.constEnd(); ++it)
+          opts.insert(it.key(), it.value());
       }
 
       // Optionally load syntax-highlight rules from a separate file.

--- a/avogadro/qtplugins/quantuminput/quantuminput.cpp
+++ b/avogadro/qtplugins/quantuminput/quantuminput.cpp
@@ -203,8 +203,8 @@ void QuantumInput::menuActivated()
       if (!userOptionsRel.isEmpty()) {
         QJsonObject userOpts = QtGui::PackageManager::resolveUserOptions(
           userOptionsRel, pkgDir, pkgCmd);
-        for (auto it = userOpts.constBegin(); it != userOpts.constEnd(); ++it)
-          opts.insert(it.key(), it.value());
+        if (!userOpts.isEmpty())
+          opts.insert(QStringLiteral("userOptions"), userOpts);
       }
 
       // Optionally load syntax-highlight rules from a separate file.

--- a/avogadro/qtplugins/quantuminput/quantuminput.cpp
+++ b/avogadro/qtplugins/quantuminput/quantuminput.cpp
@@ -202,7 +202,7 @@ void QuantumInput::menuActivated()
         theSender->property("packageUserOptions").toString();
       if (!userOptionsRel.isEmpty()) {
         QJsonObject userOpts = QtGui::PackageManager::resolveUserOptions(
-          userOptionsRel, pkgDir, pkgCmd);
+          userOptionsRel, pkgDir, pkgCmd, pkgId);
         if (!userOpts.isEmpty())
           opts.insert(QStringLiteral("userOptions"), userOpts);
       }


### PR DESCRIPTION
Script call adds `--user-options` and returns the JSON

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic user options: packages can load options from either scripts or static files; resulting options are applied cleanly.
  * Improved UI messaging: package scripts can surface warnings and errors that are shown to users.

* **Bug Fixes**
  * More robust loading: better handling of timeouts, execution failures and JSON parsing.
  * Avoids redundant nesting of userOptions when merging sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->