### PR TITLE
test: fix invocation of enable_testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ add_subdirectory(utilities)
 add_subdirectory(avogadro)
 
 if(ENABLE_TESTING)
+  include(CTest)
+  # > This command should be invoked in the top-level source directory because
+  # > ctest(1) expects to find a test file in the top-level build directory.
+  enable_testing()
   add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(AvogadroLibsTest LANGUAGES CXX)
 
-include(CTest)
-enable_testing()
-
 if(PROJECT_IS_TOP_LEVEL)
   # Enable build of standalone tests
   # testing against AvogadroLibs already installed on the system.
+  include(CTest)
+  enable_testing()
 
   # QT_VERSION not previously defined when building tests only
   set(QT_VERSION 6)


### PR DESCRIPTION
before:
```sh
        # toplevel
        cmake -S . -B build
        ctest --test-dir build/tests  ###
        # standalone test
        cmake -S tests -B standalone
        ctest --test-dir standalone
```

after:
```sh
        # toplevel
        cmake -S . -B build
        ctest --test-dir build
        # standalone test
        cmake -S tests -B standalone
        ctest --test-dir standalone
```

fix #2822
close #2818

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
