### PR TITLE
Allow the number of MOs to differ from the basis set side

### DIFF
--- a/avogadro/core/gaussianset.cpp
+++ b/avogadro/core/gaussianset.cpp
@@ -182,7 +182,11 @@ unsigned int GaussianSet::molecularOrbitalCount(ElectronType type) const
   size_t index(0);
   if (type == Beta)
     index = 1;
-  return static_cast<unsigned int>(m_moMatrix[index].rows());
+  // The number of MOs is the number of columns in the coefficient matrix.
+  // The rows are the number of atomic basis functions, which is only equal
+  // to the number of MOs for a full canonical set. Reduced/localized sets
+  // (IAO/IBO, NBO, Pipek-Mezey, ...) have fewer MOs than basis functions.
+  return static_cast<unsigned int>(m_moMatrix[index].cols());
 }
 
 void GaussianSet::outputAll(ElectronType type)

--- a/avogadro/quantumio/molden.cpp
+++ b/avogadro/quantumio/molden.cpp
@@ -259,19 +259,28 @@ void MoldenFile::processLine(std::istream& in)
           list = Core::split(line, ' ');
         }
 
-        // Now commit the buffered values with the correct spin
+        // Set the correct spin before reading coefficients; the legacy
+        // (no basis count) path below routes coefficients based on it.
         m_currentSpinBeta = pendingSpinBeta;
-        if (havePendingEnergy) {
-          if (m_currentSpinBeta)
-            m_betaOrbitalEnergy.push_back(pendingEnergy);
-          else
-            m_orbitalEnergy.push_back(pendingEnergy);
-        }
-        if (havePendingSymmetry) {
-          if (m_currentSpinBeta)
-            m_betaSymmetryLabels.push_back(pendingSymmetry);
-          else
-            m_symmetryLabels.push_back(pendingSymmetry);
+
+        // For the legacy path (no basis count) commit the header fields now,
+        // since coefficients are streamed directly and cannot be buffered.
+        // For the normal path we defer the commit until after the
+        // coefficients are read, so all-zero "padding" orbitals can be
+        // dropped as a unit (see below).
+        if (numBasisFunctions == 0) {
+          if (havePendingEnergy) {
+            if (m_currentSpinBeta)
+              m_betaOrbitalEnergy.push_back(pendingEnergy);
+            else
+              m_orbitalEnergy.push_back(pendingEnergy);
+          }
+          if (havePendingSymmetry) {
+            if (m_currentSpinBeta)
+              m_betaSymmetryLabels.push_back(pendingSymmetry);
+            else
+              m_symmetryLabels.push_back(pendingSymmetry);
+          }
         }
 
         // Parse the molecular orbital coefficients.
@@ -309,13 +318,42 @@ void MoldenFile::processLine(std::istream& in)
           list = Core::split(line, ' ');
         }
         if (numBasisFunctions > 0) {
-          if (m_currentSpinBeta)
-            m_betaMOcoeffs.insert(m_betaMOcoeffs.end(),
-                                  orbitalCoefficients.begin(),
-                                  orbitalCoefficients.end());
-          else
-            m_MOcoeffs.insert(m_MOcoeffs.end(), orbitalCoefficients.begin(),
-                              orbitalCoefficients.end());
+          // Some codes pad the [MO] section out to the full basis dimension
+          // with all-zero, zero-energy "orbitals" (common for localized
+          // orbital sets such as IAO/IBO, NBO, Pipek-Mezey, which represent
+          // a reduced subspace). A normalized MO can never have all-zero
+          // coefficients, so drop such padding entries entirely - together
+          // with their buffered energy and symmetry - to keep the orbital
+          // list limited to the meaningful orbitals.
+          bool allZero = true;
+          for (double c : orbitalCoefficients) {
+            if (c != 0.0) {
+              allZero = false;
+              break;
+            }
+          }
+
+          if (!allZero) {
+            if (havePendingEnergy) {
+              if (m_currentSpinBeta)
+                m_betaOrbitalEnergy.push_back(pendingEnergy);
+              else
+                m_orbitalEnergy.push_back(pendingEnergy);
+            }
+            if (havePendingSymmetry) {
+              if (m_currentSpinBeta)
+                m_betaSymmetryLabels.push_back(pendingSymmetry);
+              else
+                m_symmetryLabels.push_back(pendingSymmetry);
+            }
+            if (m_currentSpinBeta)
+              m_betaMOcoeffs.insert(m_betaMOcoeffs.end(),
+                                    orbitalCoefficients.begin(),
+                                    orbitalCoefficients.end());
+            else
+              m_MOcoeffs.insert(m_MOcoeffs.end(), orbitalCoefficients.begin(),
+                                orbitalCoefficients.end());
+          }
         }
         // go back one line
         in.seekg(currentPos);

--- a/tests/quantumio/moldentest.cpp
+++ b/tests/quantumio/moldentest.cpp
@@ -174,6 +174,120 @@ Occup=  0.0000
   EXPECT_NEAR(moMatrix(2, 4), 1.0, 1e-6);
 }
 
+// Localized orbital sets (IAO/IBO, NBO, Pipek-Mezey) represent a reduced
+// subspace, and some codes pad the [MO] section out to the full basis
+// dimension with all-zero, zero-energy "orbitals". These are not real
+// orbitals and must be dropped so the orbital list shows only the
+// meaningful entries.
+TEST(MoldenTest, dropsZeroPaddingOrbitals)
+{
+  static const char paddedMolden[] = R"([Molden Format]
+[GTO]
+    1 0
+ s   6 1.00
+     130.7093200    0.1543289700
+      23.8088610    0.5353281400
+       6.4436083    0.4446345400
+       5.0331513    0.0000000000
+       1.1695961    0.0000000000
+       0.3803890    0.0000000000
+ s   6 1.00
+     130.7093200    0.0000000000
+      23.8088610    0.0000000000
+       6.4436083    0.0000000000
+       5.0331513   -0.0999672300
+       1.1695961    0.3995128300
+       0.3803890    0.7001154700
+ p   3 1.00
+       5.0331513    0.1559162700
+       1.1695961    0.6076837200
+       0.3803890    0.3919573900
+
+    2 0
+ s   3 1.00
+       3.4252509    0.1543289700
+       0.6239137    0.5353281400
+       0.1688554    0.4446345400
+
+    3 0
+ s   3 1.00
+       3.4252509    0.1543289700
+       0.6239137    0.5353281400
+       0.1688554    0.4446345400
+
+[Atoms] AU
+O          1     8         0.0000000000         0.0000000000         0.226016913
+H          2     1         0.0000000000         1.4396179285        -0.904063875
+H          3     1         0.0000000000        -1.4396179285        -0.904063875
+[5D7F]
+[9G]
+[MO]
+Sym= A
+Ene=  -20.2442
+Spin= Alpha
+Occup=  2.0000
+    1       -0.994158
+    2       -0.026315
+    5        0.004261
+    6        0.005841
+    7        0.005841
+Sym= A
+Ene=   -1.2636
+Spin= Alpha
+Occup=  2.0000
+    1        0.233172
+    2       -0.837489
+    5        0.126492
+    6       -0.157787
+    7       -0.157787
+Sym= A
+Ene=    0.0000
+Spin= Alpha
+Occup=  0.0000
+    1        0.0000000000
+    2        0.0000000000
+    3        0.0000000000
+    4        0.0000000000
+    5        0.0000000000
+    6        0.0000000000
+    7        0.0000000000
+Sym= A
+Ene=    0.0000
+Spin= Alpha
+Occup=  0.0000
+    1        0.0000000000
+    2        0.0000000000
+    3        0.0000000000
+    4        0.0000000000
+    5        0.0000000000
+    6        0.0000000000
+    7        0.0000000000
+[End of Molden output]
+)";
+
+  MoldenFile format;
+  Molecule molecule;
+  EXPECT_TRUE(format.readString(paddedMolden, molecule));
+  ASSERT_EQ(format.error(), std::string());
+
+  const auto* basis = dynamic_cast<const GaussianSet*>(molecule.basisSet());
+  ASSERT_NE(basis, nullptr);
+
+  const auto moMatrix = basis->moMatrix();
+  // 7 basis functions, but only 2 real orbitals (2 zero-padding dropped).
+  EXPECT_EQ(moMatrix.rows(), 7);
+  EXPECT_EQ(moMatrix.cols(), 2);
+  EXPECT_EQ(basis->molecularOrbitalCount(), 2u);
+
+  // Energies and symmetry labels must be dropped alongside the coefficients.
+  EXPECT_EQ(basis->moEnergy().size(), 2u);
+  EXPECT_EQ(basis->symmetryLabels().size(), 2u);
+
+  // The two surviving orbitals are the meaningful ones.
+  EXPECT_NEAR(moMatrix(0, 0), -0.994158, 1e-6);
+  EXPECT_NEAR(moMatrix(0, 1), 0.233172, 1e-6);
+}
+
 // Test that supportedOperations includes Write
 TEST(MoldenTest, supportedOperations)
 {


### PR DESCRIPTION
Also ignore MO in Molden files that are all zero

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected molecular orbital counts for reduced or localized basis sets.
  * Improved Molden file parsing by correctly handling spin information and legacy orbital data.
  * Automatically removes zero-filled padding orbitals while preserving valid orbital coefficients and metadata.

* **Tests**
  * Added coverage verifying padded orbitals are excluded and remaining orbital data is accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->