### PR TITLE
Show live energy values in Auto Optimize

### DIFF
--- a/avogadro/qtplugins/autoopt/autoopt.cpp
+++ b/avogadro/qtplugins/autoopt/autoopt.cpp
@@ -57,6 +57,31 @@ namespace Avogadro::QtPlugins {
 using QtGui::Molecule;
 using QtGui::RWAtom;
 
+namespace {
+
+QString formatEnergyOverlay(const QString& method, double energy,
+                            double deltaE, bool hasEnergy,
+                            bool hasDeltaEnergy)
+{
+  if (!hasEnergy)
+    return AutoOpt::tr("%1 E = pending", "energy is not available yet")
+      .arg(method);
+
+  QString overlayText =
+    AutoOpt::tr("%1 E = %L2", "absolute energy while auto-optimizing")
+      .arg(method)
+      .arg(energy, 0, 'g', 8);
+  if (hasDeltaEnergy) {
+    overlayText +=
+      AutoOpt::tr("\nΔE = %L1", "change in energy while auto-optimizing")
+        .arg(deltaE, 0, 'g', 6);
+  }
+
+  return overlayText;
+}
+
+} // namespace
+
 #define ROTATION_SPEED 0.5
 
 AutoOpt::AutoOpt(QObject* parent_)
@@ -336,6 +361,8 @@ void AutoOpt::start()
 
   m_energy = 0.0;
   m_deltaE = 0.0;
+  m_hasEnergy = false;
+  m_hasDeltaEnergy = false;
 
   // set up masses first (needed for velocity initialization)
   setMasses(m_masses, &m_molecule->molecule());
@@ -455,8 +482,11 @@ void AutoOpt::onOptimizeStepDone(Eigen::VectorXd positions,
   int n = m_molecule->atomCount();
 
   if (std::isfinite(energy) && positions.allFinite()) {
-    m_deltaE = energy - m_energy;
+    m_hasDeltaEnergy = m_hasEnergy;
+    if (m_hasDeltaEnergy)
+      m_deltaE = energy - m_energy;
     m_energy = energy;
+    m_hasEnergy = true;
 
     Core::Array<Vector3> pos(n);
     Eigen::Map<Eigen::VectorXd>(pos[0].data(), 3 * n) = positions;
@@ -464,6 +494,7 @@ void AutoOpt::onOptimizeStepDone(Eigen::VectorXd positions,
     m_molecule->setAtomPositions3d(pos, tr("Optimize Geometry"));
     Molecule::MoleculeChanges changes = Molecule::Atoms | Molecule::Moved;
     m_molecule->emitChanged(changes);
+    emit drawablesChanged();
   }
 }
 
@@ -605,10 +636,9 @@ void AutoOpt::draw(Rendering::GroupNode& node)
                     .arg(temp, 0, 'f', 1) +
                   " K";
   } else {
-    overlayText = tr("%1 ΔE = %L2", "change in energy in kJ/mol")
-                    .arg(m_currentMethod.c_str())
-                    .arg(m_deltaE, 0, 'f', 2) +
-                  " kJ/mol";
+    overlayText = formatEnergyOverlay(QString::fromStdString(m_currentMethod),
+                                      m_energy, m_deltaE, m_hasEnergy,
+                                      m_hasDeltaEnergy);
   }
 
   auto* geo = new GeometryNode;

--- a/avogadro/qtplugins/autoopt/autoopt.h
+++ b/avogadro/qtplugins/autoopt/autoopt.h
@@ -112,6 +112,8 @@ private:
 
   Real m_energy;
   Real m_deltaE;
+  bool m_hasEnergy = false;
+  bool m_hasDeltaEnergy = false;
 
   Real m_temperature = 300.0; // Kelvin
   Real m_timeStep = 1.0;      // fs


### PR DESCRIPTION
## Summary
- show the current optimization energy in the Auto Optimize overlay as soon as results arrive
- keep showing ΔE once a prior energy exists, with higher precision for small convergence changes
- avoid misleading initial 0.00 values by showing a pending state until the first energy is computed

## Validation
- cmake -S . -B build -GNinja -DUSE_QT=ON -DENABLE_TESTING=ON -DUSE_SPGLIB=OFF -DUSE_LIBMSYM=OFF -DUSE_PLOTTER=OFF -DUSE_LIBARCHIVE=OFF
- cmake --build build --target AutoOpt AvogadroQtGuiTests --parallel
- ctest --test-dir build --output-on-failure -R 'QtGui-(CalcWorker|Molecule|RWMolecule)'

Closes #2836
