### PR TITLE
Run plugin setup command with pixi run if pixi available

### DIFF
--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -347,19 +347,26 @@ static QString readSetupCommand(const QString& packageDir)
   return {};
 }
 
-// Run a package's *-setup script (e.g. to download ML model weights).
+// Run a package's *-setup command (e.g. to download ML model weights).
+// This is called regardless of whether the package has defined one or not.
 static void runSetupScript(const QString& packageDir, const QString& setupCmd,
-                           bool isPixi, int timeoutMs)
+                           const QString& pixiExe, bool isPixi, int timeoutMs)
 {
   if (setupCmd.isEmpty())
     return;
-  const QString setupExe = findInstalledScript(packageDir, setupCmd, isPixi);
-  if (setupExe.isEmpty())
-    return;
-
   QProcess proc;
   proc.setWorkingDirectory(packageDir);
-  proc.start(setupExe, {});
+  if (isPixi) {
+    // If we have Pixi, just run the command using `pixi run`
+    proc.start(pixiExe, { QStringLiteral("run"), setupCmd });
+  } else {
+    const QString setupExe = findInstalledScript(packageDir, setupCmd, isPixi);
+    if (setupExe.isEmpty()) {
+      qDebug("No setup exe found, early return");
+      return;
+    }
+    proc.start(setupExe, {});
+  }
   if (!proc.waitForStarted(timeoutMs)) {
     qWarning() << "setup script could not be started for" << packageDir << ":"
                << proc.errorString();
@@ -403,7 +410,6 @@ void PackageManager::installPackages(const QStringList& packageDirs)
   QMap<QString, QString> setupCommands;
   for (const QString& dir : packageDirs)
     setupCommands[dir] = readSetupCommand(dir);
-
   QThread* installThread =
     QThread::create([pixiExe, pythonExe, packageDirs, setupCommands]() {
       constexpr int installTimeoutMs = 10 * 60 * 1000; // 10 minutes
@@ -438,8 +444,8 @@ void PackageManager::installPackages(const QStringList& packageDirs)
           } else {
             // Run the *-setup script if one is declared (e.g. to download ML
             // model weights).
-            runSetupScript(packageDir, setupCommands.value(packageDir), true,
-                           installTimeoutMs);
+            runSetupScript(packageDir, setupCommands.value(packageDir), pixiExe,
+                           true, installTimeoutMs);
           }
         } else {
           // Step 1: create a venv
@@ -480,8 +486,8 @@ void PackageManager::installPackages(const QStringList& packageDirs)
                        << installProc.readAllStandardError();
           } else {
             // Run the *-setup script if one is declared.
-            runSetupScript(packageDir, setupCommands.value(packageDir), false,
-                           installTimeoutMs);
+            runSetupScript(packageDir, setupCommands.value(packageDir),
+                           QStringLiteral(), false, installTimeoutMs);
           }
         }
       }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

---

This fixes the issue that I was having whereby the xtb plugin's setup script wasn't installing the xtb binary correctly, even though it worked perfectly when running it directly without Avogadro's involvement.

The problem lay with the fact that the setup command/executable was being run directly rather than using `pixi run` and therefore not within the Pixi environment that the plugin is normally run in. This PR changes that (only when Pixi is present, of course).