### PR TITLE
Fix bug with adding a perpendicular point w/no selection

### DIFF
--- a/avogadro/qtplugins/centroid/centroid.cpp
+++ b/avogadro/qtplugins/centroid/centroid.cpp
@@ -110,9 +110,10 @@ void Centroid::normal()
   if (m_molecule == nullptr || m_molecule->atomCount() == 0)
     return;
 
+  Vector3 newPos(0.0, 0.0, 0.0);
   if (m_molecule->isSelectionEmpty()) {
     auto pair = m_molecule->bestFitPlane();
-    m_molecule->addAtom(0.0, pair.second * 2.0);
+    newPos = pair.second * 2.0 + pair.first;
   } else {
     Array<Vector3> selectedAtoms;
     for (Index i = 0; i < m_molecule->atomCount(); ++i) {
@@ -123,9 +124,9 @@ void Centroid::normal()
     }
 
     auto pair = m_molecule->bestFitPlane(selectedAtoms);
-    Vector3 newPos = pair.second * 2.0 + pair.first;
-    m_molecule->addAtom(0, newPos);
+    newPos = pair.second * 2.0 + pair.first;
   }
+  m_molecule->undoMolecule()->addAtom(0, newPos);
 
   m_molecule->emitChanged(QtGui::Molecule::Atoms | QtGui::Molecule::Added);
 }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced the centroid operation to properly support undo/redo functionality. Users can now undo atom additions from this operation, improving workflow efficiency when correcting accidental changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->