### PR TITLE
Store custom atom, bond, residue, and conformer properties

### DIFF
--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -59,6 +59,7 @@ avogadro_headers(Core
   mutex.h
   nameatomtyper.h
   neighborperceiver.h
+  propertymap.h
   residue.h
   ringperceiver.h
   secondarystructure.h
@@ -93,6 +94,7 @@ target_sources(Core PRIVATE
   mutex.cpp
   nameatomtyper.cpp
   neighborperceiver.cpp
+  propertymap.cpp
   residue.cpp
   ringperceiver.cpp
   secondarystructure.cpp

--- a/avogadro/core/atom.h
+++ b/avogadro/core/atom.h
@@ -8,7 +8,12 @@
 
 #include "avogadrocore.h"
 #include "elements.h"
+#include "matrix.h"
 #include "vector.h"
+
+#include <optional>
+#include <string>
+#include <type_traits>
 
 namespace Avogadro::Core {
 
@@ -198,6 +203,22 @@ public:
 
   void setLabel(const std::string& label);
   std::string label() const;
+  /** @} */
+
+  /**
+   * Custom property access. Setters are overloaded by value type.
+   * The template getter returns std::nullopt if the property is missing
+   * or if the requested type does not match the stored type.
+   * int and double values convert to string automatically.
+   * @{
+   */
+  void setProperty(const std::string& name, double value);
+  void setProperty(const std::string& name, int value);
+  void setProperty(const std::string& name, const std::string& value);
+  void setProperty(const std::string& name, const MatrixX& value);
+
+  template <typename T>
+  std::optional<T> property(const std::string& name) const;
   /** @} */
 
 private:
@@ -421,6 +442,63 @@ template <class Molecule_T>
 std::string AtomTemplate<Molecule_T>::label() const
 {
   return m_molecule->atomLabel(m_index);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           double value)
+{
+  m_molecule->atomProperties().setDouble(name, m_index, value);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setProperty(const std::string& name, int value)
+{
+  m_molecule->atomProperties().setInt(name, m_index, value);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           const std::string& value)
+{
+  m_molecule->atomProperties().setString(name, m_index, value);
+}
+
+template <class Molecule_T>
+void AtomTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           const MatrixX& value)
+{
+  m_molecule->atomProperties().setMatrix(name, m_index, value);
+}
+
+template <class Molecule_T>
+template <typename T>
+std::optional<T> AtomTemplate<Molecule_T>::property(
+  const std::string& name) const
+{
+  const auto& props = m_molecule->atomProperties();
+  if constexpr (std::is_same_v<T, double>) {
+    return props.getDouble(name, m_index);
+  } else if constexpr (std::is_same_v<T, int>) {
+    return props.getInt(name, m_index);
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    auto result = props.getString(name, m_index);
+    if (result)
+      return result;
+    // Convert from double if available
+    auto dval = props.getDouble(name, m_index);
+    if (dval)
+      return std::to_string(*dval);
+    // Convert from int if available
+    auto ival = props.getInt(name, m_index);
+    if (ival)
+      return std::to_string(*ival);
+    return std::nullopt;
+  } else if constexpr (std::is_same_v<T, MatrixX>) {
+    return props.getMatrix(name, m_index);
+  } else {
+    return std::nullopt;
+  }
 }
 
 } // namespace Avogadro::Core

--- a/avogadro/core/bond.h
+++ b/avogadro/core/bond.h
@@ -7,8 +7,13 @@
 #define AVOGADRO_CORE_BOND_H
 
 #include "avogadrocore.h"
+#include "matrix.h"
 
 #include "atom.h"
+
+#include <optional>
+#include <string>
+#include <type_traits>
 
 namespace Avogadro::Core {
 
@@ -119,6 +124,22 @@ public:
    * A label for the bond (if any)
    */
   std::string label() const;
+
+  /**
+   * Custom property access. Setters are overloaded by value type.
+   * The template getter returns std::nullopt if the property is missing
+   * or if the requested type does not match the stored type.
+   * int and double values convert to string automatically.
+   * @{
+   */
+  void setProperty(const std::string& name, double value);
+  void setProperty(const std::string& name, int value);
+  void setProperty(const std::string& name, const std::string& value);
+  void setProperty(const std::string& name, const MatrixX& value);
+
+  template <typename T>
+  std::optional<T> property(const std::string& name) const;
+  /** @} */
 
 private:
   MoleculeType* m_molecule = nullptr;
@@ -249,6 +270,61 @@ template <class Molecule_T>
 std::string BondTemplate<Molecule_T>::label() const
 {
   return m_molecule->bondLabel(m_index);
+}
+
+template <class Molecule_T>
+void BondTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           double value)
+{
+  m_molecule->bondProperties().setDouble(name, m_index, value);
+}
+
+template <class Molecule_T>
+void BondTemplate<Molecule_T>::setProperty(const std::string& name, int value)
+{
+  m_molecule->bondProperties().setInt(name, m_index, value);
+}
+
+template <class Molecule_T>
+void BondTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           const std::string& value)
+{
+  m_molecule->bondProperties().setString(name, m_index, value);
+}
+
+template <class Molecule_T>
+void BondTemplate<Molecule_T>::setProperty(const std::string& name,
+                                           const MatrixX& value)
+{
+  m_molecule->bondProperties().setMatrix(name, m_index, value);
+}
+
+template <class Molecule_T>
+template <typename T>
+std::optional<T> BondTemplate<Molecule_T>::property(
+  const std::string& name) const
+{
+  const auto& props = m_molecule->bondProperties();
+  if constexpr (std::is_same_v<T, double>) {
+    return props.getDouble(name, m_index);
+  } else if constexpr (std::is_same_v<T, int>) {
+    return props.getInt(name, m_index);
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    auto result = props.getString(name, m_index);
+    if (result)
+      return result;
+    auto dval = props.getDouble(name, m_index);
+    if (dval)
+      return std::to_string(*dval);
+    auto ival = props.getInt(name, m_index);
+    if (ival)
+      return std::to_string(*ival);
+    return std::nullopt;
+  } else if constexpr (std::is_same_v<T, MatrixX>) {
+    return props.getMatrix(name, m_index);
+  } else {
+    return std::nullopt;
+  }
 }
 
 } // namespace Avogadro::Core

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -36,10 +36,13 @@ Molecule::Molecule()
 
 Molecule::Molecule(const Molecule& other)
   : m_data(other.m_data), m_partialCharges(other.m_partialCharges),
-    m_spectra(other.m_spectra), m_customElementMap(other.m_customElementMap),
-    m_elements(other.m_elements), m_positions2d(other.m_positions2d),
-    m_positions3d(other.m_positions3d), m_atomLabels(other.m_atomLabels),
-    m_bondLabels(other.m_bondLabels), m_residueLabels(other.m_residueLabels),
+    m_spectra(other.m_spectra), m_atomProperties(other.m_atomProperties),
+    m_bondProperties(other.m_bondProperties),
+    m_residueProperties(other.m_residueProperties),
+    m_customElementMap(other.m_customElementMap), m_elements(other.m_elements),
+    m_positions2d(other.m_positions2d), m_positions3d(other.m_positions3d),
+    m_atomLabels(other.m_atomLabels), m_bondLabels(other.m_bondLabels),
+    m_residueLabels(other.m_residueLabels),
     m_coordinates3d(other.m_coordinates3d), m_velocities(other.m_velocities),
     m_timesteps(other.m_timesteps), m_hybridizations(other.m_hybridizations),
     m_formalCharges(other.m_formalCharges), m_isotopes(other.m_isotopes),
@@ -98,6 +101,11 @@ void Molecule::readProperties(const Molecule& other)
   // copy spectra
   m_spectra = other.m_spectra;
 
+  // merge custom property maps
+  m_atomProperties = other.m_atomProperties;
+  m_bondProperties = other.m_bondProperties;
+  m_residueProperties = other.m_residueProperties;
+
   // copy orbital information
   SlaterSet* slaterSet = dynamic_cast<SlaterSet*>(other.m_basisSet);
   if (slaterSet != nullptr) {
@@ -134,6 +142,9 @@ void Molecule::readProperties(const Molecule& other)
 Molecule::Molecule(Molecule&& other) noexcept
   : m_data(other.m_data), m_partialCharges(std::move(other.m_partialCharges)),
     m_spectra(other.m_spectra),
+    m_atomProperties(std::move(other.m_atomProperties)),
+    m_bondProperties(std::move(other.m_bondProperties)),
+    m_residueProperties(std::move(other.m_residueProperties)),
     m_customElementMap(std::move(other.m_customElementMap)),
     m_elements(other.m_elements), m_positions2d(other.m_positions2d),
     m_positions3d(other.m_positions3d), m_atomLabels(other.m_atomLabels),
@@ -172,6 +183,9 @@ Molecule& Molecule::operator=(const Molecule& other)
     m_data = other.m_data;
     m_partialCharges = other.m_partialCharges;
     m_spectra = other.m_spectra;
+    m_atomProperties = other.m_atomProperties;
+    m_bondProperties = other.m_bondProperties;
+    m_residueProperties = other.m_residueProperties;
     m_customElementMap = other.m_customElementMap;
     m_elements = other.m_elements;
     m_positions2d = other.m_positions2d;
@@ -240,6 +254,9 @@ Molecule& Molecule::operator=(Molecule&& other) noexcept
     m_data = other.m_data;
     m_partialCharges = std::move(other.m_partialCharges);
     m_spectra = other.m_spectra;
+    m_atomProperties = std::move(other.m_atomProperties);
+    m_bondProperties = std::move(other.m_bondProperties);
+    m_residueProperties = std::move(other.m_residueProperties);
     m_customElementMap = std::move(other.m_customElementMap);
     m_elements = other.m_elements;
     m_positions2d = other.m_positions2d;
@@ -337,6 +354,36 @@ std::set<std::string> Molecule::partialChargeTypes() const
   for (auto& it : m_partialCharges)
     types.insert(it.first);
   return types;
+}
+
+PropertyMap& Molecule::atomProperties()
+{
+  return m_atomProperties;
+}
+
+const PropertyMap& Molecule::atomProperties() const
+{
+  return m_atomProperties;
+}
+
+PropertyMap& Molecule::bondProperties()
+{
+  return m_bondProperties;
+}
+
+const PropertyMap& Molecule::bondProperties() const
+{
+  return m_bondProperties;
+}
+
+PropertyMap& Molecule::residueProperties()
+{
+  return m_residueProperties;
+}
+
+const PropertyMap& Molecule::residueProperties() const
+{
+  return m_residueProperties;
 }
 
 std::set<std::string> Molecule::spectraTypes() const
@@ -602,6 +649,7 @@ Molecule::AtomType Molecule::addAtom(unsigned char number)
 
   m_layers.addAtomToActiveLayer(atomCount() - 1);
   m_partialCharges.clear();
+  m_atomProperties.addEntry();
   return AtomType(this, static_cast<Index>(atomCount() - 1));
 }
 
@@ -620,6 +668,7 @@ void Molecule::swapBond(Index a, Index b)
 
   m_graph.swapEdgeIndices(a, b);
   swap(m_bondOrders[a], m_bondOrders[b]);
+  m_bondProperties.swapEntries(a, b, bondCount());
 }
 void Molecule::swapAtom(Index a, Index b)
 {
@@ -641,6 +690,7 @@ void Molecule::swapAtom(Index a, Index b)
   swap(m_atomicNumbers[a], m_atomicNumbers[b]);
   m_graph.swapVertexIndices(a, b);
   m_layers.swapLayer(a, b);
+  m_atomProperties.swapEntries(a, b, atomCount());
 }
 
 bool Molecule::removeAtom(Index index)
@@ -667,6 +717,7 @@ bool Molecule::removeAtom(Index index)
   }
 
   m_partialCharges.clear();
+  m_atomProperties.removeEntry(index, atomCount());
   removeBonds(index);
 
   // before we remove, check if there's any other atom of this element
@@ -712,6 +763,8 @@ void Molecule::clearAtoms()
   m_residueLabels.clear();
   m_graph.clear();
   m_partialCharges.clear();
+  m_atomProperties.clear();
+  m_bondProperties.clear();
   m_elements.reset();
 }
 
@@ -730,6 +783,7 @@ Molecule::BondType Molecule::addBond(Index atom1, Index atom2,
   if (index >= bondCount()) {
     m_graph.addEdge(atom1, atom2);
     m_bondOrders.push_back(order);
+    m_bondProperties.addEntry();
     index = static_cast<Index>(m_graph.edgeCount() - 1);
   } else {
     m_bondOrders[index] = order;
@@ -763,6 +817,7 @@ bool Molecule::removeBond(Index index)
 {
   if (index >= bondCount())
     return false;
+  m_bondProperties.removeEntry(index, bondCount());
   m_graph.removeEdge(index);
   m_bondOrders.swapAndPop(index);
   m_partialCharges.clear();
@@ -787,6 +842,7 @@ bool Molecule::removeBond(const AtomType& a, const AtomType& b)
 void Molecule::clearBonds()
 {
   m_bondOrders.clear();
+  m_bondProperties.clear();
   m_graph.removeEdges();
   m_graph.setSize(atomCount());
   m_partialCharges.clear();

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -39,6 +39,7 @@ Molecule::Molecule(const Molecule& other)
     m_spectra(other.m_spectra), m_atomProperties(other.m_atomProperties),
     m_bondProperties(other.m_bondProperties),
     m_residueProperties(other.m_residueProperties),
+    m_conformerProperties(other.m_conformerProperties),
     m_customElementMap(other.m_customElementMap), m_elements(other.m_elements),
     m_positions2d(other.m_positions2d), m_positions3d(other.m_positions3d),
     m_atomLabels(other.m_atomLabels), m_bondLabels(other.m_bondLabels),
@@ -105,6 +106,7 @@ void Molecule::readProperties(const Molecule& other)
   m_atomProperties = other.m_atomProperties;
   m_bondProperties = other.m_bondProperties;
   m_residueProperties = other.m_residueProperties;
+  m_conformerProperties = other.m_conformerProperties;
 
   // copy orbital information
   SlaterSet* slaterSet = dynamic_cast<SlaterSet*>(other.m_basisSet);
@@ -145,6 +147,7 @@ Molecule::Molecule(Molecule&& other) noexcept
     m_atomProperties(std::move(other.m_atomProperties)),
     m_bondProperties(std::move(other.m_bondProperties)),
     m_residueProperties(std::move(other.m_residueProperties)),
+    m_conformerProperties(std::move(other.m_conformerProperties)),
     m_customElementMap(std::move(other.m_customElementMap)),
     m_elements(other.m_elements), m_positions2d(other.m_positions2d),
     m_positions3d(other.m_positions3d), m_atomLabels(other.m_atomLabels),
@@ -186,6 +189,7 @@ Molecule& Molecule::operator=(const Molecule& other)
     m_atomProperties = other.m_atomProperties;
     m_bondProperties = other.m_bondProperties;
     m_residueProperties = other.m_residueProperties;
+    m_conformerProperties = other.m_conformerProperties;
     m_customElementMap = other.m_customElementMap;
     m_elements = other.m_elements;
     m_positions2d = other.m_positions2d;
@@ -257,6 +261,7 @@ Molecule& Molecule::operator=(Molecule&& other) noexcept
     m_atomProperties = std::move(other.m_atomProperties);
     m_bondProperties = std::move(other.m_bondProperties);
     m_residueProperties = std::move(other.m_residueProperties);
+    m_conformerProperties = std::move(other.m_conformerProperties);
     m_customElementMap = std::move(other.m_customElementMap);
     m_elements = other.m_elements;
     m_positions2d = other.m_positions2d;
@@ -384,6 +389,16 @@ PropertyMap& Molecule::residueProperties()
 const PropertyMap& Molecule::residueProperties() const
 {
   return m_residueProperties;
+}
+
+PropertyMap& Molecule::conformerProperties()
+{
+  return m_conformerProperties;
+}
+
+const PropertyMap& Molecule::conformerProperties() const
+{
+  return m_conformerProperties;
 }
 
 std::set<std::string> Molecule::spectraTypes() const
@@ -1427,6 +1442,7 @@ bool Molecule::setCoordinate3d(int coord)
 void Molecule::clearCoordinate3d()
 {
   m_coordinates3d.clear();
+  m_conformerProperties.clear();
 }
 
 Array<Vector3> Molecule::coordinate3d(size_t index) const

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -780,6 +780,14 @@ void Molecule::clearAtoms()
   m_partialCharges.clear();
   m_atomProperties.clear();
   m_bondProperties.clear();
+  m_residues.clear();
+  m_residueProperties.clear();
+  m_coordinates3d.clear();
+  m_conformerProperties.clear();
+  m_velocities.clear();
+  m_timesteps.clear();
+  m_selectedAtoms.clear();
+  m_layers.clear();
   m_elements.reset();
 }
 

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -16,6 +16,7 @@
 #include "elements.h"
 #include "graph.h"
 #include "layer.h"
+#include "propertymap.h"
 #include "variantmap.h"
 #include "vector.h"
 
@@ -120,6 +121,24 @@ public:
   /** @return the types of partial charges available stored with this molecule.
    */
   std::set<std::string> partialChargeTypes() const;
+
+  /** @return the per-atom custom property map. */
+  PropertyMap& atomProperties();
+
+  /** \overload */
+  const PropertyMap& atomProperties() const;
+
+  /** @return the per-bond custom property map. */
+  PropertyMap& bondProperties();
+
+  /** \overload */
+  const PropertyMap& bondProperties() const;
+
+  /** @return the per-residue custom property map. */
+  PropertyMap& residueProperties();
+
+  /** \overload */
+  const PropertyMap& residueProperties() const;
 
   /** @return a vector of hybridizations for the atoms in the molecule. */
   Array<AtomHybridization>& hybridizations();
@@ -966,6 +985,9 @@ protected:
     m_partialCharges; //!< Sets of atomic partial charges
 
   std::map<std::string, MatrixX> m_spectra; //!< Sets of spectra
+  PropertyMap m_atomProperties;             //!< Custom per-atom properties
+  PropertyMap m_bondProperties;             //!< Custom per-bond properties
+  PropertyMap m_residueProperties;          //!< Custom per-residue properties
   CustomElementMap m_customElementMap;
   ElementMask m_elements; //!< Which elements this molecule contains (e.g., for
                           //!< force fields)

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -140,6 +140,12 @@ public:
   /** \overload */
   const PropertyMap& residueProperties() const;
 
+  /** @return the per-conformer custom property map. */
+  PropertyMap& conformerProperties();
+
+  /** \overload */
+  const PropertyMap& conformerProperties() const;
+
   /** @return a vector of hybridizations for the atoms in the molecule. */
   Array<AtomHybridization>& hybridizations();
 
@@ -988,6 +994,7 @@ protected:
   PropertyMap m_atomProperties;             //!< Custom per-atom properties
   PropertyMap m_bondProperties;             //!< Custom per-bond properties
   PropertyMap m_residueProperties;          //!< Custom per-residue properties
+  PropertyMap m_conformerProperties;        //!< Custom per-conformer properties
   CustomElementMap m_customElementMap;
   ElementMask m_elements; //!< Which elements this molecule contains (e.g., for
                           //!< force fields)

--- a/avogadro/core/propertymap.cpp
+++ b/avogadro/core/propertymap.cpp
@@ -1,0 +1,300 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "propertymap.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace Avogadro::Core {
+
+// Internal sentinel values for dense columns.
+static const double doubleSentinel = std::numeric_limits<double>::quiet_NaN();
+static const int intSentinel = std::numeric_limits<int>::min();
+
+// --- Per-index setters ---
+
+void PropertyMap::setDouble(const std::string& name, Index index, double value)
+{
+  auto& col = m_doubles[name];
+  if (col.size() <= index)
+    col.resize(index + 1, doubleSentinel);
+  col[index] = value;
+}
+
+void PropertyMap::setInt(const std::string& name, Index index, int value)
+{
+  auto& col = m_ints[name];
+  if (col.size() <= index)
+    col.resize(index + 1, intSentinel);
+  col[index] = value;
+}
+
+void PropertyMap::setString(const std::string& name, Index index,
+                            const std::string& value)
+{
+  auto& col = m_strings[name];
+  if (col.size() <= index)
+    col.resize(index + 1, std::string());
+  col[index] = value;
+}
+
+void PropertyMap::setMatrix(const std::string& name, Index index,
+                            const MatrixX& value)
+{
+  m_matrices[name][index] = value;
+}
+
+// --- Per-index getters ---
+
+std::optional<double> PropertyMap::getDouble(const std::string& name,
+                                             Index index) const
+{
+  auto it = m_doubles.find(name);
+  if (it == m_doubles.end() || index >= it->second.size())
+    return std::nullopt;
+  double val = it->second[index];
+  if (std::isnan(val))
+    return std::nullopt;
+  return val;
+}
+
+std::optional<int> PropertyMap::getInt(const std::string& name,
+                                       Index index) const
+{
+  auto it = m_ints.find(name);
+  if (it == m_ints.end() || index >= it->second.size())
+    return std::nullopt;
+  int val = it->second[index];
+  if (val == intSentinel)
+    return std::nullopt;
+  return val;
+}
+
+std::optional<std::string> PropertyMap::getString(const std::string& name,
+                                                  Index index) const
+{
+  auto it = m_strings.find(name);
+  if (it == m_strings.end() || index >= it->second.size())
+    return std::nullopt;
+  const std::string& val = it->second[index];
+  if (val.empty())
+    return std::nullopt;
+  return val;
+}
+
+std::optional<MatrixX> PropertyMap::getMatrix(const std::string& name,
+                                              Index index) const
+{
+  auto colIt = m_matrices.find(name);
+  if (colIt == m_matrices.end())
+    return std::nullopt;
+  auto entryIt = colIt->second.find(index);
+  if (entryIt == colIt->second.end())
+    return std::nullopt;
+  return entryIt->second;
+}
+
+// --- Bulk setters/getters ---
+
+void PropertyMap::setDoubles(const std::string& name,
+                             const Array<double>& values)
+{
+  m_doubles[name] = values;
+}
+
+Array<double> PropertyMap::doubles(const std::string& name) const
+{
+  auto it = m_doubles.find(name);
+  if (it != m_doubles.end())
+    return it->second;
+  return Array<double>();
+}
+
+void PropertyMap::setInts(const std::string& name, const Array<int>& values)
+{
+  m_ints[name] = values;
+}
+
+Array<int> PropertyMap::ints(const std::string& name) const
+{
+  auto it = m_ints.find(name);
+  if (it != m_ints.end())
+    return it->second;
+  return Array<int>();
+}
+
+void PropertyMap::setStrings(const std::string& name,
+                             const Array<std::string>& values)
+{
+  m_strings[name] = values;
+}
+
+Array<std::string> PropertyMap::strings(const std::string& name) const
+{
+  auto it = m_strings.find(name);
+  if (it != m_strings.end())
+    return it->second;
+  return Array<std::string>();
+}
+
+// --- Existence checks ---
+
+bool PropertyMap::hasDoubles(const std::string& name) const
+{
+  return m_doubles.find(name) != m_doubles.end();
+}
+
+bool PropertyMap::hasInts(const std::string& name) const
+{
+  return m_ints.find(name) != m_ints.end();
+}
+
+bool PropertyMap::hasStrings(const std::string& name) const
+{
+  return m_strings.find(name) != m_strings.end();
+}
+
+bool PropertyMap::hasMatrix(const std::string& name, Index index) const
+{
+  auto colIt = m_matrices.find(name);
+  if (colIt == m_matrices.end())
+    return false;
+  return colIt->second.find(index) != colIt->second.end();
+}
+
+bool PropertyMap::hasMatrices(const std::string& name) const
+{
+  return m_matrices.find(name) != m_matrices.end();
+}
+
+// --- Name enumeration ---
+
+std::set<std::string> PropertyMap::doubleNames() const
+{
+  std::set<std::string> names;
+  for (const auto& kv : m_doubles)
+    names.insert(kv.first);
+  return names;
+}
+
+std::set<std::string> PropertyMap::intNames() const
+{
+  std::set<std::string> names;
+  for (const auto& kv : m_ints)
+    names.insert(kv.first);
+  return names;
+}
+
+std::set<std::string> PropertyMap::stringNames() const
+{
+  std::set<std::string> names;
+  for (const auto& kv : m_strings)
+    names.insert(kv.first);
+  return names;
+}
+
+std::set<std::string> PropertyMap::matrixNames() const
+{
+  std::set<std::string> names;
+  for (const auto& kv : m_matrices)
+    names.insert(kv.first);
+  return names;
+}
+
+// --- Structural operations ---
+
+void PropertyMap::addEntry()
+{
+  for (auto& kv : m_doubles)
+    kv.second.push_back(doubleSentinel);
+  for (auto& kv : m_ints)
+    kv.second.push_back(intSentinel);
+  for (auto& kv : m_strings)
+    kv.second.push_back(std::string());
+  // Sparse matrices: nothing to do on add.
+}
+
+void PropertyMap::removeEntry(Index index, Index entityCount)
+{
+  // Dense columns: swap-and-pop if column is at full size.
+  for (auto& kv : m_doubles) {
+    if (kv.second.size() == entityCount)
+      kv.second.swapAndPop(index);
+  }
+  for (auto& kv : m_ints) {
+    if (kv.second.size() == entityCount)
+      kv.second.swapAndPop(index);
+  }
+  for (auto& kv : m_strings) {
+    if (kv.second.size() == entityCount)
+      kv.second.swapAndPop(index);
+  }
+
+  // Sparse matrices: remove the entry at index, re-key the last entry.
+  Index lastIndex = entityCount - 1;
+  for (auto& kv : m_matrices) {
+    auto& col = kv.second;
+    col.erase(index);
+    if (index != lastIndex) {
+      auto it = col.find(lastIndex);
+      if (it != col.end()) {
+        col[index] = std::move(it->second);
+        col.erase(it);
+      }
+    }
+  }
+}
+
+void PropertyMap::swapEntries(Index a, Index b, Index entityCount)
+{
+  for (auto& kv : m_doubles) {
+    if (kv.second.size() == entityCount)
+      std::swap(kv.second[a], kv.second[b]);
+  }
+  for (auto& kv : m_ints) {
+    if (kv.second.size() == entityCount)
+      std::swap(kv.second[a], kv.second[b]);
+  }
+  for (auto& kv : m_strings) {
+    if (kv.second.size() == entityCount)
+      std::swap(kv.second[a], kv.second[b]);
+  }
+
+  // Sparse matrices: swap entries at a and b.
+  for (auto& kv : m_matrices) {
+    auto& col = kv.second;
+    auto itA = col.find(a);
+    auto itB = col.find(b);
+    bool hasA = itA != col.end();
+    bool hasB = itB != col.end();
+    if (hasA && hasB) {
+      std::swap(itA->second, itB->second);
+    } else if (hasA) {
+      col[b] = std::move(itA->second);
+      col.erase(itA);
+    } else if (hasB) {
+      col[a] = std::move(itB->second);
+      col.erase(itB);
+    }
+  }
+}
+
+void PropertyMap::clear()
+{
+  m_doubles.clear();
+  m_ints.clear();
+  m_strings.clear();
+  m_matrices.clear();
+}
+
+bool PropertyMap::empty() const
+{
+  return m_doubles.empty() && m_ints.empty() && m_strings.empty() &&
+         m_matrices.empty();
+}
+
+} // namespace Avogadro::Core

--- a/avogadro/core/propertymap.cpp
+++ b/avogadro/core/propertymap.cpp
@@ -106,12 +106,13 @@ void PropertyMap::setDoubles(const std::string& name,
   m_doubles[name] = values;
 }
 
-Array<double> PropertyMap::doubles(const std::string& name) const
+const Array<double>& PropertyMap::doubles(const std::string& name) const
 {
+  static const Array<double> empty;
   auto it = m_doubles.find(name);
   if (it != m_doubles.end())
     return it->second;
-  return Array<double>();
+  return empty;
 }
 
 void PropertyMap::setInts(const std::string& name, const Array<int>& values)
@@ -119,12 +120,13 @@ void PropertyMap::setInts(const std::string& name, const Array<int>& values)
   m_ints[name] = values;
 }
 
-Array<int> PropertyMap::ints(const std::string& name) const
+const Array<int>& PropertyMap::ints(const std::string& name) const
 {
+  static const Array<int> empty;
   auto it = m_ints.find(name);
   if (it != m_ints.end())
     return it->second;
-  return Array<int>();
+  return empty;
 }
 
 void PropertyMap::setStrings(const std::string& name,
@@ -133,12 +135,13 @@ void PropertyMap::setStrings(const std::string& name,
   m_strings[name] = values;
 }
 
-Array<std::string> PropertyMap::strings(const std::string& name) const
+const Array<std::string>& PropertyMap::strings(const std::string& name) const
 {
+  static const Array<std::string> empty;
   auto it = m_strings.find(name);
   if (it != m_strings.end())
     return it->second;
-  return Array<std::string>();
+  return empty;
 }
 
 // --- Existence checks ---

--- a/avogadro/core/propertymap.cpp
+++ b/avogadro/core/propertymap.cpp
@@ -144,6 +144,16 @@ const Array<std::string>& PropertyMap::strings(const std::string& name) const
   return empty;
 }
 
+const std::unordered_map<Index, MatrixX>& PropertyMap::matrices(
+  const std::string& name) const
+{
+  static const std::unordered_map<Index, MatrixX> empty;
+  auto it = m_matrices.find(name);
+  if (it != m_matrices.end())
+    return it->second;
+  return empty;
+}
+
 // --- Existence checks ---
 
 bool PropertyMap::hasDoubles(const std::string& name) const

--- a/avogadro/core/propertymap.h
+++ b/avogadro/core/propertymap.h
@@ -1,0 +1,165 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CORE_PROPERTYMAP_H
+#define AVOGADRO_CORE_PROPERTYMAP_H
+
+#include "avogadrocoreexport.h"
+
+#include "avogadrocore.h"
+#include "array.h"
+#include "matrix.h"
+
+#include <climits>
+#include <cmath>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+namespace Avogadro::Core {
+
+/**
+ * @class PropertyMap propertymap.h <avogadro/core/propertymap.h>
+ * @brief A typed column store for per-entity custom properties.
+ *
+ * PropertyMap stores named columns of per-entity data (e.g., per-atom,
+ * per-bond, or per-residue). It supports four column types:
+ *
+ *  - @c double — dense, stored in Array<double> (NaN sentinel internally)
+ *  - @c int — dense, stored in Array<int> (INT_MIN sentinel internally)
+ *  - @c std::string — dense, stored in Array<std::string> ("" sentinel)
+ *  - @c MatrixX — sparse, stored in std::unordered_map<Index, MatrixX>
+ *
+ * Dense columns are always sized to the entity count. Sparse matrix columns
+ * only store entries for entities that have data.
+ *
+ * Public getters return std::optional<T>, returning std::nullopt for missing
+ * values or type mismatches. Sentinels are an internal storage detail.
+ */
+class AVOGADROCORE_EXPORT PropertyMap
+{
+public:
+  PropertyMap() = default;
+
+  // --- Per-index setters ---
+
+  /** Set a double property value for entity at @p index. */
+  void setDouble(const std::string& name, Index index, double value);
+
+  /** Set an int property value for entity at @p index. */
+  void setInt(const std::string& name, Index index, int value);
+
+  /** Set a string property value for entity at @p index. */
+  void setString(const std::string& name, Index index,
+                 const std::string& value);
+
+  /** Set a matrix property value for entity at @p index (sparse). */
+  void setMatrix(const std::string& name, Index index, const MatrixX& value);
+
+  // --- Per-index getters (return nullopt if missing or wrong type) ---
+
+  /** @return the double value for @p name at @p index, or nullopt. */
+  std::optional<double> getDouble(const std::string& name, Index index) const;
+
+  /** @return the int value for @p name at @p index, or nullopt. */
+  std::optional<int> getInt(const std::string& name, Index index) const;
+
+  /** @return the string value for @p name at @p index, or nullopt. */
+  std::optional<std::string> getString(const std::string& name,
+                                       Index index) const;
+
+  /** @return the matrix value for @p name at @p index, or nullopt. */
+  std::optional<MatrixX> getMatrix(const std::string& name, Index index) const;
+
+  // --- Bulk setters/getters ---
+
+  /** Set an entire column of double values. */
+  void setDoubles(const std::string& name, const Array<double>& values);
+
+  /** @return the full double column for @p name, or empty array if absent. */
+  Array<double> doubles(const std::string& name) const;
+
+  /** Set an entire column of int values. */
+  void setInts(const std::string& name, const Array<int>& values);
+
+  /** @return the full int column for @p name, or empty array if absent. */
+  Array<int> ints(const std::string& name) const;
+
+  /** Set an entire column of string values. */
+  void setStrings(const std::string& name, const Array<std::string>& values);
+
+  /** @return the full string column for @p name, or empty array if absent. */
+  Array<std::string> strings(const std::string& name) const;
+
+  // --- Existence checks ---
+
+  /** @return true if a double column named @p name exists. */
+  bool hasDoubles(const std::string& name) const;
+
+  /** @return true if an int column named @p name exists. */
+  bool hasInts(const std::string& name) const;
+
+  /** @return true if a string column named @p name exists. */
+  bool hasStrings(const std::string& name) const;
+
+  /** @return true if a matrix entry exists for @p name at @p index. */
+  bool hasMatrix(const std::string& name, Index index) const;
+
+  /** @return true if any matrix column named @p name exists. */
+  bool hasMatrices(const std::string& name) const;
+
+  // --- Name enumeration ---
+
+  /** @return names of all double columns. */
+  std::set<std::string> doubleNames() const;
+
+  /** @return names of all int columns. */
+  std::set<std::string> intNames() const;
+
+  /** @return names of all string columns. */
+  std::set<std::string> stringNames() const;
+
+  /** @return names of all matrix columns. */
+  std::set<std::string> matrixNames() const;
+
+  // --- Structural operations (called by Molecule on add/remove/swap) ---
+
+  /**
+   * Append a default entry to all existing dense columns.
+   * New columns are not created; only columns that already exist are extended.
+   */
+  void addEntry();
+
+  /**
+   * Remove the entry at @p index using swap-and-pop.
+   * @p entityCount is the count before removal (used to check if columns
+   * are at full size).
+   */
+  void removeEntry(Index index, Index entityCount);
+
+  /**
+   * Swap entries at indices @p a and @p b.
+   * @p entityCount is the current entity count (used to check column sizes).
+   */
+  void swapEntries(Index a, Index b, Index entityCount);
+
+  /** Clear all columns and data. */
+  void clear();
+
+  /** @return true if no columns exist. */
+  bool empty() const;
+
+private:
+  std::map<std::string, Array<double>> m_doubles;
+  std::map<std::string, Array<int>> m_ints;
+  std::map<std::string, Array<std::string>> m_strings;
+  std::map<std::string, std::unordered_map<Index, MatrixX>> m_matrices;
+};
+
+} // namespace Avogadro::Core
+
+#endif // AVOGADRO_CORE_PROPERTYMAP_H

--- a/avogadro/core/propertymap.h
+++ b/avogadro/core/propertymap.h
@@ -81,19 +81,19 @@ public:
   void setDoubles(const std::string& name, const Array<double>& values);
 
   /** @return the full double column for @p name, or empty array if absent. */
-  Array<double> doubles(const std::string& name) const;
+  const Array<double>& doubles(const std::string& name) const;
 
   /** Set an entire column of int values. */
   void setInts(const std::string& name, const Array<int>& values);
 
   /** @return the full int column for @p name, or empty array if absent. */
-  Array<int> ints(const std::string& name) const;
+  const Array<int>& ints(const std::string& name) const;
 
   /** Set an entire column of string values. */
   void setStrings(const std::string& name, const Array<std::string>& values);
 
   /** @return the full string column for @p name, or empty array if absent. */
-  Array<std::string> strings(const std::string& name) const;
+  const Array<std::string>& strings(const std::string& name) const;
 
   // --- Existence checks ---
 

--- a/avogadro/core/propertymap.h
+++ b/avogadro/core/propertymap.h
@@ -95,6 +95,11 @@ public:
   /** @return the full string column for @p name, or empty array if absent. */
   const Array<std::string>& strings(const std::string& name) const;
 
+  /** @return the sparse matrix column for @p name, or an empty map if absent.
+   */
+  const std::unordered_map<Index, MatrixX>& matrices(
+    const std::string& name) const;
+
   // --- Existence checks ---
 
   /** @return true if a double column named @p name exists. */

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -578,6 +578,51 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
     }
   }
 
+  // Read residue properties (parallel arrays stored at root level)
+  if (jsonRoot.contains("residueProperties")) {
+    json resProps = jsonRoot["residueProperties"];
+    if (resProps.is_object()) {
+      for (auto& property : resProps.items()) {
+        const auto& arr = property.value();
+        if (arr.is_array() && arr.size() == molecule.residueCount()) {
+          bool allString = true;
+          bool hasFloat = false;
+          for (size_t i = 0; i < arr.size(); ++i) {
+            if (arr[i].is_number()) {
+              allString = false;
+              if (arr[i].is_number_float())
+                hasFloat = true;
+            } else if (!arr[i].is_string()) {
+              allString = false;
+            }
+          }
+          if (allString) {
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_string()) {
+                molecule.residueProperties().setString(
+                  property.key(), i, arr[i].get<std::string>());
+              }
+            }
+          } else if (hasFloat) {
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_number()) {
+                molecule.residueProperties().setDouble(property.key(), i,
+                                                       arr[i].get<double>());
+              }
+            }
+          } else {
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_number_integer()) {
+                molecule.residueProperties().setInt(property.key(), i,
+                                                    arr[i].get<int>());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   if (jsonRoot.contains("unitCell") || jsonRoot.contains("unit cell")) {
     json unitCell = jsonRoot["unitCell"];
     if (!unitCell.is_object())
@@ -1797,7 +1842,33 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
     }
     root["residues"] = residues;
 
-    // TODO check for residue properties
+    // Write residue properties as parallel arrays alongside residues
+    if (!molecule.residueProperties().empty()) {
+      json resProps;
+      for (const auto& name : molecule.residueProperties().doubleNames()) {
+        json arr;
+        auto values = molecule.residueProperties().doubles(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        resProps[name] = arr;
+      }
+      for (const auto& name : molecule.residueProperties().intNames()) {
+        json arr;
+        auto values = molecule.residueProperties().ints(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        resProps[name] = arr;
+      }
+      for (const auto& name : molecule.residueProperties().stringNames()) {
+        json arr;
+        auto values = molecule.residueProperties().strings(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        resProps[name] = arr;
+      }
+      if (!resProps.empty())
+        root["residueProperties"] = resProps;
+    }
   }
 
   // any constraints?

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -323,8 +323,43 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
     json atomProperties = atoms["properties"];
     if (atomProperties.is_object()) {
       for (auto& property : atomProperties.items()) {
-        if (property.value().is_array()) {
-          // TODO: handle atom properties
+        const auto& arr = property.value();
+        if (arr.is_array() && arr.size() == atomCount) {
+          // Detect type from first non-null element
+          bool allString = true;
+          bool hasFloat = false;
+          for (size_t i = 0; i < arr.size(); ++i) {
+            if (arr[i].is_number()) {
+              allString = false;
+              if (arr[i].is_number_float())
+                hasFloat = true;
+            } else if (!arr[i].is_string()) {
+              allString = false;
+            }
+          }
+          if (allString) {
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_string()) {
+                molecule.atomProperties().setString(property.key(), i,
+                                                    arr[i].get<std::string>());
+              }
+            }
+          } else if (hasFloat) {
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_number()) {
+                molecule.atomProperties().setDouble(property.key(), i,
+                                                    arr[i].get<double>());
+              }
+            }
+          } else {
+            // All integers
+            for (size_t i = 0; i < arr.size(); ++i) {
+              if (arr[i].is_number_integer()) {
+                molecule.atomProperties().setInt(property.key(), i,
+                                                 arr[i].get<int>());
+              }
+            }
+          }
         }
       }
     }
@@ -443,8 +478,41 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
         json bondProperties = bonds["properties"];
         if (bondProperties.is_object()) {
           for (auto& property : bondProperties.items()) {
-            if (property.value().is_array()) {
-              // TODO: handle bond properties
+            const auto& arr = property.value();
+            if (arr.is_array() && arr.size() == molecule.bondCount()) {
+              bool allString = true;
+              bool hasFloat = false;
+              for (size_t i = 0; i < arr.size(); ++i) {
+                if (arr[i].is_number()) {
+                  allString = false;
+                  if (arr[i].is_number_float())
+                    hasFloat = true;
+                } else if (!arr[i].is_string()) {
+                  allString = false;
+                }
+              }
+              if (allString) {
+                for (size_t i = 0; i < arr.size(); ++i) {
+                  if (arr[i].is_string()) {
+                    molecule.bondProperties().setString(
+                      property.key(), i, arr[i].get<std::string>());
+                  }
+                }
+              } else if (hasFloat) {
+                for (size_t i = 0; i < arr.size(); ++i) {
+                  if (arr[i].is_number()) {
+                    molecule.bondProperties().setDouble(property.key(), i,
+                                                        arr[i].get<double>());
+                  }
+                }
+              } else {
+                for (size_t i = 0; i < arr.size(); ++i) {
+                  if (arr[i].is_number_integer()) {
+                    molecule.bondProperties().setInt(property.key(), i,
+                                                     arr[i].get<int>());
+                  }
+                }
+              }
             }
           }
         }
@@ -1611,7 +1679,33 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
       atoms["layer"] = atomLayer;
     }
 
-    // TODO check for atom properties
+    // Write custom atom properties
+    if (!molecule.atomProperties().empty()) {
+      json atomProps;
+      for (const auto& name : molecule.atomProperties().doubleNames()) {
+        json arr;
+        auto values = molecule.atomProperties().doubles(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        atomProps[name] = arr;
+      }
+      for (const auto& name : molecule.atomProperties().intNames()) {
+        json arr;
+        auto values = molecule.atomProperties().ints(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        atomProps[name] = arr;
+      }
+      for (const auto& name : molecule.atomProperties().stringNames()) {
+        json arr;
+        auto values = molecule.atomProperties().strings(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        atomProps[name] = arr;
+      }
+      if (!atomProps.empty())
+        atoms["properties"] = atomProps;
+    }
     root["atoms"] = atoms; // end atoms
   }
 
@@ -1639,7 +1733,33 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
       bonds["labels"] = labels;
     }
 
-    // TODO check for bond properties
+    // Write custom bond properties
+    if (!molecule.bondProperties().empty()) {
+      json bondProps;
+      for (const auto& name : molecule.bondProperties().doubleNames()) {
+        json arr;
+        auto values = molecule.bondProperties().doubles(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        bondProps[name] = arr;
+      }
+      for (const auto& name : molecule.bondProperties().intNames()) {
+        json arr;
+        auto values = molecule.bondProperties().ints(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        bondProps[name] = arr;
+      }
+      for (const auto& name : molecule.bondProperties().stringNames()) {
+        json arr;
+        auto values = molecule.bondProperties().strings(name);
+        for (Index i = 0; i < values.size(); ++i)
+          arr.push_back(values[i]);
+        bondProps[name] = arr;
+      }
+      if (!bondProps.empty())
+        bonds["properties"] = bondProps;
+    }
     root["bonds"] = bonds;
   }
 

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -11,6 +11,7 @@
 #include <avogadro/core/gaussianset.h>
 #include <avogadro/core/layermanager.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/propertymap.h>
 #include <avogadro/core/residue.h>
 #include <avogadro/core/spacegroups.h>
 #include <avogadro/core/unitcell.h>
@@ -86,6 +87,85 @@ json eigenColToJson(const MatrixX& matrix, int column)
     j.push_back(matrix(i, column));
   }
   return j;
+}
+
+using Core::PropertyMap;
+
+/** Deserialize a JSON object of named arrays into a PropertyMap. */
+void deserializeProperties(const json& obj, PropertyMap& props,
+                           size_t expectedCount)
+{
+  if (!obj.is_object())
+    return;
+  for (auto& property : obj.items()) {
+    const auto& arr = property.value();
+    if (!arr.is_array() || arr.size() != expectedCount)
+      continue;
+
+    // Detect type from array elements
+    bool allString = true;
+    bool hasFloat = false;
+    for (size_t i = 0; i < arr.size(); ++i) {
+      if (arr[i].is_number()) {
+        allString = false;
+        if (arr[i].is_number_float())
+          hasFloat = true;
+      } else if (!arr[i].is_string()) {
+        allString = false;
+      }
+    }
+
+    // Use bulk setters for efficiency
+    const auto& key = property.key();
+    if (allString) {
+      Array<std::string> values;
+      values.reserve(arr.size());
+      for (size_t i = 0; i < arr.size(); ++i)
+        values.push_back(arr[i].is_string() ? arr[i].get<std::string>()
+                                            : std::string());
+      props.setStrings(key, values);
+    } else if (hasFloat) {
+      Array<double> values;
+      values.reserve(arr.size());
+      for (size_t i = 0; i < arr.size(); ++i)
+        values.push_back(arr[i].is_number() ? arr[i].get<double>() : 0.0);
+      props.setDoubles(key, values);
+    } else {
+      Array<int> values;
+      values.reserve(arr.size());
+      for (size_t i = 0; i < arr.size(); ++i)
+        values.push_back(arr[i].is_number_integer() ? arr[i].get<int>() : 0);
+      props.setInts(key, values);
+    }
+  }
+}
+
+/** Serialize a PropertyMap into a JSON object of named arrays. */
+json serializeProperties(const PropertyMap& props)
+{
+  json result;
+  for (const auto& name : props.doubleNames()) {
+    json arr;
+    const auto& values = props.doubles(name);
+    for (Index i = 0; i < values.size(); ++i)
+      arr.push_back(values[i]);
+    result[name] = arr;
+  }
+  for (const auto& name : props.intNames()) {
+    json arr;
+    const auto& values = props.ints(name);
+    for (Index i = 0; i < values.size(); ++i)
+      arr.push_back(values[i]);
+    result[name] = arr;
+  }
+  for (const auto& name : props.stringNames()) {
+    json arr;
+    const auto& values = props.strings(name);
+    for (Index i = 0; i < values.size(); ++i)
+      arr.push_back(values[i]);
+    result[name] = arr;
+  }
+  return result;
 }
 
 // Sanitize a raw string by replacing invalid UTF-8 sequences with '?'
@@ -319,51 +399,9 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
     }
   }
 
-  if (atoms.contains("properties")) {
-    json atomProperties = atoms["properties"];
-    if (atomProperties.is_object()) {
-      for (auto& property : atomProperties.items()) {
-        const auto& arr = property.value();
-        if (arr.is_array() && arr.size() == atomCount) {
-          // Detect type from first non-null element
-          bool allString = true;
-          bool hasFloat = false;
-          for (size_t i = 0; i < arr.size(); ++i) {
-            if (arr[i].is_number()) {
-              allString = false;
-              if (arr[i].is_number_float())
-                hasFloat = true;
-            } else if (!arr[i].is_string()) {
-              allString = false;
-            }
-          }
-          if (allString) {
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_string()) {
-                molecule.atomProperties().setString(property.key(), i,
-                                                    arr[i].get<std::string>());
-              }
-            }
-          } else if (hasFloat) {
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_number()) {
-                molecule.atomProperties().setDouble(property.key(), i,
-                                                    arr[i].get<double>());
-              }
-            }
-          } else {
-            // All integers
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_number_integer()) {
-                molecule.atomProperties().setInt(property.key(), i,
-                                                 arr[i].get<int>());
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  if (atoms.contains("properties"))
+    deserializeProperties(atoms["properties"], molecule.atomProperties(),
+                          atomCount);
 
   // Selection is optional, but if present should be loaded.
   if (atoms.contains("selected")) {
@@ -474,49 +512,9 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
         }
       }
 
-      if (bonds.contains("properties")) {
-        json bondProperties = bonds["properties"];
-        if (bondProperties.is_object()) {
-          for (auto& property : bondProperties.items()) {
-            const auto& arr = property.value();
-            if (arr.is_array() && arr.size() == molecule.bondCount()) {
-              bool allString = true;
-              bool hasFloat = false;
-              for (size_t i = 0; i < arr.size(); ++i) {
-                if (arr[i].is_number()) {
-                  allString = false;
-                  if (arr[i].is_number_float())
-                    hasFloat = true;
-                } else if (!arr[i].is_string()) {
-                  allString = false;
-                }
-              }
-              if (allString) {
-                for (size_t i = 0; i < arr.size(); ++i) {
-                  if (arr[i].is_string()) {
-                    molecule.bondProperties().setString(
-                      property.key(), i, arr[i].get<std::string>());
-                  }
-                }
-              } else if (hasFloat) {
-                for (size_t i = 0; i < arr.size(); ++i) {
-                  if (arr[i].is_number()) {
-                    molecule.bondProperties().setDouble(property.key(), i,
-                                                        arr[i].get<double>());
-                  }
-                }
-              } else {
-                for (size_t i = 0; i < arr.size(); ++i) {
-                  if (arr[i].is_number_integer()) {
-                    molecule.bondProperties().setInt(property.key(), i,
-                                                     arr[i].get<int>());
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      if (bonds.contains("properties"))
+        deserializeProperties(bonds["properties"], molecule.bondProperties(),
+                              molecule.bondCount());
     }
   }
 
@@ -579,49 +577,10 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
   }
 
   // Read residue properties (parallel arrays stored at root level)
-  if (jsonRoot.contains("residueProperties")) {
-    json resProps = jsonRoot["residueProperties"];
-    if (resProps.is_object()) {
-      for (auto& property : resProps.items()) {
-        const auto& arr = property.value();
-        if (arr.is_array() && arr.size() == molecule.residueCount()) {
-          bool allString = true;
-          bool hasFloat = false;
-          for (size_t i = 0; i < arr.size(); ++i) {
-            if (arr[i].is_number()) {
-              allString = false;
-              if (arr[i].is_number_float())
-                hasFloat = true;
-            } else if (!arr[i].is_string()) {
-              allString = false;
-            }
-          }
-          if (allString) {
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_string()) {
-                molecule.residueProperties().setString(
-                  property.key(), i, arr[i].get<std::string>());
-              }
-            }
-          } else if (hasFloat) {
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_number()) {
-                molecule.residueProperties().setDouble(property.key(), i,
-                                                       arr[i].get<double>());
-              }
-            }
-          } else {
-            for (size_t i = 0; i < arr.size(); ++i) {
-              if (arr[i].is_number_integer()) {
-                molecule.residueProperties().setInt(property.key(), i,
-                                                    arr[i].get<int>());
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  if (jsonRoot.contains("residueProperties"))
+    deserializeProperties(jsonRoot["residueProperties"],
+                          molecule.residueProperties(),
+                          molecule.residueCount());
 
   if (jsonRoot.contains("unitCell") || jsonRoot.contains("unit cell")) {
     json unitCell = jsonRoot["unitCell"];
@@ -1726,28 +1685,7 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
 
     // Write custom atom properties
     if (!molecule.atomProperties().empty()) {
-      json atomProps;
-      for (const auto& name : molecule.atomProperties().doubleNames()) {
-        json arr;
-        auto values = molecule.atomProperties().doubles(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        atomProps[name] = arr;
-      }
-      for (const auto& name : molecule.atomProperties().intNames()) {
-        json arr;
-        auto values = molecule.atomProperties().ints(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        atomProps[name] = arr;
-      }
-      for (const auto& name : molecule.atomProperties().stringNames()) {
-        json arr;
-        auto values = molecule.atomProperties().strings(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        atomProps[name] = arr;
-      }
+      json atomProps = serializeProperties(molecule.atomProperties());
       if (!atomProps.empty())
         atoms["properties"] = atomProps;
     }
@@ -1780,28 +1718,7 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
 
     // Write custom bond properties
     if (!molecule.bondProperties().empty()) {
-      json bondProps;
-      for (const auto& name : molecule.bondProperties().doubleNames()) {
-        json arr;
-        auto values = molecule.bondProperties().doubles(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        bondProps[name] = arr;
-      }
-      for (const auto& name : molecule.bondProperties().intNames()) {
-        json arr;
-        auto values = molecule.bondProperties().ints(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        bondProps[name] = arr;
-      }
-      for (const auto& name : molecule.bondProperties().stringNames()) {
-        json arr;
-        auto values = molecule.bondProperties().strings(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        bondProps[name] = arr;
-      }
+      json bondProps = serializeProperties(molecule.bondProperties());
       if (!bondProps.empty())
         bonds["properties"] = bondProps;
     }
@@ -1844,28 +1761,7 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
 
     // Write residue properties as parallel arrays alongside residues
     if (!molecule.residueProperties().empty()) {
-      json resProps;
-      for (const auto& name : molecule.residueProperties().doubleNames()) {
-        json arr;
-        auto values = molecule.residueProperties().doubles(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        resProps[name] = arr;
-      }
-      for (const auto& name : molecule.residueProperties().intNames()) {
-        json arr;
-        auto values = molecule.residueProperties().ints(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        resProps[name] = arr;
-      }
-      for (const auto& name : molecule.residueProperties().stringNames()) {
-        json arr;
-        auto values = molecule.residueProperties().strings(name);
-        for (Index i = 0; i < values.size(); ++i)
-          arr.push_back(values[i]);
-        resProps[name] = arr;
-      }
+      json resProps = serializeProperties(molecule.residueProperties());
       if (!resProps.empty())
         root["residueProperties"] = resProps;
     }

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -98,43 +98,81 @@ void deserializeProperties(const json& obj, PropertyMap& props,
   if (!obj.is_object())
     return;
   for (auto& property : obj.items()) {
-    const auto& arr = property.value();
-    if (!arr.is_array() || arr.size() != expectedCount)
+    const auto& value = property.value();
+    const auto& key = property.key();
+
+    // Sparse matrix column: object of {"_type":"matrix","entries":{...}}
+    if (value.is_object() && value.value("_type", "") == "matrix" &&
+        value.contains("entries") && value["entries"].is_object()) {
+      for (auto& entry : value["entries"].items()) {
+        const auto& m = entry.value();
+        if (!m.is_object() || !m.contains("rows") || !m.contains("cols") ||
+            !m.contains("data") || !m["data"].is_array())
+          continue;
+        Eigen::Index rows = m["rows"].get<Eigen::Index>();
+        Eigen::Index cols = m["cols"].get<Eigen::Index>();
+        const auto& data = m["data"];
+        if (rows <= 0 || cols <= 0 ||
+            static_cast<Eigen::Index>(data.size()) != rows * cols)
+          continue;
+        MatrixX matrix(rows, cols);
+        for (Eigen::Index r = 0; r < rows; ++r)
+          for (Eigen::Index c = 0; c < cols; ++c)
+            matrix(r, c) = data[r * cols + c].get<double>();
+        const std::string& idxKey = entry.key();
+        if (idxKey.empty())
+          continue;
+        Index idx = 0;
+        bool validIdx = true;
+        for (char c : idxKey) {
+          if (c < '0' || c > '9') {
+            validIdx = false;
+            break;
+          }
+          idx = idx * 10 + static_cast<Index>(c - '0');
+        }
+        if (validIdx)
+          props.setMatrix(key, idx, matrix);
+      }
+      continue;
+    }
+
+    if (!value.is_array() || value.size() != expectedCount)
       continue;
 
     // Detect type from array elements
     bool allString = true;
     bool hasFloat = false;
-    for (size_t i = 0; i < arr.size(); ++i) {
-      if (arr[i].is_number()) {
+    for (size_t i = 0; i < value.size(); ++i) {
+      if (value[i].is_number()) {
         allString = false;
-        if (arr[i].is_number_float())
+        if (value[i].is_number_float())
           hasFloat = true;
-      } else if (!arr[i].is_string()) {
+      } else if (!value[i].is_string()) {
         allString = false;
       }
     }
 
     // Use bulk setters for efficiency
-    const auto& key = property.key();
     if (allString) {
       Array<std::string> values;
-      values.reserve(arr.size());
-      for (size_t i = 0; i < arr.size(); ++i)
-        values.push_back(arr[i].is_string() ? arr[i].get<std::string>()
-                                            : std::string());
+      values.reserve(value.size());
+      for (size_t i = 0; i < value.size(); ++i)
+        values.push_back(value[i].is_string() ? value[i].get<std::string>()
+                                              : std::string());
       props.setStrings(key, values);
     } else if (hasFloat) {
       Array<double> values;
-      values.reserve(arr.size());
-      for (size_t i = 0; i < arr.size(); ++i)
-        values.push_back(arr[i].is_number() ? arr[i].get<double>() : 0.0);
+      values.reserve(value.size());
+      for (size_t i = 0; i < value.size(); ++i)
+        values.push_back(value[i].is_number() ? value[i].get<double>() : 0.0);
       props.setDoubles(key, values);
     } else {
       Array<int> values;
-      values.reserve(arr.size());
-      for (size_t i = 0; i < arr.size(); ++i)
-        values.push_back(arr[i].is_number_integer() ? arr[i].get<int>() : 0);
+      values.reserve(value.size());
+      for (size_t i = 0; i < value.size(); ++i)
+        values.push_back(value[i].is_number_integer() ? value[i].get<int>()
+                                                      : 0);
       props.setInts(key, values);
     }
   }
@@ -164,6 +202,25 @@ json serializeProperties(const PropertyMap& props)
     for (Index i = 0; i < values.size(); ++i)
       arr.push_back(values[i]);
     result[name] = arr;
+  }
+  for (const auto& name : props.matrixNames()) {
+    json entries = json::object();
+    for (const auto& kv : props.matrices(name)) {
+      const MatrixX& matrix = kv.second;
+      json data = json::array();
+      for (Eigen::Index r = 0; r < matrix.rows(); ++r)
+        for (Eigen::Index c = 0; c < matrix.cols(); ++c)
+          data.push_back(matrix(r, c));
+      json entry;
+      entry["rows"] = matrix.rows();
+      entry["cols"] = matrix.cols();
+      entry["data"] = data;
+      entries[std::to_string(kv.first)] = entry;
+    }
+    json col;
+    col["_type"] = "matrix";
+    col["entries"] = entries;
+    result[name] = col;
   }
   return result;
 }

--- a/avogadro/io/cjsonformat.cpp
+++ b/avogadro/io/cjsonformat.cpp
@@ -639,6 +639,13 @@ bool CjsonFormat::deserialize(std::istream& file, Molecule& molecule,
                           molecule.residueProperties(),
                           molecule.residueCount());
 
+  // Read conformer properties (parallel arrays sized to coordinate3dCount()).
+  // Must come after conformer coords are loaded (above at "3dSets").
+  if (jsonRoot.contains("conformerProperties"))
+    deserializeProperties(jsonRoot["conformerProperties"],
+                          molecule.conformerProperties(),
+                          molecule.coordinate3dCount());
+
   if (jsonRoot.contains("unitCell") || jsonRoot.contains("unit cell")) {
     json unitCell = jsonRoot["unitCell"];
     if (!unitCell.is_object())
@@ -1822,6 +1829,13 @@ bool CjsonFormat::serialize(std::ostream& file, const Molecule& molecule,
       if (!resProps.empty())
         root["residueProperties"] = resProps;
     }
+  }
+
+  // Conformer properties (parallel arrays sized to coordinate3dCount())
+  if (!molecule.conformerProperties().empty()) {
+    json confProps = serializeProperties(molecule.conformerProperties());
+    if (!confProps.empty())
+      root["conformerProperties"] = confProps;
   }
 
   // any constraints?

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -77,6 +77,25 @@ public:
   const Molecule& molecule() const { return m_molecule; }
 
   /**
+   * Forwarders so the Core::AtomTemplate/BondTemplate proxies can reach the
+   * underlying property maps when parameterised on RWMolecule. MSVC checks
+   * template-member-function bodies eagerly, so these must exist even if no
+   * caller currently sets matrix/dense properties via an RWAtom/RWBond.
+   * @{
+   */
+  Core::PropertyMap& atomProperties() { return m_molecule.atomProperties(); }
+  const Core::PropertyMap& atomProperties() const
+  {
+    return m_molecule.atomProperties();
+  }
+  Core::PropertyMap& bondProperties() { return m_molecule.bondProperties(); }
+  const Core::PropertyMap& bondProperties() const
+  {
+    return m_molecule.bondProperties();
+  }
+  /** @} */
+
+  /**
    * Add a new atom to the molecule.
    * @param atomicNumber The atomic number of the new atom.
    * @param usingPositions Whether or not to use positions for this atom.

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -11,10 +11,12 @@
 #include <avogadro/core/color3f.h>
 #include <avogadro/core/mesh.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/propertymap.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/core/vector.h>
 
 using Avogadro::Index;
+using Avogadro::MatrixX;
 using Avogadro::Vector2;
 using Avogadro::Vector3;
 using Avogadro::Vector3f;
@@ -24,6 +26,7 @@ using Avogadro::Core::Bond;
 using Avogadro::Core::Color3f;
 using Avogadro::Core::Mesh;
 using Avogadro::Core::Molecule;
+using Avogadro::Core::PropertyMap;
 using Avogadro::Core::UnitCell;
 using Avogadro::Core::Variant;
 using Avogadro::Core::VariantMap;
@@ -483,4 +486,281 @@ TEST_F(MoleculeTest, formulaCompositionUnitCellMixed)
   std::map<std::string, size_t> comp = molecule.formulaComposition();
   EXPECT_EQ(comp["Na"], 1);
   EXPECT_EQ(comp["Cl"], 1);
+}
+
+// --- PropertyMap standalone tests ---
+
+TEST(PropertyMapTest, DoubleProperties)
+{
+  PropertyMap pm;
+  pm.setDouble("charge", 0, -0.3);
+  pm.setDouble("charge", 1, 0.15);
+
+  auto val0 = pm.getDouble("charge", 0);
+  auto val1 = pm.getDouble("charge", 1);
+  ASSERT_TRUE(val0.has_value());
+  ASSERT_TRUE(val1.has_value());
+  EXPECT_DOUBLE_EQ(*val0, -0.3);
+  EXPECT_DOUBLE_EQ(*val1, 0.15);
+
+  // Missing index
+  EXPECT_FALSE(pm.getDouble("charge", 5).has_value());
+  // Missing name
+  EXPECT_FALSE(pm.getDouble("nonexistent", 0).has_value());
+}
+
+TEST(PropertyMapTest, IntProperties)
+{
+  PropertyMap pm;
+  pm.setInt("type", 0, 42);
+  pm.setInt("type", 2, 7);
+
+  EXPECT_EQ(*pm.getInt("type", 0), 42);
+  // Index 1 was auto-filled with sentinel
+  EXPECT_FALSE(pm.getInt("type", 1).has_value());
+  EXPECT_EQ(*pm.getInt("type", 2), 7);
+}
+
+TEST(PropertyMapTest, StringProperties)
+{
+  PropertyMap pm;
+  pm.setString("label", 0, "C.ar");
+  pm.setString("label", 1, "N.am");
+
+  EXPECT_EQ(*pm.getString("label", 0), "C.ar");
+  EXPECT_EQ(*pm.getString("label", 1), "N.am");
+  EXPECT_FALSE(pm.getString("label", 5).has_value());
+}
+
+TEST(PropertyMapTest, SparseMatrices)
+{
+  PropertyMap pm;
+  MatrixX tensor(3, 3);
+  tensor << 1, 0, 0, 0, 2, 0, 0, 0, 3;
+  pm.setMatrix("nmr_tensor", 5, tensor);
+
+  EXPECT_TRUE(pm.hasMatrix("nmr_tensor", 5));
+  EXPECT_FALSE(pm.hasMatrix("nmr_tensor", 0));
+
+  auto result = pm.getMatrix("nmr_tensor", 5);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->rows(), 3);
+  EXPECT_EQ(result->cols(), 3);
+  EXPECT_DOUBLE_EQ((*result)(0, 0), 1.0);
+  EXPECT_DOUBLE_EQ((*result)(2, 2), 3.0);
+
+  EXPECT_FALSE(pm.getMatrix("nmr_tensor", 0).has_value());
+}
+
+TEST(PropertyMapTest, BulkSetGet)
+{
+  PropertyMap pm;
+  Array<double> charges(3, 0.0);
+  charges[0] = -0.3;
+  charges[1] = 0.15;
+  charges[2] = 0.15;
+  pm.setDoubles("charge", charges);
+
+  auto retrieved = pm.doubles("charge");
+  EXPECT_EQ(retrieved.size(), 3);
+  EXPECT_DOUBLE_EQ(retrieved[0], -0.3);
+
+  // Non-existent column returns empty
+  EXPECT_TRUE(pm.doubles("nope").empty());
+}
+
+TEST(PropertyMapTest, NameEnumeration)
+{
+  PropertyMap pm;
+  pm.setDouble("charge", 0, 1.0);
+  pm.setDouble("spin", 0, 0.5);
+  pm.setInt("type", 0, 1);
+  pm.setString("label", 0, "C");
+
+  auto dnames = pm.doubleNames();
+  EXPECT_EQ(dnames.size(), 2);
+  EXPECT_TRUE(dnames.count("charge"));
+  EXPECT_TRUE(dnames.count("spin"));
+  EXPECT_EQ(pm.intNames().size(), 1);
+  EXPECT_EQ(pm.stringNames().size(), 1);
+}
+
+TEST(PropertyMapTest, AddEntry)
+{
+  PropertyMap pm;
+  pm.setDouble("charge", 0, 1.0);
+  pm.setInt("type", 0, 5);
+  pm.addEntry();
+
+  // Column should now be size 2
+  auto col = pm.doubles("charge");
+  EXPECT_EQ(col.size(), 2);
+  // New entry should be sentinel (nullopt via getter)
+  EXPECT_FALSE(pm.getDouble("charge", 1).has_value());
+  EXPECT_FALSE(pm.getInt("type", 1).has_value());
+}
+
+TEST(PropertyMapTest, RemoveEntry)
+{
+  PropertyMap pm;
+  pm.setDouble("charge", 0, 1.0);
+  pm.setDouble("charge", 1, 2.0);
+  pm.setDouble("charge", 2, 3.0);
+
+  // Remove index 0 (swap with last, then pop)
+  pm.removeEntry(0, 3);
+
+  auto col = pm.doubles("charge");
+  EXPECT_EQ(col.size(), 2);
+  // Index 0 should now have old index 2's value
+  EXPECT_DOUBLE_EQ(*pm.getDouble("charge", 0), 3.0);
+  EXPECT_DOUBLE_EQ(*pm.getDouble("charge", 1), 2.0);
+}
+
+TEST(PropertyMapTest, RemoveEntrySparseMatrix)
+{
+  PropertyMap pm;
+  MatrixX m1(2, 2);
+  m1 << 1, 0, 0, 1;
+  MatrixX m2(2, 2);
+  m2 << 2, 0, 0, 2;
+
+  pm.setMatrix("tensor", 0, m1);
+  pm.setMatrix("tensor", 2, m2);
+
+  // Remove index 0 (swap with last index=2, then pop)
+  pm.removeEntry(0, 3);
+
+  // m2 (was at index 2) should now be at index 0
+  EXPECT_TRUE(pm.hasMatrix("tensor", 0));
+  EXPECT_DOUBLE_EQ((*pm.getMatrix("tensor", 0))(0, 0), 2.0);
+  EXPECT_FALSE(pm.hasMatrix("tensor", 2));
+}
+
+TEST(PropertyMapTest, SwapEntries)
+{
+  PropertyMap pm;
+  pm.setDouble("charge", 0, 1.0);
+  pm.setDouble("charge", 1, 2.0);
+
+  pm.swapEntries(0, 1, 2);
+  EXPECT_DOUBLE_EQ(*pm.getDouble("charge", 0), 2.0);
+  EXPECT_DOUBLE_EQ(*pm.getDouble("charge", 1), 1.0);
+}
+
+TEST(PropertyMapTest, Clear)
+{
+  PropertyMap pm;
+  pm.setDouble("a", 0, 1.0);
+  pm.setInt("b", 0, 2);
+  pm.setString("c", 0, "x");
+  EXPECT_FALSE(pm.empty());
+
+  pm.clear();
+  EXPECT_TRUE(pm.empty());
+  EXPECT_TRUE(pm.doubleNames().empty());
+}
+
+// --- Molecule integration tests ---
+
+TEST_F(MoleculeTest, AtomProperties)
+{
+  m_testMolecule.atomProperties().setDouble("charge", 0, -0.3);
+  m_testMolecule.atomProperties().setDouble("charge", 1, 0.15);
+  m_testMolecule.atomProperties().setDouble("charge", 2, 0.15);
+
+  EXPECT_DOUBLE_EQ(*m_testMolecule.atomProperties().getDouble("charge", 0),
+                   -0.3);
+  EXPECT_DOUBLE_EQ(*m_testMolecule.atomProperties().getDouble("charge", 2),
+                   0.15);
+}
+
+TEST_F(MoleculeTest, AtomProxyProperties)
+{
+  Atom o1 = m_testMolecule.atom(0);
+  o1.setProperty("spin_density", 0.42);
+  o1.setProperty("type_index", 3);
+  o1.setProperty("symmetry_label", std::string("C2v"));
+
+  auto spin = o1.property<double>("spin_density");
+  ASSERT_TRUE(spin.has_value());
+  EXPECT_DOUBLE_EQ(*spin, 0.42);
+
+  auto typeIdx = o1.property<int>("type_index");
+  ASSERT_TRUE(typeIdx.has_value());
+  EXPECT_EQ(*typeIdx, 3);
+
+  auto symLabel = o1.property<std::string>("symmetry_label");
+  ASSERT_TRUE(symLabel.has_value());
+  EXPECT_EQ(*symLabel, "C2v");
+
+  // Wrong type returns nullopt
+  EXPECT_FALSE(o1.property<int>("spin_density").has_value());
+  EXPECT_FALSE(o1.property<double>("symmetry_label").has_value());
+
+  // Numeric to string conversion
+  auto spinStr = o1.property<std::string>("spin_density");
+  ASSERT_TRUE(spinStr.has_value());
+  // Should be a string representation of 0.42
+  EXPECT_NE(spinStr->find("0.42"), std::string::npos);
+}
+
+TEST_F(MoleculeTest, BondProxyProperties)
+{
+  Bond b = m_testMolecule.bond(0);
+  b.setProperty("wiberg_index", 0.95);
+
+  auto wi = b.property<double>("wiberg_index");
+  ASSERT_TRUE(wi.has_value());
+  EXPECT_DOUBLE_EQ(*wi, 0.95);
+}
+
+TEST_F(MoleculeTest, AtomPropertyMatrices)
+{
+  Atom o1 = m_testMolecule.atom(0);
+  MatrixX tensor(3, 3);
+  tensor << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  o1.setProperty("nmr_tensor", tensor);
+
+  auto result = o1.property<MatrixX>("nmr_tensor");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->rows(), 3);
+  EXPECT_DOUBLE_EQ((*result)(1, 1), 5.0);
+
+  // Other atoms don't have it
+  Atom h2 = m_testMolecule.atom(1);
+  EXPECT_FALSE(h2.property<MatrixX>("nmr_tensor").has_value());
+}
+
+TEST_F(MoleculeTest, RemoveAtomPreservesProperties)
+{
+  // Set properties on all 3 atoms (water: O, H, H)
+  m_testMolecule.atomProperties().setDouble("charge", 0, -0.8);
+  m_testMolecule.atomProperties().setDouble("charge", 1, 0.4);
+  m_testMolecule.atomProperties().setDouble("charge", 2, 0.4);
+
+  // Remove atom 0 (oxygen) — swap-and-pop with atom 2
+  m_testMolecule.removeAtom(0);
+
+  EXPECT_EQ(m_testMolecule.atomCount(), 2);
+  // Index 0 should now have old atom 2's charge
+  auto charge0 = m_testMolecule.atomProperties().getDouble("charge", 0);
+  ASSERT_TRUE(charge0.has_value());
+  EXPECT_DOUBLE_EQ(*charge0, 0.4);
+}
+
+TEST_F(MoleculeTest, CopyMoleculePreservesProperties)
+{
+  m_testMolecule.atomProperties().setDouble("charge", 0, -0.3);
+  m_testMolecule.bondProperties().setDouble("wiberg", 0, 0.95);
+
+  Molecule copy(m_testMolecule);
+
+  EXPECT_DOUBLE_EQ(*copy.atomProperties().getDouble("charge", 0), -0.3);
+  EXPECT_DOUBLE_EQ(*copy.bondProperties().getDouble("wiberg", 0), 0.95);
+
+  // Modify copy, verify original unchanged (COW)
+  copy.atomProperties().setDouble("charge", 0, 999.0);
+  EXPECT_DOUBLE_EQ(*m_testMolecule.atomProperties().getDouble("charge", 0),
+                   -0.3);
 }

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -764,3 +764,41 @@ TEST_F(MoleculeTest, CopyMoleculePreservesProperties)
   EXPECT_DOUBLE_EQ(*m_testMolecule.atomProperties().getDouble("charge", 0),
                    -0.3);
 }
+
+TEST_F(MoleculeTest, ConformerProperties)
+{
+  // Set up two conformers
+  Array<Vector3> coords1(3, Vector3::Zero());
+  Array<Vector3> coords2(3, Vector3::Zero());
+  m_testMolecule.setCoordinate3d(coords1, 0);
+  m_testMolecule.setCoordinate3d(coords2, 1);
+
+  // Store per-conformer energies
+  m_testMolecule.conformerProperties().setDouble("energy", 0, -75.5);
+  m_testMolecule.conformerProperties().setDouble("energy", 1, -74.2);
+
+  auto e0 = m_testMolecule.conformerProperties().getDouble("energy", 0);
+  auto e1 = m_testMolecule.conformerProperties().getDouble("energy", 1);
+  ASSERT_TRUE(e0.has_value());
+  ASSERT_TRUE(e1.has_value());
+  EXPECT_DOUBLE_EQ(*e0, -75.5);
+  EXPECT_DOUBLE_EQ(*e1, -74.2);
+
+  // Store per-conformer forces as MatrixX (atomCount x 3)
+  MatrixX forces(3, 3);
+  forces << 0.1, 0.2, 0.3, -0.1, -0.2, -0.3, 0.0, 0.0, 0.0;
+  m_testMolecule.conformerProperties().setMatrix("forces", 0, forces);
+
+  auto f0 = m_testMolecule.conformerProperties().getMatrix("forces", 0);
+  ASSERT_TRUE(f0.has_value());
+  EXPECT_EQ(f0->rows(), 3);
+  EXPECT_EQ(f0->cols(), 3);
+  EXPECT_DOUBLE_EQ((*f0)(0, 0), 0.1);
+
+  // Conformer 1 has no forces
+  EXPECT_FALSE(m_testMolecule.conformerProperties().hasMatrix("forces", 1));
+
+  // clearCoordinate3d should clear conformer properties
+  m_testMolecule.clearCoordinate3d();
+  EXPECT_TRUE(m_testMolecule.conformerProperties().empty());
+}

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -12,6 +12,7 @@
 #include <avogadro/core/mesh.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/propertymap.h>
+#include <avogadro/core/residue.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/core/vector.h>
 
@@ -127,6 +128,44 @@ TEST_F(MoleculeTest, removeAtom)
   molecule.clearAtoms();
 
   EXPECT_EQ(0, molecule.atomCount());
+}
+
+TEST_F(MoleculeTest, clearAtomsResetsAtomKeyedState)
+{
+  Molecule molecule;
+  Atom a0 = molecule.addAtom(6);
+  Atom a1 = molecule.addAtom(1);
+  Atom a2 = molecule.addAtom(1);
+  molecule.addBond(a0, a1, 1);
+  molecule.addBond(a0, a2, 1);
+
+  // residues hold atom indices and must not survive clearAtoms()
+  std::string resName("MOL");
+  Avogadro::Index resNumber = 1;
+  char chain = 'A';
+  molecule.addResidue(resName, resNumber, chain);
+  molecule.residueProperties().setString("kind", 0, "ligand");
+
+  // conformer-keyed and per-atom-trajectory state
+  Array<Vector3> coords(3, Vector3(0.0, 0.0, 0.0));
+  molecule.setCoordinate3d(coords, 0);
+  molecule.setCoordinate3d(coords, 1);
+  molecule.conformerProperties().setDouble("energy", 0, -1.0);
+  molecule.setVelocities(coords, 0);
+  molecule.setTimeStep(0.5, 0);
+
+  // selection is atom-indexed
+  molecule.setAtomSelected(0, true);
+
+  molecule.clearAtoms();
+
+  EXPECT_EQ(0, molecule.atomCount());
+  EXPECT_EQ(0, molecule.bondCount());
+  EXPECT_EQ(static_cast<Avogadro::Index>(0), molecule.residueCount());
+  EXPECT_TRUE(molecule.residueProperties().empty());
+  EXPECT_EQ(static_cast<size_t>(0), molecule.coordinate3dCount());
+  EXPECT_TRUE(molecule.conformerProperties().empty());
+  EXPECT_TRUE(molecule.isSelectionEmpty());
 }
 
 TEST_F(MoleculeTest, addBond)

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -316,6 +316,99 @@ TEST_F(MoleculeTest, assignment)
   assertEqual(m_testMolecule, assign);
 }
 
+// Helper for property-map copy/move tests: populates one of each column type
+// (double, int, string, matrix) on atomProperties so a single fixture exercises
+// the full PropertyMap surface.
+static void populateAtomProperties(Molecule& m)
+{
+  m.addAtom(6);
+  m.addAtom(1);
+  m.atomProperties().setDouble("charge", 0, -0.5);
+  m.atomProperties().setInt("type", 1, 7);
+  m.atomProperties().setString("label", 0, "alpha");
+  MatrixX tensor(2, 2);
+  tensor << 1.0, 2.0, 3.0, 4.0;
+  m.atomProperties().setMatrix("tensor", 0, tensor);
+}
+
+TEST_F(MoleculeTest, propertyMapCopyConstruct)
+{
+  Molecule original;
+  populateAtomProperties(original);
+
+  Molecule copy(original);
+
+  EXPECT_DOUBLE_EQ(*copy.atomProperties().getDouble("charge", 0), -0.5);
+  EXPECT_EQ(*copy.atomProperties().getInt("type", 1), 7);
+  EXPECT_EQ(*copy.atomProperties().getString("label", 0), "alpha");
+  ASSERT_TRUE(copy.atomProperties().getMatrix("tensor", 0).has_value());
+  MatrixX expected(2, 2);
+  expected << 1.0, 2.0, 3.0, 4.0;
+  EXPECT_TRUE(copy.atomProperties().getMatrix("tensor", 0)->isApprox(expected));
+
+  // Deep copy: mutating the copy must not bleed back into the original.
+  copy.atomProperties().setDouble("charge", 0, 99.0);
+  EXPECT_DOUBLE_EQ(*original.atomProperties().getDouble("charge", 0), -0.5);
+}
+
+TEST_F(MoleculeTest, propertyMapCopyAssign)
+{
+  Molecule original;
+  populateAtomProperties(original);
+
+  // Pre-populate destination with different data to verify it gets overwritten.
+  Molecule assigned;
+  assigned.addAtom(8);
+  assigned.atomProperties().setDouble("charge", 0, 99.0);
+  assigned.atomProperties().setString("stale", 0, "should be replaced");
+
+  assigned = original;
+
+  EXPECT_DOUBLE_EQ(*assigned.atomProperties().getDouble("charge", 0), -0.5);
+  EXPECT_EQ(*assigned.atomProperties().getInt("type", 1), 7);
+  EXPECT_EQ(*assigned.atomProperties().getString("label", 0), "alpha");
+  ASSERT_TRUE(assigned.atomProperties().getMatrix("tensor", 0).has_value());
+  // Pre-existing column that did not exist in source must be gone.
+  EXPECT_FALSE(assigned.atomProperties().hasStrings("stale"));
+
+  // Deep copy.
+  assigned.atomProperties().setDouble("charge", 0, 42.0);
+  EXPECT_DOUBLE_EQ(*original.atomProperties().getDouble("charge", 0), -0.5);
+}
+
+TEST_F(MoleculeTest, propertyMapMoveConstruct)
+{
+  Molecule original;
+  populateAtomProperties(original);
+
+  Molecule moved(std::move(original));
+
+  EXPECT_DOUBLE_EQ(*moved.atomProperties().getDouble("charge", 0), -0.5);
+  EXPECT_EQ(*moved.atomProperties().getInt("type", 1), 7);
+  EXPECT_EQ(*moved.atomProperties().getString("label", 0), "alpha");
+  ASSERT_TRUE(moved.atomProperties().getMatrix("tensor", 0).has_value());
+  MatrixX expected(2, 2);
+  expected << 1.0, 2.0, 3.0, 4.0;
+  EXPECT_TRUE(
+    moved.atomProperties().getMatrix("tensor", 0)->isApprox(expected));
+}
+
+TEST_F(MoleculeTest, propertyMapMoveAssign)
+{
+  Molecule original;
+  populateAtomProperties(original);
+
+  Molecule target;
+  target.addAtom(8);
+  target.atomProperties().setDouble("charge", 0, 99.0);
+
+  target = std::move(original);
+
+  EXPECT_DOUBLE_EQ(*target.atomProperties().getDouble("charge", 0), -0.5);
+  EXPECT_EQ(*target.atomProperties().getInt("type", 1), 7);
+  ASSERT_TRUE(target.atomProperties().getMatrix("tensor", 0).has_value());
+}
+
 TEST_F(MoleculeTest, estimateVelocities)
 {
   Molecule molecule;

--- a/tests/io/cjsontest.cpp
+++ b/tests/io/cjsontest.cpp
@@ -327,3 +327,81 @@ TEST(CjsonTest, partialCharges)
   EXPECT_EQ(mullikenCharges(0, 0), 0.16726);
   EXPECT_EQ(mullikenCharges(1, 0), -0.201292);
 }
+
+TEST(CjsonTest, atomPropertiesRoundTrip)
+{
+  // Create a molecule with custom atom properties
+  Molecule molecule;
+  molecule.addAtom(8);
+  molecule.addAtom(1);
+  molecule.addAtom(1);
+  molecule.addBond(0, 1, 1);
+  molecule.addBond(0, 2, 1);
+
+  molecule.atomProperties().setDouble("mulliken_charge", 0, -0.3);
+  molecule.atomProperties().setDouble("mulliken_charge", 1, 0.15);
+  molecule.atomProperties().setDouble("mulliken_charge", 2, 0.15);
+  molecule.atomProperties().setInt("type_index", 0, 42);
+  molecule.atomProperties().setInt("type_index", 1, 7);
+  molecule.atomProperties().setInt("type_index", 2, 7);
+  molecule.atomProperties().setString("atom_type", 0, "O.3");
+  molecule.atomProperties().setString("atom_type", 1, "H");
+  molecule.atomProperties().setString("atom_type", 2, "H");
+
+  // Write to CJSON
+  CjsonFormat cjson;
+  std::string output;
+  ASSERT_TRUE(cjson.writeString(output, molecule));
+
+  // Read back
+  Molecule readMol;
+  ASSERT_TRUE(cjson.readString(output, readMol));
+
+  // Verify double properties
+  auto charge0 = readMol.atomProperties().getDouble("mulliken_charge", 0);
+  ASSERT_TRUE(charge0.has_value());
+  EXPECT_DOUBLE_EQ(*charge0, -0.3);
+  auto charge2 = readMol.atomProperties().getDouble("mulliken_charge", 2);
+  ASSERT_TRUE(charge2.has_value());
+  EXPECT_DOUBLE_EQ(*charge2, 0.15);
+
+  // Verify int properties
+  auto type0 = readMol.atomProperties().getInt("type_index", 0);
+  ASSERT_TRUE(type0.has_value());
+  EXPECT_EQ(*type0, 42);
+
+  // Verify string properties
+  auto atomType0 = readMol.atomProperties().getString("atom_type", 0);
+  ASSERT_TRUE(atomType0.has_value());
+  EXPECT_EQ(*atomType0, "O.3");
+  auto atomType1 = readMol.atomProperties().getString("atom_type", 1);
+  ASSERT_TRUE(atomType1.has_value());
+  EXPECT_EQ(*atomType1, "H");
+}
+
+TEST(CjsonTest, bondPropertiesRoundTrip)
+{
+  Molecule molecule;
+  molecule.addAtom(8);
+  molecule.addAtom(1);
+  molecule.addAtom(1);
+  molecule.addBond(0, 1, 1);
+  molecule.addBond(0, 2, 1);
+
+  molecule.bondProperties().setDouble("wiberg_index", 0, 0.95);
+  molecule.bondProperties().setDouble("wiberg_index", 1, 0.93);
+
+  CjsonFormat cjson;
+  std::string output;
+  ASSERT_TRUE(cjson.writeString(output, molecule));
+
+  Molecule readMol;
+  ASSERT_TRUE(cjson.readString(output, readMol));
+
+  auto wi0 = readMol.bondProperties().getDouble("wiberg_index", 0);
+  ASSERT_TRUE(wi0.has_value());
+  EXPECT_DOUBLE_EQ(*wi0, 0.95);
+  auto wi1 = readMol.bondProperties().getDouble("wiberg_index", 1);
+  ASSERT_TRUE(wi1.has_value());
+  EXPECT_DOUBLE_EQ(*wi1, 0.93);
+}

--- a/tests/io/cjsontest.cpp
+++ b/tests/io/cjsontest.cpp
@@ -9,16 +9,19 @@
 
 #include <avogadro/core/matrix.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/residue.h>
 #include <avogadro/core/unitcell.h>
 
 #include <avogadro/io/cjsonformat.h>
 
+using Avogadro::Index;
 using Avogadro::MatrixX;
 using Avogadro::PI_F;
 using Avogadro::Real;
 using Avogadro::Core::Atom;
 using Avogadro::Core::Bond;
 using Avogadro::Core::Molecule;
+using Avogadro::Core::Residue;
 using Avogadro::Core::UnitCell;
 using Avogadro::Core::Variant;
 using Avogadro::Io::CjsonFormat;
@@ -404,4 +407,44 @@ TEST(CjsonTest, bondPropertiesRoundTrip)
   auto wi1 = readMol.bondProperties().getDouble("wiberg_index", 1);
   ASSERT_TRUE(wi1.has_value());
   EXPECT_DOUBLE_EQ(*wi1, 0.93);
+}
+
+TEST(CjsonTest, residuePropertiesRoundTrip)
+{
+  // Build a minimal molecule with residues
+  Molecule molecule;
+  Atom a1 = molecule.addAtom(6); // C
+  Atom a2 = molecule.addAtom(7); // N
+
+  std::string name1 = std::string("ALA");
+  Index id1 = 1;
+  char chain1 = 'A';
+  Residue r1(name1, id1, chain1);
+  r1.addResidueAtom("CA", a1);
+  molecule.addResidue(r1);
+
+  std::string name2 = std::string("GLY");
+  Index id2 = 2;
+  char chain2 = 'A';
+  Residue r2(name2, id2, chain2);
+  r2.addResidueAtom("CA", a2);
+  molecule.addResidue(r2);
+
+  molecule.residueProperties().setDouble("bfactor", 0, 15.2);
+  molecule.residueProperties().setDouble("bfactor", 1, 22.7);
+
+  CjsonFormat cjson;
+  std::string output;
+  ASSERT_TRUE(cjson.writeString(output, molecule));
+
+  Molecule readMol;
+  ASSERT_TRUE(cjson.readString(output, readMol));
+
+  EXPECT_EQ(readMol.residueCount(), 2);
+  auto bf0 = readMol.residueProperties().getDouble("bfactor", 0);
+  ASSERT_TRUE(bf0.has_value());
+  EXPECT_DOUBLE_EQ(*bf0, 15.2);
+  auto bf1 = readMol.residueProperties().getDouble("bfactor", 1);
+  ASSERT_TRUE(bf1.has_value());
+  EXPECT_DOUBLE_EQ(*bf1, 22.7);
 }

--- a/tests/io/cjsontest.cpp
+++ b/tests/io/cjsontest.cpp
@@ -409,6 +409,74 @@ TEST(CjsonTest, bondPropertiesRoundTrip)
   EXPECT_DOUBLE_EQ(*wi1, 0.93);
 }
 
+TEST(CjsonTest, conformerPropertiesRoundTrip)
+{
+  // Build a molecule with multiple conformers and per-conformer properties.
+  // Per-atom 3D positions must also be set; the CJSON writer only emits
+  // the conformer "3dSets" block alongside an existing "3d" coords block.
+  Molecule molecule;
+  Atom o = molecule.addAtom(8);
+  Atom h1 = molecule.addAtom(1);
+  Atom h2 = molecule.addAtom(1);
+  o.setPosition3d(Avogadro::Vector3(0.0, 0.0, 0.0));
+  h1.setPosition3d(Avogadro::Vector3(0.6, -0.5, 0.0));
+  h2.setPosition3d(Avogadro::Vector3(-0.6, -0.5, 0.0));
+
+  Avogadro::Core::Array<Avogadro::Vector3> frame0;
+  frame0.push_back(Avogadro::Vector3(0.0, 0.0, 0.0));
+  frame0.push_back(Avogadro::Vector3(0.6, -0.5, 0.0));
+  frame0.push_back(Avogadro::Vector3(-0.6, -0.5, 0.0));
+  Avogadro::Core::Array<Avogadro::Vector3> frame1;
+  frame1.push_back(Avogadro::Vector3(0.0, 0.1, 0.0));
+  frame1.push_back(Avogadro::Vector3(0.7, -0.4, 0.0));
+  frame1.push_back(Avogadro::Vector3(-0.7, -0.4, 0.0));
+  Avogadro::Core::Array<Avogadro::Vector3> frame2;
+  frame2.push_back(Avogadro::Vector3(0.0, 0.2, 0.0));
+  frame2.push_back(Avogadro::Vector3(0.8, -0.3, 0.0));
+  frame2.push_back(Avogadro::Vector3(-0.8, -0.3, 0.0));
+  molecule.setCoordinate3d(frame0, 0);
+  molecule.setCoordinate3d(frame1, 1);
+  molecule.setCoordinate3d(frame2, 2);
+
+  // Per-conformer dense columns plus one sparse matrix column.
+  molecule.conformerProperties().setDouble("energy", 0, -76.4);
+  molecule.conformerProperties().setDouble("energy", 1, -76.2);
+  molecule.conformerProperties().setDouble("energy", 2, -76.0);
+  molecule.conformerProperties().setString("method", 0, "B3LYP");
+  molecule.conformerProperties().setString("method", 1, "B3LYP");
+  molecule.conformerProperties().setString("method", 2, "B3LYP");
+
+  MatrixX forces0(3, 3);
+  forces0 << 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09;
+  molecule.conformerProperties().setMatrix("forces", 0, forces0);
+
+  CjsonFormat cjson;
+  std::string output;
+  ASSERT_TRUE(cjson.writeString(output, molecule));
+
+  Molecule readMol;
+  ASSERT_TRUE(cjson.readString(output, readMol));
+
+  EXPECT_EQ(readMol.coordinate3dCount(), static_cast<size_t>(3));
+
+  auto e0 = readMol.conformerProperties().getDouble("energy", 0);
+  ASSERT_TRUE(e0.has_value());
+  EXPECT_DOUBLE_EQ(*e0, -76.4);
+  auto e2 = readMol.conformerProperties().getDouble("energy", 2);
+  ASSERT_TRUE(e2.has_value());
+  EXPECT_DOUBLE_EQ(*e2, -76.0);
+
+  auto m0 = readMol.conformerProperties().getString("method", 0);
+  ASSERT_TRUE(m0.has_value());
+  EXPECT_EQ(*m0, "B3LYP");
+
+  auto f0 = readMol.conformerProperties().getMatrix("forces", 0);
+  ASSERT_TRUE(f0.has_value());
+  EXPECT_TRUE(f0->isApprox(forces0));
+  EXPECT_FALSE(
+    readMol.conformerProperties().getMatrix("forces", 1).has_value());
+}
+
 TEST(CjsonTest, matrixPropertiesRoundTrip)
 {
   // NMR tensors live on a sparse matrix column — verify round-trip.

--- a/tests/io/cjsontest.cpp
+++ b/tests/io/cjsontest.cpp
@@ -409,6 +409,45 @@ TEST(CjsonTest, bondPropertiesRoundTrip)
   EXPECT_DOUBLE_EQ(*wi1, 0.93);
 }
 
+TEST(CjsonTest, matrixPropertiesRoundTrip)
+{
+  // NMR tensors live on a sparse matrix column — verify round-trip.
+  Molecule molecule;
+  molecule.addAtom(6);
+  molecule.addAtom(1);
+  molecule.addAtom(1);
+
+  MatrixX tensor0(3, 3);
+  tensor0 << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+  MatrixX tensor2(2, 3);
+  tensor2 << -1.5, 2.5, 3.5, 4.5, -5.5, 6.5;
+
+  molecule.atomProperties().setMatrix("nmr_tensor", 0, tensor0);
+  molecule.atomProperties().setMatrix("nmr_tensor", 2, tensor2);
+
+  CjsonFormat cjson;
+  std::string output;
+  ASSERT_TRUE(cjson.writeString(output, molecule));
+
+  Molecule readMol;
+  ASSERT_TRUE(cjson.readString(output, readMol));
+
+  auto t0 = readMol.atomProperties().getMatrix("nmr_tensor", 0);
+  ASSERT_TRUE(t0.has_value());
+  EXPECT_EQ(t0->rows(), 3);
+  EXPECT_EQ(t0->cols(), 3);
+  EXPECT_TRUE(t0->isApprox(tensor0));
+
+  auto t2 = readMol.atomProperties().getMatrix("nmr_tensor", 2);
+  ASSERT_TRUE(t2.has_value());
+  EXPECT_EQ(t2->rows(), 2);
+  EXPECT_EQ(t2->cols(), 3);
+  EXPECT_TRUE(t2->isApprox(tensor2));
+
+  // Sparse: index 1 was never set, must remain unset.
+  EXPECT_FALSE(readMol.atomProperties().getMatrix("nmr_tensor", 1).has_value());
+}
+
 TEST(CjsonTest, residuePropertiesRoundTrip)
 {
   // Build a minimal molecule with residues


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom property support for atoms, bonds, residues, and conformers with flexible typing (numeric, string, matrix values).
  * Properties now persist across molecule copying and CJSON serialization/deserialization.
  * Atoms and bonds can set and retrieve typed properties with automatic type conversion fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->