### PR TITLE
Set the identifier for generic output based on the format

### DIFF
--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -22,6 +22,12 @@ GenericOutput::GenericOutput() {}
 
 GenericOutput::~GenericOutput() {}
 
+std::string GenericOutput::identifier() const
+{
+  const std::lock_guard<std::mutex> lock(m_identifierMutex);
+  return m_identifier;
+}
+
 std::vector<std::string> GenericOutput::fileExtensions() const
 {
   std::vector<std::string> extensions;
@@ -85,6 +91,11 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
         break;
       }
     }
+  }
+
+  if (reader != nullptr) {
+    const std::lock_guard<std::mutex> lock(m_identifierMutex);
+    m_identifier = reader->identifier();
   }
 
   // rewind the stream

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -93,7 +93,12 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
     }
   }
 
+  // Reset every time to be sure we don't return the *last* identifier
+  const std::lock_guard<std::mutex> lock(m_identifierMutex);
+  m_identifier = "Avogadro: Generic Output";
+
   if (reader != nullptr) {
+    // now update the identifier
     const std::lock_guard<std::mutex> lock(m_identifierMutex);
     m_identifier = reader->identifier();
   }

--- a/avogadro/quantumio/genericoutput.h
+++ b/avogadro/quantumio/genericoutput.h
@@ -10,6 +10,7 @@
 #include <avogadro/io/fileformat.h>
 
 #include <map>
+#include <mutex>
 #include <vector>
 
 namespace Avogadro {
@@ -27,7 +28,7 @@ public:
   }
 
   FileFormat* newInstance() const override { return new GenericOutput; }
-  std::string identifier() const override { return "Avogadro: Generic Output"; }
+  std::string identifier() const override;
   std::string name() const override { return "Generic Output"; }
   std::string description() const override { return "Generic output format."; }
 
@@ -42,6 +43,12 @@ public:
     // Empty, as we do not write output files.
     return false;
   }
+
+protected:
+  // The identifier is only known once read() has sniffed the file, which may
+  // happen on a worker thread while the GUI thread displays it - so guard it.
+  mutable std::mutex m_identifierMutex;
+  std::string m_identifier = "Avogadro: Generic Output";
 };
 
 } // namespace QuantumIO


### PR DESCRIPTION
Fix #2900 in connection with an avogadroapp change

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output identifiers now reflect the detected file format after reading.
  * Improved reliability when format information is accessed while processing occurs in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->