### PR TITLE
Extend PlotConformer scan coordinate support

### DIFF
--- a/avogadro/qtplugins/plotconformer/plotconformer.cpp
+++ b/avogadro/qtplugins/plotconformer/plotconformer.cpp
@@ -12,14 +12,20 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
 
 #include <avogadro/core/array.h>
+#include <avogadro/core/angletools.h>
+#include <avogadro/core/constraint.h>
+#include <avogadro/core/vector.h>
 #include <avogadro/io/fileformatmanager.h>
-#include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtgui/chartdialog.h>
 #include <avogadro/qtgui/chartwidget.h>
+#include <avogadro/qtgui/molecule.h>
+#include <cmath>
+#include <limits>
 
 using Avogadro::QtGui::Molecule;
 
@@ -30,6 +36,194 @@ constexpr double EvToKcal = 23.06054;
 constexpr double KcalToKJ = 4.184; // by definition
 
 using Core::Array;
+
+static QString constraintLabel(const Core::Constraint& c)
+{
+  const int a = static_cast<int>(c.aIndex()) + 1;
+  const int b = static_cast<int>(c.bIndex()) + 1;
+  const int cc = static_cast<int>(c.cIndex()) + 1;
+  const int d = static_cast<int>(c.dIndex()) + 1;
+
+  switch (c.type()) {
+    case Core::Constraint::DistanceConstraint:
+      return QObject::tr("Distance %1-%2").arg(a).arg(b);
+    case Core::Constraint::AngleConstraint:
+      return QObject::tr("Angle %1-%2-%3").arg(a).arg(b).arg(cc);
+    case Core::Constraint::TorsionConstraint:
+      return QObject::tr("Dihedral %1-%2-%3-%4").arg(a).arg(b).arg(cc).arg(d);
+    default:
+      return QObject::tr("Constraint");
+  }
+}
+
+static float constraintValue(QtGui::Molecule& mol, const Core::Constraint& c)
+{
+  const Vector3 a = mol.atomPosition3d(c.aIndex());
+  const Vector3 b = mol.atomPosition3d(c.bIndex());
+
+  switch (c.type()) {
+    case Core::Constraint::DistanceConstraint:
+      return static_cast<float>((a - b).norm());
+    case Core::Constraint::AngleConstraint:
+      return static_cast<float>(calculateAngle(a, b, mol.atomPosition3d(c.cIndex())));
+    case Core::Constraint::TorsionConstraint:
+      return static_cast<float>(calculateDihedral(
+        a, b, mol.atomPosition3d(c.cIndex()), mol.atomPosition3d(c.dIndex())));
+    default:
+      return 0.0f;
+  }
+}
+
+static QString xAxisTitleForConstraint(const Core::Constraint& c)
+{
+  switch (c.type()) {
+    case Core::Constraint::DistanceConstraint:
+      return QObject::tr("Bond length (Å)");
+    case Core::Constraint::AngleConstraint:
+      return QObject::tr("Angle (°)");
+    case Core::Constraint::TorsionConstraint:
+      return QObject::tr("Dihedral (°)");
+    default:
+      return QObject::tr("Frame");
+  }
+}
+
+static void unwrapPeriodicSeries(DataSeries& values, float period)
+{
+  if (values.empty() || period <= 0.0f)
+    return;
+
+  const float halfPeriod = period * 0.5f;
+  float offset = 0.0f;
+  float previous = values[0];
+
+  for (size_t i = 1; i < values.size(); ++i) {
+    float current = values[i] + offset;
+    const float delta = current - previous;
+    if (delta > halfPeriod) {
+      offset -= period;
+      current -= period;
+    } else if (delta < -halfPeriod) {
+      offset += period;
+      current += period;
+    }
+
+    values[i] = current;
+    previous = current;
+  }
+}
+
+static void shiftSeriesToPreferredWindow(DataSeries& values, float period,
+                                         float minimum, float maximum)
+{
+  if (values.empty() || period <= 0.0f || minimum >= maximum)
+    return;
+
+  const float minShift =
+    std::floor((*std::min_element(values.begin(), values.end()) - maximum) /
+               period) *
+    period;
+  const float maxShift =
+    std::ceil((*std::max_element(values.begin(), values.end()) - minimum) /
+              period) *
+    period;
+
+  int bestCount = -1;
+  float bestShift = 0.0f;
+  float bestCenterDistance = std::numeric_limits<float>::max();
+  const float preferredCenter = 0.5f * (minimum + maximum);
+
+  for (float shift = minShift; shift <= maxShift; shift += period) {
+    int count = 0;
+    float centerDistance = 0.0f;
+    for (float value : values) {
+      const float shifted = value - shift;
+      if (shifted >= minimum && shifted <= maximum) {
+        ++count;
+        centerDistance += std::fabs(shifted - preferredCenter);
+      }
+    }
+
+    if (count > bestCount ||
+        (count == bestCount && centerDistance < bestCenterDistance)) {
+      bestCount = count;
+      bestShift = shift;
+      bestCenterDistance = centerDistance;
+    }
+  }
+
+  for (float& value : values)
+    value -= bestShift;
+}
+
+int PlotConformer::currentConformerIndex() const
+{
+  if (!m_molecule || m_molecule->coordinate3dCount() == 0)
+    return -1;
+
+  const Array<Vector3>& current = m_molecule->atomPositions3d();
+  if (current.empty())
+    return -1;
+
+  constexpr double tolerance = 1.0e-10;
+  int bestIndex = -1;
+  double bestDistance = std::numeric_limits<double>::max();
+
+  for (int i = 0; i < static_cast<int>(m_molecule->coordinate3dCount()); ++i) {
+    const Array<Vector3> coords = m_molecule->coordinate3d(i);
+    if (coords.size() != current.size())
+      continue;
+
+    double sum = 0.0;
+    bool exactMatch = true;
+    for (size_t j = 0; j < current.size(); ++j) {
+      const double distance = (coords[j] - current[j]).squaredNorm();
+      sum += distance;
+      if (distance > tolerance)
+        exactMatch = false;
+    }
+
+    if (exactMatch)
+      return i;
+
+    if (sum < bestDistance) {
+      bestDistance = sum;
+      bestIndex = i;
+    }
+  }
+
+  return bestIndex;
+}
+
+void PlotConformer::updateXAxisOptions()
+{
+  if (!m_xAxisCombo)
+    return;
+
+  const QVariant currentData = m_xAxisCombo->currentData();
+
+  m_xAxisCombo->blockSignals(true);
+  m_xAxisCombo->clear();
+  m_xAxisCombo->addItem(tr("Frame"), -1);
+
+  if (m_molecule) {
+    const auto& constraints = m_molecule->constraints();
+    for (int i = 0; i < static_cast<int>(constraints.size()); ++i) {
+      const auto& c = constraints[static_cast<size_t>(i)];
+      if (c.type() == Core::Constraint::DistanceConstraint ||
+          c.type() == Core::Constraint::AngleConstraint ||
+          c.type() == Core::Constraint::TorsionConstraint) {
+        m_xAxisCombo->addItem(constraintLabel(c), i);
+      }
+    }
+  }
+
+  int index = m_xAxisCombo->findData(currentData);
+  if (index < 0)
+    index = 0;
+  m_xAxisCombo->setCurrentIndex(index);
+  m_xAxisCombo->blockSignals(false);
+}
 
 PlotConformer::PlotConformer(QObject* parent_)
   : Avogadro::QtGui::ExtensionPlugin(parent_), m_actions(QList<QAction*>()),
@@ -81,6 +275,14 @@ void PlotConformer::moleculeChanged(unsigned int c)
   if (changes & Molecule::Added || changes & Molecule::Removed ||
       changes & Molecule::Modified)
     updateActions();
+
+  if (m_dialog &&
+      (changes & Molecule::Atoms || changes & Molecule::Constraints ||
+       changes & Molecule::Properties)) {
+    if (changes & Molecule::Constraints)
+      updateXAxisOptions();
+    updatePlot();
+  }
 }
 
 void PlotConformer::updateActions()
@@ -104,13 +306,39 @@ void PlotConformer::updateActions()
 
 void PlotConformer::clicked(float x, float y, Qt::KeyboardModifiers modifiers)
 {
-  // switch to the closest conformer to x
-  int conformer = static_cast<int>(x);
+//  // switch to the closest conformer to x
+//  int conformer = static_cast<int>(x);
+//  if (conformer < 0)
+//    conformer = 0;
+//  if (conformer >= m_molecule->coordinate3dCount())
+//    conformer = m_molecule->coordinate3dCount() - 1;
+//  m_molecule->setCoordinate3d(conformer);
+//  m_molecule->emitChanged(Molecule::Atoms);
+  if (!m_molecule)
+    return;
+  
+  const int xMode = (m_xAxisCombo ? m_xAxisCombo->currentData().toInt() : -1);
+  
+  int conformer = 0;
+  if (xMode < 0) {
+    conformer = static_cast<int>(x);
+  } else if (!m_lastXData.empty()) {
+    float best = std::numeric_limits<float>::max();
+    for (int i = 0; i < static_cast<int>(m_lastXData.size()); ++i) {
+      const float d = std::fabs(m_lastXData[static_cast<size_t>(i)] - x);
+      if (d < best) {
+        best = d;
+        conformer = i;
+      }
+    }
+  }
+  
   if (conformer < 0)
     conformer = 0;
-  if (conformer >= m_molecule->coordinate3dCount())
-    conformer = m_molecule->coordinate3dCount() - 1;
-  m_currentFrame = conformer;
+  const int maxIdx = static_cast<int>(m_molecule->coordinate3dCount()) - 1;
+  if (conformer > maxIdx)
+    conformer = maxIdx;
+  
   m_molecule->setCoordinate3d(conformer);
   m_molecule->emitChanged(Molecule::Atoms);
   updatePlot();
@@ -156,6 +384,21 @@ void PlotConformer::displayDialog()
     propertyLayout->addStretch();
     mainLayout->addLayout(propertyLayout);
 
+    // X axis selection (Frame or constraint coordinate)
+    QHBoxLayout* xAxisLayout = new QHBoxLayout();
+    QLabel* xAxisLabel = new QLabel(tr("X Axis:"), m_dialog.get());
+    m_xAxisCombo = new QComboBox(m_dialog.get());
+
+    xAxisLayout->addWidget(xAxisLabel);
+    xAxisLayout->addWidget(m_xAxisCombo);
+    xAxisLayout->addStretch();
+    mainLayout->addLayout(xAxisLayout);
+
+    m_unwrapDihedralsCheck =
+      new QCheckBox(tr("Unwrap dihedral scans"), m_dialog.get());
+    m_unwrapDihedralsCheck->setChecked(true);
+    mainLayout->addWidget(m_unwrapDihedralsCheck);
+
     // Create energy conversion layout
     QHBoxLayout* conversionLayout = new QHBoxLayout();
     QLabel* conversionLabel = new QLabel(tr("Energy Units:"), m_dialog.get());
@@ -192,8 +435,13 @@ void PlotConformer::displayDialog()
     connect(m_targetUnitsCombo,
             QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &PlotConformer::updatePlot);
+    connect(m_xAxisCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &PlotConformer::updatePlot);
+    connect(m_unwrapDihedralsCheck, &QCheckBox::toggled, this,
+            &PlotConformer::updatePlot);
   }
 
+  updateXAxisOptions();
   updatePlot();
   m_dialog->show();
   m_dialog->raise();
@@ -206,6 +454,9 @@ void PlotConformer::updatePlot()
     return;
 
   DataSeries xData, yData;
+  const Array<Vector3> originalPositions = m_molecule->atomPositions3d();
+  const int currentIndex = currentConformerIndex();
+  const int xMode = (m_xAxisCombo ? m_xAxisCombo->currentData().toInt() : -1);
 
   QString plotType = m_propertyCombo->currentData().toString();
 
@@ -219,11 +470,39 @@ void PlotConformer::updatePlot()
     generateVelocitiesCurve(xData, yData);
   }
 
+  if (xData.empty() || yData.empty())
+    return;
+
+  bool isDihedralConstraint = false;
+  if (xMode >= 0) {
+    const auto& constraints = m_molecule->constraints();
+    if (xMode < static_cast<int>(constraints.size()) &&
+        constraints[static_cast<size_t>(xMode)].type() ==
+          Core::Constraint::TorsionConstraint) {
+      isDihedralConstraint = true;
+      if (m_unwrapDihedralsCheck && m_unwrapDihedralsCheck->isChecked()) {
+        unwrapPeriodicSeries(xData, 360.0f);
+        shiftSeriesToPreferredWindow(xData, 360.0f, -180.0f, 180.0f);
+      }
+    }
+  }
+
+  if (m_unwrapDihedralsCheck)
+    m_unwrapDihedralsCheck->setEnabled(isDihedralConstraint);
+
+  m_molecule->setAtomPositions3d(originalPositions);
+  m_lastXData = xData;
+
   // Now generate a plot with the data
   float min = *std::min_element(yData.begin(), yData.end());
   float max = *std::max_element(yData.begin(), yData.end());
 
-  const char* xTitle = "Frame";
+  QString xTitle = tr("Frame");
+  if (xMode >= 0) {
+    const auto& constraints = m_molecule->constraints();
+    if (xMode < static_cast<int>(constraints.size()))
+      xTitle = xAxisTitleForConstraint(constraints[static_cast<size_t>(xMode)]);
+  }
   QString yTitle;
 
   if (plotType == "rmsd") {
@@ -242,19 +521,26 @@ void PlotConformer::updatePlot()
   m_chartWidget->setShowPoints(true);
   m_chartWidget->setLegendLocation(QtGui::ChartWidget::LegendLocation::None);
   m_chartWidget->addPlot(xData, yData, QtGui::color4ub{ 255, 0, 0, 255 });
-
-  // Add a marker for the current frame
-  if (m_currentFrame >= 0 && m_currentFrame < static_cast<int>(xData.size())) {
-    DataSeries markerX = { xData[m_currentFrame] };
-    DataSeries markerY = { yData[m_currentFrame] };
-    m_chartWidget->addPlot(markerX, markerY,
-                           QtGui::color4ub{ 255, 165, 0, 255 });
+  if (currentIndex >= 0 && currentIndex < static_cast<int>(xData.size()) &&
+      currentIndex < static_cast<int>(yData.size())) {
+    DataSeries highlightX{ xData[static_cast<size_t>(currentIndex)] };
+    DataSeries highlightY{ yData[static_cast<size_t>(currentIndex)] };
+    m_chartWidget->addPlot(highlightX, highlightY,
+                           QtGui::color4ub{ 0, 102, 204, 255 });
   }
-
   // make sure to pad the axes slightly
   m_chartWidget->setXAxisLimits(
     -0.1, static_cast<float>(m_molecule->coordinate3dCount()) - 0.9);
   m_chartWidget->setYAxisLimits(min, max * 1.1f);
+  if (xMode < 0) {
+    m_chartWidget->setXAxisLimits(
+      -0.1f, static_cast<float>(m_molecule->coordinate3dCount()) - 0.9f);
+  } else {
+    const float xmin = *std::min_element(xData.begin(), xData.end());
+    const float xmax = *std::max_element(xData.begin(), xData.end());
+    const float pad = std::max(1e-3f, (xmax - xmin) * 0.02f);
+    m_chartWidget->setXAxisLimits(xmin - pad, xmax + pad);
+  }
   m_chartWidget->setXAxisTitle(xTitle);
   m_chartWidget->setYAxisTitle(yTitle);
 }
@@ -264,12 +550,13 @@ void PlotConformer::generateRmsdCurve(DataSeries& x, DataSeries& y)
   if (!m_molecule)
     return;
 
-  m_molecule->setCoordinate3d(0);
-  Array<Vector3> ref = m_molecule->atomPositions3d();
+  const Array<Vector3> ref = m_molecule->coordinate3d(0);
+  const Array<Vector3> originalPositions = m_molecule->atomPositions3d();
+  const int xMode = (m_xAxisCombo ? m_xAxisCombo->currentData().toInt() : -1);
+  const auto& constraints = m_molecule->constraints();
 
   for (int i = 0; i < m_molecule->coordinate3dCount(); ++i) {
-    m_molecule->setCoordinate3d(i);
-    Array<Vector3> positions = m_molecule->atomPositions3d();
+    const Array<Vector3> positions = m_molecule->coordinate3d(i);
     double sum = 0;
     for (size_t j = 0; j < positions.size(); ++j) {
       sum += (positions[j][0] - ref[j][0]) * (positions[j][0] - ref[j][0]) +
@@ -277,9 +564,18 @@ void PlotConformer::generateRmsdCurve(DataSeries& x, DataSeries& y)
              (positions[j][2] - ref[j][2]) * (positions[j][2] - ref[j][2]);
     }
     sum = sqrt(sum / m_molecule->coordinate3dCount());
-    x.push_back(i);
+
+    float xVal = static_cast<float>(i);
+    if (xMode >= 0 && xMode < static_cast<int>(constraints.size())) {
+      m_molecule->setCoordinate3d(i);
+      xVal = constraintValue(*m_molecule, constraints[static_cast<size_t>(xMode)]);
+    }
+
+    x.push_back(xVal);
     y.push_back(sum);
   }
+
+  m_molecule->setAtomPositions3d(originalPositions);
 }
 
 void PlotConformer::generateEnergyCurve(DataSeries& x, DataSeries& y)
@@ -306,7 +602,17 @@ void PlotConformer::generateEnergyCurve(DataSeries& x, DataSeries& y)
     // Convert: first to kcal/mol, then to target units
     relativeE = relativeE * fromFactor * toFactor;
 
-    x.push_back(static_cast<double>(entry));
+    float xVal = static_cast<float>(entry); // default: frame
+    const int xMode = (m_xAxisCombo ? m_xAxisCombo->currentData().toInt() : -1);
+    const auto& constraints = m_molecule->constraints();
+    if (xMode >= 0 && xMode < static_cast<int>(constraints.size())) {
+      const Array<Vector3> originalPositions = m_molecule->atomPositions3d();
+      m_molecule->setCoordinate3d(entry);
+      xVal = constraintValue(*m_molecule, constraints[static_cast<size_t>(xMode)]);
+      m_molecule->setAtomPositions3d(originalPositions);
+    }
+
+    x.push_back(xVal);
     y.push_back(relativeE);
   }
 }

--- a/avogadro/qtplugins/plotconformer/plotconformer.h
+++ b/avogadro/qtplugins/plotconformer/plotconformer.h
@@ -9,6 +9,7 @@
 #include <avogadro/qtgui/extensionplugin.h>
 
 #include <QDialog>
+#include <QCheckBox>
 #include <QComboBox>
 
 #include <memory>
@@ -52,6 +53,9 @@ private slots:
   void clicked(float x, float y, Qt::KeyboardModifiers modifiers);
 
 private:
+  int currentConformerIndex() const;
+  void updateXAxisOptions();
+
   // Generate RMSD data from a coordinate set
   // Writes the results to @p x and @p y
   void generateRmsdCurve(DataSeries& x, DataSeries& y);
@@ -74,7 +78,9 @@ private:
   QComboBox* m_propertyCombo;
   QComboBox* m_unitsCombo;
   QComboBox* m_targetUnitsCombo;
-  int m_currentFrame = 0;
+  QComboBox* m_xAxisCombo;
+  QCheckBox* m_unwrapDihedralsCheck = nullptr;
+  DataSeries m_lastXData;
 };
 
 inline QString PlotConformer::description() const


### PR DESCRIPTION
- Add support for plotting conformer data against scan coordinates (selected as constraints) instead of only frame index, so that relaxed scan plots can be visualized

- Add active conformer marker, which is synchronized with the molecule's actual current coordinates so the plot updates when the conformer changes from other tools.

- Use Avogadro angle/dihedral utilities for coordinate evaluation, and refresh available X-axis options when constraints change.

- Add optional dihedral unwrapping with a dialog toggle

DISCLAIMER: AI tools were used to assist the development. The final code was fully human-revised

Signed-off-by: Javier Cerezo <javier.cerezo@um.es>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
