### PR TITLE
Avoid calling --display-name for package scripts, set via metadata

### DIFF
--- a/avogadro/molequeue/inputgenerator.cpp
+++ b/avogadro/molequeue/inputgenerator.cpp
@@ -92,10 +92,16 @@ QString InputGenerator::displayName() const
 {
   m_errors.clear();
   if (m_displayName.isEmpty()) {
-    m_displayName =
-      QString(m_interpreter->execute(QStringList() << "--display-name"));
-    m_errors << m_interpreter->errorList();
-    m_displayName = m_displayName.trimmed();
+    if (m_interpreter->isPackageMode()) {
+      m_displayName = m_interpreter->packageDisplayName().trimmed();
+      if (m_displayName.isEmpty())
+        m_displayName = m_interpreter->packageIdentifier().trimmed();
+    } else {
+      m_displayName =
+        QString(m_interpreter->execute(QStringList() << "--display-name"));
+      m_errors << m_interpreter->errorList();
+      m_displayName = m_displayName.trimmed();
+    }
   }
 
   return m_displayName;

--- a/avogadro/molequeue/inputgenerator.h
+++ b/avogadro/molequeue/inputgenerator.h
@@ -481,7 +481,9 @@ public:
   QJsonObject options() const;
 
   /**
-   * Query the script for a user-friendly name (<tt>--display-name</tt>).
+   * Return a user-friendly name for the generator.
+   * @note In package mode this is taken from package metadata. For legacy
+   *       script mode, the value is queried from <tt>--display-name</tt>.
    * @note The results will be cached the first time this function is called
    * and reused in subsequent calls.
    * @note If an error occurs, the error string will be set. Call hasErrors()

--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -119,10 +119,16 @@ QString InterfaceScript::displayName() const
 {
   m_errors.clear();
   if (m_displayName.isEmpty()) {
-    m_displayName = QString(m_interpreter->execute(
-      QStringList() << QStringLiteral("--display-name")));
-    m_errors << m_interpreter->errorList();
-    m_displayName = m_displayName.trimmed();
+    if (m_interpreter->isPackageMode()) {
+      m_displayName = m_interpreter->packageDisplayName().trimmed();
+      if (m_displayName.isEmpty())
+        m_displayName = m_interpreter->packageIdentifier().trimmed();
+    } else {
+      m_displayName = QString(m_interpreter->execute(
+        QStringList() << QStringLiteral("--display-name")));
+      m_errors << m_interpreter->errorList();
+      m_displayName = m_displayName.trimmed();
+    }
   }
 
   return m_displayName;

--- a/avogadro/qtgui/interfacescript.h
+++ b/avogadro/qtgui/interfacescript.h
@@ -479,7 +479,9 @@ public:
   QJsonObject options() const;
 
   /**
-   * Query the script for a user-friendly name (<tt>--display-name</tt>).
+   * Return a user-friendly name for the script.
+   * @note In package mode this is taken from package metadata. For legacy
+   *       script mode, the value is queried from <tt>--display-name</tt>.
    * @note The results will be cached the first time this function is called
    * and reused in subsequent calls.
    * @note If an error occurs, the error string will be set. Call hasErrors()

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -54,15 +54,21 @@ void PythonScript::setScriptFilePath(const QString& scriptFile)
 {
   m_scriptFilePath = scriptFile;
   m_packageMode = false;
+  m_packageDir.clear();
+  m_packageCommand.clear();
+  m_packageIdentifier.clear();
+  m_packageDisplayName.clear();
 }
 
 void PythonScript::setPackageInfo(const QString& packageDir,
                                   const QString& command,
-                                  const QString& identifier)
+                                  const QString& identifier,
+                                  const QString& displayName)
 {
   m_packageDir = packageDir;
   m_packageCommand = command;
   m_packageIdentifier = identifier;
+  m_packageDisplayName = displayName;
   m_packageMode = true;
   m_scriptFilePath.clear();
 }

--- a/avogadro/qtgui/pythonscript.h
+++ b/avogadro/qtgui/pythonscript.h
@@ -61,7 +61,8 @@ public:
    * working directory, instead of launching a script file via python.
    */
   void setPackageInfo(const QString& packageDir, const QString& command,
-                      const QString& identifier);
+                      const QString& identifier,
+                      const QString& displayName = QString());
 
   /**
    * @return True if this script is in package mode.
@@ -82,6 +83,11 @@ public:
    * @return The package identifier (only meaningful in package mode).
    */
   QString packageIdentifier() const { return m_packageIdentifier; }
+
+  /**
+   * @return The package display name from metadata, if one was provided.
+   */
+  QString packageDisplayName() const { return m_packageDisplayName; }
 
   /**
    * @return True if an error is set.
@@ -182,6 +188,7 @@ protected:
   QString m_packageDir;
   QString m_packageCommand;
   QString m_packageIdentifier;
+  QString m_packageDisplayName;
   QStringList m_errors;
   QProcess* m_process;
 

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -190,8 +190,9 @@ void Command::menuActivated()
     widget = m_dialogs.value(key, nullptr);
     if (!widget) {
       widget = new InterfaceWidget(QString(), theParent);
-      widget->interfaceScript().interpreter().setPackageInfo(pkgDir, pkgCmd,
-                                                             pkgId);
+      widget->interfaceScript().interpreter().setPackageInfo(
+        pkgDir, pkgCmd, pkgId,
+        theSender->property("packageDisplayName").toString());
 
       // Build options from pyproject.toml metadata; never call --print-options
       // for package-based commands (mirrors QuantumInput::menuActivated()).
@@ -276,9 +277,9 @@ void Command::run()
     const auto& interp = iface.interpreter();
     QJsonObject options;
     if (interp.isPackageMode()) {
-      m_currentScript->interpreter().setPackageInfo(interp.packageDir(),
-                                                    interp.packageCommand(),
-                                                    interp.packageIdentifier());
+      m_currentScript->interpreter().setPackageInfo(
+        interp.packageDir(), interp.packageCommand(),
+        interp.packageIdentifier(), interp.packageDisplayName());
       // Copy cached options so insertMolecule() doesn't call --print-options
       m_currentScript->setOptionsJson(iface.options());
       // Wrap user selections under "options" so Python receives them as
@@ -457,6 +458,7 @@ void Command::registerFeature(const QString& type, const QString& packageDir,
   action->setProperty("packageDir", packageDir);
   action->setProperty("packageCommand", command);
   action->setProperty("packageIdentifier", identifier);
+  action->setProperty("packageDisplayName", item);
   action->setProperty("packageMenuPath", menuPathList);
   action->setProperty("packageUserOptions",
                       metadata.value("user-options").toString());

--- a/avogadro/qtplugins/quantuminput/quantuminput.cpp
+++ b/avogadro/qtplugins/quantuminput/quantuminput.cpp
@@ -184,7 +184,8 @@ void QuantumInput::menuActivated()
     if (!dlg) {
       dlg = new InputGeneratorDialog(theParent);
       dlg->widget().inputGenerator().interpreter().setPackageInfo(
-        pkgDir, pkgCmd, pkgId);
+        pkgDir, pkgCmd, pkgId,
+        theSender->property("packageDisplayName").toString());
 
       // The pyproject.toml [avogadro.X] table may declare a separate
       // user-options file (JSON or TOML) that overrides the defaults baked
@@ -295,9 +296,10 @@ void QuantumInput::registerFeature(const QString& type,
     return;
 
   // Extract label from metadata
-  QString label = metadata.value("program-name").toString();
-  if (label.isEmpty())
-    label = identifier;
+  QString displayName = metadata.value("program-name").toString();
+  if (displayName.isEmpty())
+    displayName = identifier;
+  QString label = displayName;
   if (!label.endsWith("…") && !label.endsWith("..."))
     label.append("…");
 
@@ -307,6 +309,7 @@ void QuantumInput::registerFeature(const QString& type,
   action->setProperty("packageDir", packageDir);
   action->setProperty("packageCommand", command);
   action->setProperty("packageIdentifier", identifier);
+  action->setProperty("packageDisplayName", displayName);
   action->setProperty("packageUserOptions",
                       metadata.value("user-options").toString());
   action->setProperty("packageInputFormat",


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display name resolution and handling for scripts and package-based generators with better fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->