### PR TITLE
Dynamic user options: Pass {} as input, and fix hang by sending EOF

### DIFF
--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -20,6 +20,8 @@
 #include <QtCore/QJsonParseError>
 #include <QtCore/QSettings>
 
+using namespace Qt::StringLiterals;
+
 namespace Avogadro::QtGui {
 
 PackageManager::PackageManager(QObject* parent) : QObject(parent) {}
@@ -158,6 +160,13 @@ QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
     }
     proc.start(scriptExe, userOptsArgs);
   }
+
+  // Plugins may always expect some valid JSON as input over stdin, even if it's
+  // just an empty object
+  QByteArray scriptStdin = "{}"_ba;
+  proc.write(scriptStdin);
+  // Python
+  proc.closeWriteChannel();
 
   constexpr int timeoutMs = 30000; // 30 seconds
   if (!proc.waitForStarted(timeoutMs)) {


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
