### PR TITLE
Enable "D" stereo by inverting all dihedral angles for side-chains

### DIFF
--- a/avogadro/qtplugins/insertpeptide/insertpeptide.cpp
+++ b/avogadro/qtplugins/insertpeptide/insertpeptide.cpp
@@ -363,7 +363,15 @@ void InsertPeptide::performInsert()
 
     // Read amino acid if not already cached
     if (aaMap.find(aaStdString) == aaMap.end()) {
-      aaMap[aaStdString] = readAminoAcid(aaString);
+      AminoAcid aa = readAminoAcid(aaString);
+      if (stereo == 'D') {
+        // Mirror through the N-CA-C plane: negate every dihedral.
+        // Bond lengths and angles are invariant under reflection, so this
+        // converts the L geometry from the zmat into its D enantiomer.
+        for (auto& coord : aa.internalCoords)
+          coord.dihedral = -coord.dihedral;
+      }
+      aaMap[aaStdString] = aa;
     }
 
     AminoAcid amino = aaMap[aaStdString];
@@ -413,8 +421,6 @@ void InsertPeptide::performInsert()
 
       // Handle internal coordinates
       Core::InternalCoordinate coord = amino.internalCoords[j];
-
-      // TODO : Handle stereochemistry for D- amino acids
 
       // For residues after the first, we need to adjust references
       if (i > 0) {

--- a/avogadro/qtplugins/insertpeptide/insertpeptidedialog.ui
+++ b/avogadro/qtplugins/insertpeptide/insertpeptidedialog.ui
@@ -276,9 +276,6 @@
       </item>
       <item row="3" column="1">
        <widget class="QLabel" name="label_2">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="text">
          <string>Stereochemistry:</string>
         </property>
@@ -298,14 +295,8 @@
         </item>
         <item>
          <widget class="QRadioButton" name="dStereoButton">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
           <property name="text">
            <string notr="true">D</string>
-          </property>
-          <property name="checkable">
-           <bool>false</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * D-amino acid stereochemistry option is now available for selection in the peptide insertion interface.
  * Stereochemistry controls are now enabled and functional for user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->