### PR TITLE
Add tetrahedral center inversion button

### DIFF
--- a/avogadro/qtgui/CMakeLists.txt
+++ b/avogadro/qtgui/CMakeLists.txt
@@ -69,6 +69,7 @@ avogadro_headers(QtGui
   scenepluginmodel.h
   slatersetconcurrent.h
   sortfiltertreeproxymodel.h
+  stereotools.h
   timedprogressdialog.h
   toolplugin.h
   utilities.h
@@ -112,6 +113,7 @@ target_sources(QtGui PRIVATE
   scenepluginmodel.cpp
   slatersetconcurrent.cpp
   sortfiltertreeproxymodel.cpp
+  stereotools.cpp
   timedprogressdialog.cpp
   toolplugin.cpp
   utilities.cpp

--- a/avogadro/qtgui/stereotools.cpp
+++ b/avogadro/qtgui/stereotools.cpp
@@ -1,0 +1,315 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "stereotools.h"
+
+#include "molecule.h"
+#include "rwmolecule.h"
+
+#include <avogadro/core/atom.h>
+#include <avogadro/core/graph.h>
+#include <avogadro/core/vector.h>
+
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+using Avogadro::Core::Carbon;
+using Avogadro::Core::Graph;
+using Avogadro::Index;
+using Avogadro::Vector3;
+
+constexpr double minNormSquared = 1.0e-8;
+constexpr double minSignedDistance = 1.0e-5;
+constexpr double antiParallelDotTolerance = -0.999999;
+constexpr double pi = 3.14159265358979323846;
+
+std::vector<Index> collectSubstituentAtoms(const Graph& graph, Index centerAtom,
+                                           Index startAtom)
+{
+  std::vector<Index> component;
+  std::vector<bool> visited(graph.size(), false);
+  std::vector<Index> stack{ startAtom };
+  visited[startAtom] = true;
+
+  while (!stack.empty()) {
+    Index current = stack.back();
+    stack.pop_back();
+    component.push_back(current);
+
+    for (size_t neighbor : graph.neighbors(current)) {
+      if (neighbor == centerAtom || visited[neighbor])
+        continue;
+
+      visited[neighbor] = true;
+      stack.push_back(static_cast<Index>(neighbor));
+    }
+  }
+
+  return component;
+}
+
+bool containsAnyOtherNeighbor(const std::vector<Index>& component,
+                              const std::vector<Index>& neighbors,
+                              Index currentNeighbor)
+{
+  return std::any_of(neighbors.begin(), neighbors.end(), [&](Index neighbor) {
+    return neighbor != currentNeighbor &&
+           std::find(component.begin(), component.end(), neighbor) !=
+             component.end();
+  });
+}
+
+double signedDistanceToPlane(const Vector3& planeOrigin, const Vector3& normal,
+                             const Vector3& point)
+{
+  return normal.dot(point - planeOrigin);
+}
+
+bool isUsableDirection(const Vector3& direction)
+{
+  return std::isfinite(direction.x()) && std::isfinite(direction.y()) &&
+         std::isfinite(direction.z()) &&
+         direction.squaredNorm() > minNormSquared;
+}
+
+Vector3 candidateDirectionFromPlaneReflection(const Vector3& centerPosition,
+                                              const Vector3& candidateVector,
+                                              const Vector3& planeOrigin,
+                                              const Vector3& planeNormal)
+{
+  const Vector3 candidatePosition = centerPosition + candidateVector;
+  const double signedDistance =
+    signedDistanceToPlane(planeOrigin, planeNormal, candidatePosition);
+  const Vector3 reflectedPosition =
+    candidatePosition - 2.0 * signedDistance * planeNormal;
+  return reflectedPosition - centerPosition;
+}
+
+Vector3 candidateDirectionFromSphereIntersection(
+  const Vector3& centerPosition, const Vector3& candidateDirection,
+  const Vector3& planeOrigin, const Vector3& planeNormal,
+  double originalSignedDistance)
+{
+  const double bondLength = candidateDirection.norm();
+  if (bondLength * bondLength <= minNormSquared)
+    return Vector3::Zero();
+
+  const double centerSignedDistance =
+    signedDistanceToPlane(planeOrigin, planeNormal, centerPosition);
+  const double targetNormalComponent =
+    (-originalSignedDistance - centerSignedDistance) / bondLength;
+  if (std::abs(targetNormalComponent) > 1.0)
+    return Vector3::Zero();
+
+  Vector3 tangent =
+    candidateDirection.normalized() -
+    candidateDirection.normalized().dot(planeNormal) * planeNormal;
+  if (tangent.squaredNorm() <= minNormSquared)
+    tangent = planeNormal.unitOrthogonal();
+  else
+    tangent.normalize();
+
+  const double tangentScale =
+    std::sqrt(std::max(0.0, 1.0 - targetNormalComponent * targetNormalComponent));
+  return tangentScale * tangent + targetNormalComponent * planeNormal;
+}
+
+bool flipsConfiguration(const Vector3& centerPosition,
+                        const Vector3& candidateDirection,
+                        const Vector3& planeOrigin, const Vector3& planeNormal,
+                        double originalSignedDistance)
+{
+  const Vector3 rotatedPosition = centerPosition + candidateDirection;
+  const double rotatedSignedDistance =
+    signedDistanceToPlane(planeOrigin, planeNormal, rotatedPosition);
+
+  return std::abs(rotatedSignedDistance) > minSignedDistance &&
+         originalSignedDistance * rotatedSignedDistance < 0.0;
+}
+
+Eigen::Quaterniond stereochemistryRotation(const Vector3& from,
+                                          const Vector3& to,
+                                          const std::array<Vector3, 3>& fixed)
+{
+  const Vector3 fromDirection = from.normalized();
+  const Vector3 toDirection = to.normalized();
+  const double directionDot = fromDirection.dot(toDirection);
+
+  if (directionDot > antiParallelDotTolerance)
+    return Eigen::Quaterniond::FromTwoVectors(fromDirection, toDirection);
+
+  std::array<Vector3, 3> candidateAxes = {
+    fixed[0] - fixed[1],
+    fixed[1] - fixed[2],
+    fixed[2] - fixed[0],
+  };
+
+  for (Vector3 axis : candidateAxes) {
+    axis -= axis.dot(fromDirection) * fromDirection;
+    if (axis.squaredNorm() <= minNormSquared)
+      continue;
+
+    axis.normalize();
+    return Eigen::Quaterniond(Eigen::AngleAxisd(pi, axis));
+  }
+
+  return Eigen::Quaterniond(
+    Eigen::AngleAxisd(pi, fromDirection.unitOrthogonal()));
+}
+
+} // namespace
+
+namespace Avogadro::QtGui {
+
+StereoInversionResult StereoTools::invertTetrahedralCenter(RWMolecule& molecule,
+                                                           Index atomId)
+{
+  if (atomId >= molecule.atomCount())
+    return StereoInversionResult::InvalidAtom;
+
+  const auto centerAtom = molecule.atom(atomId);
+  if (!centerAtom.isValid())
+    return StereoInversionResult::InvalidAtom;
+  if (centerAtom.atomicNumber() != Carbon)
+    return StereoInversionResult::NonCarbonCenter;
+
+  const Graph& graph = molecule.molecule().graph();
+  std::vector<Index> neighbors;
+  for (size_t neighbor : graph.neighbors(atomId))
+    neighbors.push_back(static_cast<Index>(neighbor));
+
+  if (neighbors.size() != 4)
+    return StereoInversionResult::NonTetrahedralCenter;
+
+  for (Index neighbor : neighbors) {
+    auto bond = molecule.bond(atomId, neighbor);
+    if (!bond.isValid() || bond.order() != 1)
+      return StereoInversionResult::UnsupportedBondOrders;
+  }
+
+  struct Candidate
+  {
+    Index neighbor = MaxIndex;
+    std::vector<Index> atoms;
+    bool hydrogen = false;
+  };
+
+  Candidate bestCandidate;
+  for (Index neighbor : neighbors) {
+    std::vector<Index> component =
+      collectSubstituentAtoms(graph, atomId, neighbor);
+    if (containsAnyOtherNeighbor(component, neighbors, neighbor))
+      continue;
+
+    Candidate candidate{ neighbor, std::move(component),
+                         molecule.atomicNumber(neighbor) == 1 };
+    if (bestCandidate.neighbor == MaxIndex ||
+        (candidate.hydrogen && !bestCandidate.hydrogen) ||
+        (candidate.hydrogen == bestCandidate.hydrogen &&
+         candidate.atoms.size() < bestCandidate.atoms.size())) {
+      bestCandidate = std::move(candidate);
+    }
+  }
+
+  if (bestCandidate.neighbor == MaxIndex)
+    return StereoInversionResult::NoMovableSubstituent;
+
+  const Vector3 centerPosition = molecule.atomPosition3d(atomId);
+  const Vector3 candidateVector =
+    molecule.atomPosition3d(bestCandidate.neighbor) - centerPosition;
+  if (!isUsableDirection(candidateVector))
+    return StereoInversionResult::DegenerateGeometry;
+
+  std::array<Index, 3> fixedNeighbors{};
+  size_t fixedIndex = 0;
+  for (Index neighbor : neighbors) {
+    if (neighbor != bestCandidate.neighbor)
+      fixedNeighbors[fixedIndex++] = neighbor;
+  }
+
+  const Vector3 planeOrigin = molecule.atomPosition3d(fixedNeighbors[0]);
+  const std::array<Vector3, 3> fixedVectors = {
+    molecule.atomPosition3d(fixedNeighbors[0]) - centerPosition,
+    molecule.atomPosition3d(fixedNeighbors[1]) - centerPosition,
+    molecule.atomPosition3d(fixedNeighbors[2]) - centerPosition,
+  };
+  const Vector3 planeVector1 = fixedVectors[1] - fixedVectors[0];
+  const Vector3 planeVector2 = fixedVectors[2] - fixedVectors[0];
+  Vector3 planeNormal = planeVector1.cross(planeVector2);
+  if (!isUsableDirection(planeNormal))
+    return StereoInversionResult::DegenerateGeometry;
+  planeNormal.normalize();
+
+  const Vector3 candidatePosition = centerPosition + candidateVector;
+  const double originalSignedDistance =
+    signedDistanceToPlane(planeOrigin, planeNormal, candidatePosition);
+  if (std::abs(originalSignedDistance) <= minSignedDistance)
+    return StereoInversionResult::DegenerateGeometry;
+
+  std::vector<Vector3> candidateDirections;
+  Vector3 reflectedDirection = candidateDirectionFromPlaneReflection(
+    centerPosition, candidateVector, planeOrigin, planeNormal);
+  if (isUsableDirection(reflectedDirection))
+    candidateDirections.push_back(reflectedDirection);
+
+  Vector3 intersectedDirection = candidateDirectionFromSphereIntersection(
+    centerPosition, candidateVector, planeOrigin, planeNormal,
+    originalSignedDistance);
+  if (isUsableDirection(intersectedDirection))
+    candidateDirections.push_back(candidateVector.norm() *
+                                  intersectedDirection.normalized());
+
+  Vector3 centroidDirection = Vector3::Zero();
+  for (Index neighbor : fixedNeighbors) {
+    Vector3 direction = molecule.atomPosition3d(neighbor) - centerPosition;
+    if (!isUsableDirection(direction))
+      return StereoInversionResult::DegenerateGeometry;
+    centroidDirection += direction.normalized();
+  }
+  if (isUsableDirection(centroidDirection))
+    candidateDirections.push_back(candidateVector.norm() *
+                                  centroidDirection.normalized());
+
+  Vector3 selectedDirection = Vector3::Zero();
+  for (const Vector3& direction : candidateDirections) {
+    if (!isUsableDirection(direction))
+      continue;
+    if (flipsConfiguration(centerPosition, direction, planeOrigin, planeNormal,
+                           originalSignedDistance)) {
+      selectedDirection = direction;
+      break;
+    }
+  }
+
+  if (!isUsableDirection(selectedDirection))
+    return StereoInversionResult::DegenerateGeometry;
+
+  const Eigen::Quaterniond rotation =
+    stereochemistryRotation(candidateVector, selectedDirection, fixedVectors);
+  if (!std::isfinite(rotation.x()) || !std::isfinite(rotation.y()) ||
+      !std::isfinite(rotation.z()) || !std::isfinite(rotation.w()))
+    return StereoInversionResult::DegenerateGeometry;
+
+  molecule.undoStack().beginMacro(QStringLiteral("Invert Tetrahedral Center"));
+  for (Index movingAtom : bestCandidate.atoms) {
+    const Vector3 currentPosition = molecule.atomPosition3d(movingAtom);
+    const Vector3 rotatedPosition =
+      centerPosition + rotation * (currentPosition - centerPosition);
+    molecule.setAtomPosition3d(movingAtom, rotatedPosition,
+                               QStringLiteral("Invert Tetrahedral Center"));
+  }
+  molecule.undoStack().endMacro();
+  molecule.emitChanged(Molecule::Atoms | Molecule::Modified);
+
+  return StereoInversionResult::Success;
+}
+
+} // namespace Avogadro::QtGui

--- a/avogadro/qtgui/stereotools.h
+++ b/avogadro/qtgui/stereotools.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_QTGUI_STEREOTOOLS_H
+#define AVOGADRO_QTGUI_STEREOTOOLS_H
+
+#include "avogadroqtguiexport.h"
+
+#include <avogadro/core/avogadrocore.h>
+
+namespace Avogadro::QtGui {
+
+class RWMolecule;
+
+enum class StereoInversionResult
+{
+  Success = 0,
+  InvalidAtom,
+  NonCarbonCenter,
+  NonTetrahedralCenter,
+  UnsupportedBondOrders,
+  NoMovableSubstituent,
+  DegenerateGeometry
+};
+
+class AVOGADROQTGUI_EXPORT StereoTools
+{
+public:
+  static StereoInversionResult invertTetrahedralCenter(RWMolecule& molecule,
+                                                       Index atomId);
+};
+
+} // namespace Avogadro::QtGui
+
+#endif // AVOGADRO_QTGUI_STEREOTOOLS_H

--- a/avogadro/qtplugins/manipulator/manipulatewidget.ui
+++ b/avogadro/qtplugins/manipulator/manipulatewidget.ui
@@ -238,6 +238,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QPushButton" name="invertTetrahedralButton">
+     <property name="toolTip">
+      <string>Move the smallest isolated substituent to the opposite side of a selected tetrahedral carbon.</string>
+     </property>
+     <property name="text">
+      <string>Invert Tetrahedral Center</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Reset</set>

--- a/avogadro/qtplugins/manipulator/manipulator.cpp
+++ b/avogadro/qtplugins/manipulator/manipulator.cpp
@@ -10,6 +10,7 @@
 
 #include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtgui/rwmolecule.h>
+#include <avogadro/qtgui/stereotools.h>
 
 #include <avogadro/qtopengl/glwidget.h>
 
@@ -21,6 +22,7 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
+#include <QMessageBox>
 
 using Avogadro::QtGui::Molecule;
 
@@ -63,6 +65,8 @@ Manipulator::Manipulator(QObject* parent_)
   setIcon();
   connect(m_toolWidget->buttonBox, SIGNAL(clicked(QAbstractButton*)), this,
           SLOT(buttonClicked(QAbstractButton*)));
+  connect(m_toolWidget->invertTetrahedralButton, SIGNAL(clicked()), this,
+          SLOT(invertSelectedTetrahedralCenter()));
 }
 
 Manipulator::~Manipulator() {}
@@ -146,6 +150,56 @@ void Manipulator::buttonClicked(QAbstractButton* button)
   axisRotate(rotation * DEG_TO_RAD, center, moveSelected);
 
   m_molecule->emitChanged(Molecule::Atoms | Molecule::Modified);
+}
+
+void Manipulator::invertSelectedTetrahedralCenter()
+{
+  if (!m_molecule || !m_toolWidget)
+    return;
+
+  std::vector<Index> selectedAtoms;
+  for (Index i = 0; i < m_molecule->atomCount(); ++i) {
+    if (m_molecule->atomSelected(i))
+      selectedAtoms.push_back(i);
+  }
+
+  if (selectedAtoms.size() != 1) {
+    QMessageBox::warning(m_toolWidget, tr("Invert Tetrahedral Center"),
+                         tr("Select exactly one tetrahedral carbon first."));
+    return;
+  }
+
+  const auto result =
+    QtGui::StereoTools::invertTetrahedralCenter(*m_molecule, selectedAtoms[0]);
+  if (result == QtGui::StereoInversionResult::Success)
+    return;
+
+  QString message;
+  switch (result) {
+    case QtGui::StereoInversionResult::NonCarbonCenter:
+      message = tr("Only tetrahedral carbon centers are supported.");
+      break;
+    case QtGui::StereoInversionResult::NonTetrahedralCenter:
+      message = tr("The selected atom must have four bonded neighbors.");
+      break;
+    case QtGui::StereoInversionResult::UnsupportedBondOrders:
+      message = tr("Only centers with four single bonds can be inverted.");
+      break;
+    case QtGui::StereoInversionResult::NoMovableSubstituent:
+      message = tr("No isolated substituent could be moved safely.");
+      break;
+    case QtGui::StereoInversionResult::DegenerateGeometry:
+      message = tr("The selected center does not have usable 3D geometry.");
+      break;
+    case QtGui::StereoInversionResult::InvalidAtom:
+      message = tr("The selected atom is no longer valid.");
+      break;
+    case QtGui::StereoInversionResult::Success:
+      message = tr("Select exactly one tetrahedral carbon first.");
+      break;
+  }
+
+  QMessageBox::warning(m_toolWidget, tr("Invert Tetrahedral Center"), message);
 }
 
 QUndoCommand* Manipulator::keyPressEvent(QKeyEvent* e)

--- a/avogadro/qtplugins/manipulator/manipulator.h
+++ b/avogadro/qtplugins/manipulator/manipulator.h
@@ -61,6 +61,7 @@ public:
 
 public slots:
   void buttonClicked(QAbstractButton* button);
+  void invertSelectedTetrahedralCenter();
 
 private:
   /**

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -25,6 +25,7 @@ set(tests
   Molecule
   PackageManager
   RWMolecule
+  StereoTools
 )
 
 if (BUILD_MOLEQUEUE)

--- a/tests/qtgui/stereotoolstest.cpp
+++ b/tests/qtgui/stereotoolstest.cpp
@@ -1,0 +1,179 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/vector.h>
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/rwmolecule.h>
+#include <avogadro/qtgui/stereotools.h>
+
+#include <Eigen/Geometry>
+
+using Avogadro::Vector3;
+using Avogadro::QtGui::Molecule;
+using Avogadro::QtGui::RWAtom;
+using Avogadro::QtGui::RWMolecule;
+using Avogadro::QtGui::StereoInversionResult;
+using Avogadro::QtGui::StereoTools;
+
+namespace {
+
+double signedDistanceToPlane(const Vector3& origin, const Vector3& a,
+                             const Vector3& b, const Vector3& point)
+{
+  const Vector3 normal = (a - origin).cross(b - origin).normalized();
+  return normal.dot(point - origin);
+}
+
+} // namespace
+
+TEST(StereoToolsTest, invertSimpleTetrahedralCarbon)
+{
+  Molecule molecule;
+  RWMolecule mol(molecule);
+
+  RWAtom center = mol.addAtom(6, Vector3(0.0, 0.0, 0.0));
+  RWAtom hydrogen = mol.addAtom(1, Vector3(0.75, 0.70, 0.65));
+  RWAtom fluorine = mol.addAtom(9, Vector3(-1.00, -0.55, 0.80));
+  RWAtom chlorine = mol.addAtom(17, Vector3(-0.70, 1.05, -0.45));
+  RWAtom bromine = mol.addAtom(35, Vector3(0.95, -0.75, -0.95));
+
+  mol.addBond(center, hydrogen);
+  mol.addBond(center, fluorine);
+  mol.addBond(center, chlorine);
+  mol.addBond(center, bromine);
+
+  const Vector3 centerPosition = center.position3d();
+  const double originalDistance =
+    (hydrogen.position3d() - centerPosition).norm();
+  const double originalSign = signedDistanceToPlane(
+    fluorine.position3d(), chlorine.position3d(), bromine.position3d(),
+    hydrogen.position3d());
+
+  EXPECT_EQ(StereoTools::invertTetrahedralCenter(mol, center.index()),
+            StereoInversionResult::Success);
+
+  const double invertedDistance =
+    (hydrogen.position3d() - centerPosition).norm();
+  const double invertedSign = signedDistanceToPlane(
+    fluorine.position3d(), chlorine.position3d(), bromine.position3d(),
+    hydrogen.position3d());
+
+  EXPECT_LT(originalSign * invertedSign, 0.0);
+  EXPECT_NEAR(originalDistance, invertedDistance, 1.0e-6);
+}
+
+TEST(StereoToolsTest, invertRingLikeTetrahedralCarbon)
+{
+  Molecule molecule;
+  RWMolecule mol(molecule);
+
+  RWAtom center = mol.addAtom(6, Vector3(0.0, 0.0, 0.0));
+  RWAtom hydrogen = mol.addAtom(1, Vector3(0.85, 0.15, 0.70));
+  RWAtom methyl = mol.addAtom(6, Vector3(-1.00, 0.20, 0.65));
+  RWAtom ringA = mol.addAtom(6, Vector3(-0.55, 1.05, -0.75));
+  RWAtom ringB = mol.addAtom(6, Vector3(0.75, -1.05, -0.70));
+  RWAtom ringBridge1 = mol.addAtom(6, Vector3(0.10, 1.60, -1.10));
+  RWAtom ringBridge2 = mol.addAtom(6, Vector3(1.00, 0.20, -1.25));
+  RWAtom methylH1 = mol.addAtom(1, Vector3(-1.70, 0.85, 1.05));
+  RWAtom methylH2 = mol.addAtom(1, Vector3(-1.35, -0.75, 0.95));
+  RWAtom methylH3 = mol.addAtom(1, Vector3(-1.40, 0.40, -0.35));
+
+  mol.addBond(center, hydrogen);
+  mol.addBond(center, methyl);
+  mol.addBond(center, ringA);
+  mol.addBond(center, ringB);
+  mol.addBond(ringA, ringBridge1);
+  mol.addBond(ringBridge1, ringBridge2);
+  mol.addBond(ringBridge2, ringB);
+  mol.addBond(methyl, methylH1);
+  mol.addBond(methyl, methylH2);
+  mol.addBond(methyl, methylH3);
+
+  const double originalSign = signedDistanceToPlane(
+    methyl.position3d(), ringA.position3d(), ringB.position3d(),
+    hydrogen.position3d());
+
+  EXPECT_EQ(StereoTools::invertTetrahedralCenter(mol, center.index()),
+            StereoInversionResult::Success);
+
+  const double invertedSign = signedDistanceToPlane(
+    methyl.position3d(), ringA.position3d(), ringB.position3d(),
+    hydrogen.position3d());
+
+  EXPECT_LT(originalSign * invertedSign, 0.0);
+}
+
+TEST(StereoToolsTest, rejectCentersWithoutIsolatedSubstituent)
+{
+  Molecule molecule;
+  RWMolecule mol(molecule);
+
+  RWAtom center = mol.addAtom(6, Vector3(0.0, 0.0, 0.0));
+  RWAtom a = mol.addAtom(6, Vector3(0.85, 0.20, 0.75));
+  RWAtom b = mol.addAtom(6, Vector3(-0.95, -0.30, 0.75));
+  RWAtom c = mol.addAtom(6, Vector3(-0.75, 1.00, -0.55));
+  RWAtom d = mol.addAtom(6, Vector3(0.90, -0.95, -0.55));
+
+  mol.addBond(center, a);
+  mol.addBond(center, b);
+  mol.addBond(center, c);
+  mol.addBond(center, d);
+  mol.addBond(a, b);
+  mol.addBond(b, c);
+  mol.addBond(c, d);
+
+  EXPECT_EQ(StereoTools::invertTetrahedralCenter(mol, center.index()),
+            StereoInversionResult::NoMovableSubstituent);
+}
+
+TEST(StereoToolsTest, invertMultiAtomSubstituentOnRegularTetrahedron)
+{
+  Molecule molecule;
+  RWMolecule mol(molecule);
+
+  RWAtom center = mol.addAtom(6, Vector3(0.0, 0.0, 0.0));
+  RWAtom methyl = mol.addAtom(6, Vector3(1.0, 1.0, 1.0));
+  RWAtom fixedA = mol.addAtom(6, Vector3(-1.0, -1.0, 1.0));
+  RWAtom fixedB = mol.addAtom(6, Vector3(-1.0, 1.0, -1.0));
+  RWAtom fixedC = mol.addAtom(6, Vector3(1.0, -1.0, -1.0));
+  RWAtom methylH1 = mol.addAtom(1, Vector3(1.75, 1.10, 1.35));
+  RWAtom methylH2 = mol.addAtom(1, Vector3(1.10, 1.80, 1.20));
+  RWAtom methylH3 = mol.addAtom(1, Vector3(1.25, 1.05, 1.95));
+
+  mol.addBond(center, methyl);
+  mol.addBond(center, fixedA);
+  mol.addBond(center, fixedB);
+  mol.addBond(center, fixedC);
+  mol.addBond(fixedA, fixedB);
+  mol.addBond(fixedB, fixedC);
+  mol.addBond(methyl, methylH1);
+  mol.addBond(methyl, methylH2);
+  mol.addBond(methyl, methylH3);
+
+  const double originalSign = signedDistanceToPlane(
+    fixedA.position3d(), fixedB.position3d(), fixedC.position3d(),
+    methyl.position3d());
+
+  Vector3 axis = fixedA.position3d() - fixedB.position3d();
+  axis -= axis.dot(methyl.position3d().normalized()) *
+          methyl.position3d().normalized();
+  axis.normalize();
+
+  const Eigen::Quaterniond expectedRotation(
+    Eigen::AngleAxisd(3.14159265358979323846, axis));
+  const Vector3 expectedMethylH1 = expectedRotation * methylH1.position3d();
+
+  EXPECT_EQ(StereoTools::invertTetrahedralCenter(mol, center.index()),
+            StereoInversionResult::Success);
+
+  const double invertedSign = signedDistanceToPlane(
+    fixedA.position3d(), fixedB.position3d(), fixedC.position3d(),
+    methyl.position3d());
+
+  EXPECT_LT(originalSign * invertedSign, 0.0);
+  EXPECT_NEAR((methylH1.position3d() - expectedMethylH1).norm(), 0.0, 1.0e-6);
+}


### PR DESCRIPTION
## Summary
- add a QtGui stereo inversion helper for tetrahedral carbon centers
- expose the action in the Manipulate tool as an invert button with validation messages
- cover simple, ring-like, and anti-parallel multi-atom inversion cases in QtGui tests

Closes #2838