### PR TITLE
When changing atoms, bonds, etc. invalidate surfaces, spectra, etc.

### DIFF
--- a/avogadro/qtgui/molecule.cpp
+++ b/avogadro/qtgui/molecule.cpp
@@ -8,6 +8,8 @@
 
 #include <iostream>
 
+#include <avogadro/core/basisset.h>
+
 // for HTML-formatted formulas
 #include <QtCore/QRegularExpression>
 
@@ -295,8 +297,21 @@ Index Molecule::bondUniqueId(Index b) const
 
 void Molecule::emitChanged(unsigned int change)
 {
-  if (change != NoChange)
+  if (change != NoChange) {
+    // Structural changes invalidate derived computational data
+    if ((change & Atoms) || (change & Bonds)) {
+      clearCubes();
+      clearMeshes();
+      delete m_basisSet;
+      m_basisSet = nullptr;
+      m_spectra.clear();
+      m_vibrationFrequencies.clear();
+      m_vibrationIRIntensities.clear();
+      m_vibrationRamanIntensities.clear();
+      m_vibrationLx.clear();
+    }
     emit changed(change);
+  }
 }
 
 void Molecule::emitUpdate() const

--- a/avogadro/qtplugins/surfaces/surfaces.cpp
+++ b/avogadro/qtplugins/surfaces/surfaces.cpp
@@ -258,7 +258,8 @@ void Surfaces::moleculeChanged(unsigned int changes)
 {
   auto currentCubes = m_cubes.size();
 
-  if (changes & Molecule::Added || changes & Molecule::Removed) {
+  if (changes & Molecule::Added || changes & Molecule::Removed ||
+      changes & Molecule::Modified) {
     m_cubes = m_molecule->cubes();
     m_basis = m_molecule->basisSet();
   }

--- a/avogadro/qtplugins/surfaces/surfaces.cpp
+++ b/avogadro/qtplugins/surfaces/surfaces.cpp
@@ -262,6 +262,11 @@ void Surfaces::moleculeChanged(unsigned int changes)
       changes & Molecule::Modified) {
     m_cubes = m_molecule->cubes();
     m_basis = m_molecule->basisSet();
+    // Molecule::emitChanged() deletes cubes/meshes on Atoms/Bonds changes,
+    // so our cached raw pointers may now be dangling.
+    m_cube = nullptr;
+    m_mesh1 = nullptr;
+    m_mesh2 = nullptr;
   }
 
   // if we now have more cubes than before


### PR DESCRIPTION
Fix #2618

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where molecular visualizations and cached computational data could become out of sync when the molecular structure was modified.
  * Improved surface visualization updates to properly reflect all molecule changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->