### PR TITLE
Force UTF-8 mode for Windows Python scripts

### DIFF
--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -13,6 +13,7 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QLocale>
 #include <QtCore/QProcess>
+#include <QtCore/QProcessEnvironment>
 #include <QtCore/QSettings>
 #include <QtCore/QStandardPaths>
 
@@ -126,6 +127,12 @@ void PythonScript::setDefaultPythonInterpreter()
 
 QString PythonScript::resolveCommand(QStringList& realArgs, QProcess& proc)
 {
+#ifdef Q_OS_WIN
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.insert(QStringLiteral("PYTHONUTF8"), QStringLiteral("1"));
+  proc.setProcessEnvironment(environment);
+#endif
+
   // --- Package mode: pixi run <command> <identifier> [args] ---
   if (m_packageMode) {
     if (m_pixi.isEmpty()) {

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -27,6 +27,12 @@ set(tests
   RWMolecule
 )
 
+if(Python3_EXECUTABLE)
+  list(APPEND tests
+    PythonScript
+  )
+endif()
+
 if (BUILD_MOLEQUEUE)
   # Pull in MoleQueue
   find_package(MoleQueue REQUIRED NO_MODULE)

--- a/tests/qtgui/pythonscripttest.cpp
+++ b/tests/qtgui/pythonscripttest.cpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/qtgui/pythonscript.h>
+
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryDir>
+
+using Avogadro::QtGui::PythonScript;
+
+TEST(PythonScriptTest, WindowsUsesUtf8Mode)
+{
+#ifndef Q_OS_WIN
+  GTEST_SKIP() << "PYTHONUTF8 is only set on Windows.";
+#else
+  QTemporaryDir temporaryDirectory;
+  ASSERT_TRUE(temporaryDirectory.isValid());
+
+  QFile script(temporaryDirectory.filePath("utf8_mode.py"));
+  ASSERT_TRUE(script.open(QIODevice::WriteOnly | QIODevice::Text));
+  const QByteArray source("import sys\nprint(sys.flags.utf8_mode)\n");
+  ASSERT_EQ(script.write(source), source.size());
+  script.close();
+
+  PythonScript pythonScript(script.fileName());
+  EXPECT_EQ(pythonScript.execute({}).trimmed(), QByteArray("1"));
+#endif
+}


### PR DESCRIPTION
For Windows launches, set `PYTHONUTF8=1` on the process environment in the shared `PythonScript` launch path. This makes direct Python and pixi-launched plugin scripts use UTF-8 consistently, avoiding system-locale decoding of plugin output.

Adds a Windows regression test that launches a temporary Python script and verifies `sys.flags.utf8_mode` is enabled.

Validation:
- `git diff --check`
- Confirmed locally that `PYTHONUTF8=1` enables Python UTF-8 mode
- Full CMake/Qt test suite was not run locally because this environment lacks CMake and Qt

Fixes #1618.