### PR TITLE
Create secondary structure for insertpeptide and retain it

### DIFF
--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -500,8 +500,9 @@ void RWMolecule::addResidue(const Core::Residue& residue, Index offset)
   Index id = residue.residueId();
   char chain = residue.chainId();
   m_molecule.addResidue(name, id, chain);
-  Core::Residue newResidue = m_molecule.residue(m_molecule.residueCount() - 1);
+  Core::Residue& newResidue = m_molecule.residue(m_molecule.residueCount() - 1);
   newResidue.setHeterogen(residue.isHeterogen());
+  newResidue.setSecondaryStructure(residue.secondaryStructure());
 
   // now go through all the atoms and add them using the offset
   for (Core::Atom atom : residue.residueAtoms()) {

--- a/avogadro/qtplugins/insertpeptide/insertpeptide.cpp
+++ b/avogadro/qtplugins/insertpeptide/insertpeptide.cpp
@@ -8,6 +8,7 @@
 
 #include <avogadro/core/array.h>
 #include <avogadro/core/residue.h>
+#include <avogadro/core/secondarystructure.h>
 
 #include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtgui/rwmolecule.h>
@@ -371,8 +372,8 @@ void InsertPeptide::performInsert()
     }
 
     // Create residue
-    auto residue = newMol.addResidue(aaStdString, ++currentResidueNumber,
-                                     chain.toLatin1()[0]);
+    auto& residue = newMol.addResidue(aaStdString, ++currentResidueNumber,
+                                      chain.toLatin1()[0]);
 
     // Add atoms from this amino acid
     for (size_t j = 0; j < amino.atomNames.size(); j++) {
@@ -507,6 +508,10 @@ void InsertPeptide::performInsert()
   for (size_t i = 0; i < positions.size(); i++) {
     newMol.setAtomPosition3d(i, positions[i]);
   }
+
+  // okay, make sure we have secondary structure assigned
+  Core::SecondaryStructureAssigner ssa;
+  ssa.assign(&newMol);
 
   m_molecule->undoMolecule()->appendMolecule(newMol, tr("Insert Peptide"));
   emit requestActiveTool("Manipulator");


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secondary structure information is now correctly maintained when adding residues to molecular structures
  * Peptide insertion has been improved to properly assign secondary structure data to newly created peptide structures for more accurate molecular representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->