### PR TITLE
Stop unnecessary runs of plugins with `--display-name`

### DIFF
--- a/avogadro/molequeue/inputgenerator.cpp
+++ b/avogadro/molequeue/inputgenerator.cpp
@@ -91,11 +91,10 @@ QJsonObject InputGenerator::options() const
 QString InputGenerator::displayName() const
 {
   m_errors.clear();
+  // Not actually sure where this is even used now that the name is declared
+  // statically, but keeping the method in to avoid breaking anything
   if (m_displayName.isEmpty()) {
-    m_displayName =
-      QString(m_interpreter->execute(QStringList() << "--display-name"));
-    m_errors << m_interpreter->errorList();
-    m_displayName = m_displayName.trimmed();
+    m_displayName = QString("Please report it if you ever see this text!");
   }
 
   return m_displayName;

--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -118,11 +118,10 @@ QJsonObject InterfaceScript::options() const
 QString InterfaceScript::displayName() const
 {
   m_errors.clear();
+  // Not actually sure where this is even used now that the name is declared
+  // statically, but keeping the method in to avoid breaking anything
   if (m_displayName.isEmpty()) {
-    m_displayName = QString(m_interpreter->execute(
-      QStringList() << QStringLiteral("--display-name")));
-    m_errors << m_interpreter->errorList();
-    m_displayName = m_displayName.trimmed();
+    m_displayName = QString("Please report it if you ever see this text!");
   }
 
   return m_displayName;


### PR DESCRIPTION
This stems from a side observation made while debugging the current state of https://github.com/OpenChemistry/avogadrolibs/pull/2703.

By adding this code to a plugin's `main()` function I gained some good insights:

```python
def main():
    import time
    with open(f"/home/matt/{time.time_ns()}_cli.txt", "w") as f:
        f.write(" ".join(sys.argv))
    parser = argparse.ArgumentParser()
    ...
    args = parser.parse_args()
    with open(f"/home/matt/{time.time_ns()}_args.txt", "w") as f:
        f.write(str(args))
    ...
```

Because it writes both the original CLI arguments and the parsed arguments to file, there's a `*_cli.txt` file saved every single time the plugin is run.

What is happening at the moment is that every time a menu command or input generator is run, the plugin is being run *twice*: first using `<plugin> <feature> --display-name --lang <lang>`, then a second time without the flag.

The call seems to stem from the `displayName()` method, which runs the plugin in this way if `m_displayName` is empty. Most plugins will now error every time they are run with the `--display-name` flag, and that doesn't seem to be a problem for anything, so presumably the method and attribute are just a remnant of the old system. I'm not sure where it's supposed to appear.

I was reluctant to possibly break something by removing the method, so here I've fixed the issue by just returning a placeholder string if `m_displayName` is empty, rather than running the plugin. It works – the extra run no longer happens, and I don't see the placeholder string in the UI anywhere – but presumably this method really just ought to be chucked out completely eventually.

---

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
