### PR TITLE
Keep labels aligned with their anchors in screen space

### DIFF
--- a/avogadro/rendering/textlabelbase_vs.glsl
+++ b/avogadro/rendering/textlabelbase_vs.glsl
@@ -40,8 +40,19 @@ void main(void)
   // Transform to eye coordinates:
   vec4 eyeAnchor = mv * vec4(anchor, 1.0);
 
-  // Apply radius;
-  eyeAnchor += vec4(0., 0., radius, 0.);
+  // Apply radius
+  // Scale about camera origin, that shifts z forward by radius.
+  // eyeAnchor.z is negative for items in front of the camera
+  // The scaling factor is:
+  // S = eyeAnchor.z'/eyeAnchor.z
+  //   = (eyeAnchor.z + radius)/eyeAnchor.z 
+  //   = 1 + radius/eyeAnchor.z
+  
+  float MIN_DEPTH = 1.0e-06;
+  if(-eyeAnchor.z > MIN_DEPTH) {
+    float scale = 1.0 + radius / eyeAnchor.z; 
+    eyeAnchor *= vec4(scale, scale, scale, 1.0);
+  }
 
   // Transform to clip coordinates
   vec4 clipAnchor = proj * eyeAnchor;


### PR DESCRIPTION
Switch from an offset of the labels along camera Z to a scaling about the camera origin, so that they don't become displaced from their anchors in screen space.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
