### PR TITLE
Improve support for QCSchema v2 JSON files

### DIFF
--- a/avogadro/quantumio/genericjson.cpp
+++ b/avogadro/quantumio/genericjson.cpp
@@ -56,10 +56,11 @@ bool GenericJson::read(std::istream& in, Core::Molecule& molecule)
 
   // Okay, look for particular keys
   if (root.find("schema_name") != root.end()) {
-    if (root["schema_name"].get<std::string>() == "QC_JSON")
-      reader = new QCSchema();
-    else if (root["schema_name"].get<std::string>() == "qcschema_molecule")
-      reader = new QCSchema();
+    if (root["schema_name"].is_string()) {
+      const std::string schemaName = root["schema_name"].get<std::string>();
+      if (schemaName == "QC_JSON" || schemaName == "qcschema_molecule")
+        reader = new QCSchema();
+    }
   } else if (root.find("simulation") != root.end()) {
     reader = new NWChemJson();
   }

--- a/avogadro/quantumio/genericjson.cpp
+++ b/avogadro/quantumio/genericjson.cpp
@@ -58,6 +58,8 @@ bool GenericJson::read(std::istream& in, Core::Molecule& molecule)
   if (root.find("schema_name") != root.end()) {
     if (root["schema_name"].get<std::string>() == "QC_JSON")
       reader = new QCSchema();
+    else if (root["schema_name"].get<std::string>() == "qcschema_molecule")
+      reader = new QCSchema();
   } else if (root.find("simulation") != root.end()) {
     reader = new NWChemJson();
   }

--- a/avogadro/quantumio/qcschema.cpp
+++ b/avogadro/quantumio/qcschema.cpp
@@ -12,11 +12,18 @@
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/unitcell.h>
 #include <avogadro/core/vector.h>
+#include <avogadro/core/version.h>
 
 #include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <iomanip>
 #include <iostream>
 
 using json = nlohmann::json;
+using ordered_json = nlohmann::ordered_json;
 using std::string;
 
 namespace Avogadro::QuantumIO {
@@ -69,7 +76,7 @@ std::vector<std::string> QCSchema::mimeTypes() const
 
 bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
 {
-  float coordinateScale = 1.0; // default to Angstroms
+  double coordinateScale = 1.0; // default to Angstroms
 
   // This should be JSON so look for key attributes
   json root;
@@ -93,11 +100,15 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     return false;
   }
 
-  // if the schema_name is qcschema_molecule, then the coordinates are in
-  // bohr
-  if (root["schema_name"].get<std::string>() == "qcschema_molecule") {
+  // "qcschema_molecule" is the MolSSI specification, while "QC_JSON" is the
+  // older WebMO variant. The MolSSI form uses bohr and zero-based connectivity
+  // indices, the WebMO one uses Angstroms and one-based indices.
+  const bool molssi =
+    root["schema_name"].get<std::string>() == "qcschema_molecule";
+  if (molssi) {
     coordinateScale = BOHR_TO_ANGSTROM;
   }
+  const Index indexOffset = molssi ? 0 : 1;
 
   // get the elements
   if (root.find("symbols") == root.end() || !root["symbols"].is_array()) {
@@ -142,14 +153,20 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
 
   // check for (optional) connectivity
   if (root.find("connectivity") != root.end() &&
-      root["connectivity"].is_array()) {
+      root["connectivity"].is_array() && !root["connectivity"].empty()) {
     // read the bonds and orders
     json connectivity = root["connectivity"];
     // stored as an array of 3-value arrays start, end, order
+    // the order may be fractional in the MolSSI specification
     for (const auto& bond : connectivity) {
-      Index start = bond[0].get<Index>() - 1;
-      Index end = bond[1].get<Index>() - 1;
-      unsigned char order = bond[2].get<unsigned char>();
+      if (!bond.is_array() || bond.size() < 3)
+        continue;
+      Index start = bond[0].get<Index>() - indexOffset;
+      Index end = bond[1].get<Index>() - indexOffset;
+      if (start >= atomCount || end >= atomCount)
+        continue;
+      auto order =
+        static_cast<unsigned char>(std::lround(bond[2].get<double>()));
       molecule.addBond(start, end, order);
     }
   } else {
@@ -158,17 +175,27 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     molecule.perceiveBondOrders();
   }
 
-  // check for optional comment / name
-  if (root.find("comment") != root.end())
+  // check for optional name / comment
+  if (root.find("name") != root.end() && root["name"].is_string())
+    molecule.setData("name", root["name"].get<std::string>());
+  else if (root.find("comment") != root.end() && root["comment"].is_string())
     molecule.setData("name", root["comment"].get<std::string>());
 
   // check for molecular_charge and molecular_multiplicity
-  if (root.find("molecular_charge") != root.end()) {
-    molecule.setData("totalCharge", root["molecular_charge"].get<int>());
+  // (the specification types both of these as floats)
+  if (root.find("molecular_charge") != root.end() &&
+      root["molecular_charge"].is_number()) {
+    molecule.setData("totalCharge", static_cast<int>(std::lround(
+                                      root["molecular_charge"].get<double>())));
   }
-  if (root.find("molecular_multiplicity") != root.end()) {
-    molecule.setData("totalSpinMultiplicity",
-                     root["molecular_multiplicity"].get<int>());
+  if (root.find("molecular_multiplicity") != root.end() &&
+      root["molecular_multiplicity"].is_number()) {
+    int multiplicity = static_cast<int>(
+      std::lround(root["molecular_multiplicity"].get<double>()));
+    // some files in the wild write a multiplicity of zero - ignore those and
+    // let the molecule work one out from the electron count instead
+    if (multiplicity >= 1)
+      molecule.setData("totalSpinMultiplicity", multiplicity);
   }
 
   // if the "properties object exists" look for properties
@@ -395,6 +422,128 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
   }
 
   return true;
+}
+
+namespace {
+
+/**
+ * QCSchema requires the provenance version to be a PEP 440 string, but our
+ * version may carry a git description (e.g. "2.0.0-209-gcae74147"). Keep the
+ * leading numeric release and move anything that follows into a local version
+ * label, e.g. "2.0.0+209.gcae74147".
+ */
+std::string pep440Version(const std::string& version)
+{
+  std::string::size_type end = version.find_first_not_of("0123456789.");
+  std::string release = version.substr(0, end);
+  // trim any trailing separator left behind, e.g. "2.0.0-" => "2.0.0"
+  while (!release.empty() && release.back() == '.')
+    release.pop_back();
+  if (release.empty())
+    return "0";
+  if (end == std::string::npos)
+    return release;
+
+  // the local label allows only lowercase alphanumerics separated by periods
+  std::string local;
+  for (std::string::size_type i = end; i < version.size(); ++i) {
+    char c = version[i];
+    if (std::isalnum(static_cast<unsigned char>(c)))
+      local += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    else if (!local.empty() && local.back() != '.')
+      local += '.';
+  }
+  while (!local.empty() && local.back() == '.')
+    local.pop_back();
+  if (local.empty())
+    return release;
+
+  return release + "+" + local;
+}
+
+} // namespace
+
+bool QCSchema::write(std::ostream& out, const Core::Molecule& molecule)
+{
+  const Index atomCount = molecule.atomCount();
+  if (atomCount == 0) {
+    appendError("Error: no atoms to write.");
+    return false;
+  }
+  // custom / dummy elements have no elemental symbol, so they cannot be
+  // expressed in a qcschema_molecule
+  if (molecule.hasCustomElements()) {
+    appendError("Error: QCSchema cannot represent custom elements.");
+    return false;
+  }
+
+  // use an ordered object so the output is stable and human readable
+  ordered_json root;
+
+  root["schema_name"] = "qcschema_molecule";
+  root["schema_version"] = 3;
+
+  if (molecule.data("name").type() == Core::Variant::String) {
+    std::string name = molecule.data("name").toString();
+    if (!name.empty())
+      root["name"] = name;
+  }
+  if (molecule.data("comment").type() == Core::Variant::String) {
+    std::string comment = molecule.data("comment").toString();
+    if (!comment.empty())
+      root["comment"] = comment;
+  }
+
+  // the ordered array of elemental symbols, in title case
+  ordered_json symbols = ordered_json::array();
+  const auto& atomicNumbers = molecule.atomicNumbers();
+  for (Index i = 0; i < atomCount; ++i)
+    symbols.push_back(Elements::symbol(atomicNumbers[i]));
+  root["symbols"] = symbols;
+
+  // geometry is a flat (3 * nat) array in bohr
+  ordered_json geometry = ordered_json::array();
+  const auto& positions = molecule.atomPositions3d();
+  for (Index i = 0; i < atomCount; ++i) {
+    const Vector3& pos = positions[i];
+    for (unsigned int j = 0; j < 3; ++j)
+      geometry.push_back(pos[j] * ANGSTROM_TO_BOHR);
+  }
+  root["geometry"] = geometry;
+
+  // both of these are typed as floats by the specification, and the
+  // multiplicity must be positive
+  root["molecular_charge"] = static_cast<double>(molecule.totalCharge());
+  root["molecular_multiplicity"] =
+    static_cast<double>(std::max<int>(molecule.totalSpinMultiplicity(), 1));
+
+  // connectivity is optional, and must be omitted rather than left empty
+  // each entry is (index a, index b, bond order) with zero-based indices
+  if (molecule.bondCount() > 0) {
+    ordered_json connectivity = ordered_json::array();
+    const auto& bondPairs = molecule.bondPairs();
+    const auto& bondOrders = molecule.bondOrders();
+    for (Index i = 0; i < molecule.bondCount(); ++i) {
+      // the specification limits bond orders to the range [0, 5]
+      double order = std::min(static_cast<double>(bondOrders[i]), 5.0);
+      connectivity.push_back(ordered_json::array(
+        { bondPairs[i].first, bondPairs[i].second, order }));
+    }
+    root["connectivity"] = connectivity;
+  }
+
+  // the coordinates come from the user, so ask that they be left alone rather
+  // than re-centered and re-oriented by the consumer
+  root["fix_com"] = true;
+  root["fix_orientation"] = true;
+
+  root["provenance"] = { { "creator", "Avogadro" },
+                         { "version", pep440Version(Avogadro::version()) },
+                         { "routine", "Avogadro::QuantumIO::QCSchema" } };
+
+  out << std::setw(2) << root << '\n';
+
+  return out.good();
 }
 
 } // namespace Avogadro::QuantumIO

--- a/avogadro/quantumio/qcschema.cpp
+++ b/avogadro/quantumio/qcschema.cpp
@@ -93,9 +93,13 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
   }
 
   // check for 'schema_name'
-  if (root.find("schema_name") == root.end() ||
-      (root["schema_name"].get<std::string>() != "QC_JSON" &&
-       root["schema_name"].get<std::string>() != "qcschema_molecule")) {
+  const auto schema = root.find("schema_name");
+  if (schema == root.end() || !schema->is_string()) {
+    appendError("Error: Input is not a QC_JSON object.");
+    return false;
+  }
+  const std::string schemaName = schema->get<std::string>();
+  if (schemaName != "QC_JSON" && schemaName != "qcschema_molecule") {
     appendError("Error: Input is not a QC_JSON object.");
     return false;
   }
@@ -103,8 +107,7 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
   // "qcschema_molecule" is the MolSSI specification, while "QC_JSON" is the
   // older WebMO variant. The MolSSI form uses bohr and zero-based connectivity
   // indices, the WebMO one uses Angstroms and one-based indices.
-  const bool molssi =
-    root["schema_name"].get<std::string>() == "qcschema_molecule";
+  const bool molssi = schemaName == "qcschema_molecule";
   if (molssi) {
     coordinateScale = BOHR_TO_ANGSTROM;
   }
@@ -120,6 +123,10 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
   unsigned char atomicNum(0);
   for (const auto& element : elements) {
     // convert from a string to atomic number
+    if (!element.is_string()) {
+      appendError("Error: \"symbols\" array must contain element symbols.");
+      return false;
+    }
     std::string symbol = element.get<std::string>();
     atomicNum = Elements::atomicNumberFromSymbol(symbol);
 
@@ -145,6 +152,10 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     appendError("Error: \"geometry\" array has incorrect length.");
     return false;
   }
+  if (!isNumericArray(geometry)) {
+    appendError("Error: \"geometry\" array must be numeric.");
+    return false;
+  }
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     auto a = molecule.atom(i);
     Vector3 pos(geometry[3 * i], geometry[3 * i + 1], geometry[3 * i + 2]);
@@ -161,12 +172,17 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     for (const auto& bond : connectivity) {
       if (!bond.is_array() || bond.size() < 3)
         continue;
+      // the endpoints must be integers, the order may be fractional
+      if (!bond[0].is_number_integer() || !bond[1].is_number_integer() ||
+          !bond[2].is_number())
+        continue;
       Index start = bond[0].get<Index>() - indexOffset;
       Index end = bond[1].get<Index>() - indexOffset;
       if (start >= atomCount || end >= atomCount)
         continue;
-      auto order =
-        static_cast<unsigned char>(std::lround(bond[2].get<double>()));
+      // the specification limits bond orders to the range [0, 5]
+      double bondOrder = std::min(std::max(bond[2].get<double>(), 0.0), 5.0);
+      auto order = static_cast<unsigned char>(std::lround(bondOrder));
       molecule.addBond(start, end, order);
     }
   } else {
@@ -205,7 +221,7 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     if (properties.find("dipole_moment") != properties.end()) {
       // read the numeric array
       json dipole = properties["dipole_moment"];
-      if (dipole.size() == 3) {
+      if (isNumericArray(dipole) && dipole.size() == 3) {
         Core::Variant dipoleMoment(dipole[0].get<float>(),
                                    dipole[1].get<float>(),
                                    dipole[2].get<float>());
@@ -233,7 +249,8 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
     if (properties.find("total_energy") != properties.end() &&
         properties["total_energy"].is_object()) {
       json totalEnergy = properties["total_energy"];
-      if (totalEnergy.find("value") != totalEnergy.end())
+      if (totalEnergy.find("value") != totalEnergy.end() &&
+          totalEnergy["value"].is_number())
         molecule.setData("totalEnergy", totalEnergy["value"].get<float>());
     }
 
@@ -245,7 +262,7 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
 
       // energies should be a numeric array
       if (sequence.find("energies") != sequence.end() &&
-          sequence["energies"].is_array()) {
+          isNumericArray(sequence["energies"])) {
         std::vector<double> energies;
         for (unsigned int i = 0; i < sequence["energies"].size(); ++i) {
           energies.push_back(sequence["energies"][i].get<float>());
@@ -258,7 +275,8 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
         for (unsigned int i = 0; i < coordSets.size(); ++i) {
           Array<Vector3> setArray;
           json set = coordSets[i];
-          if (isNumericArray(set)) {
+          // every step has to match the atoms we read above
+          if (isNumericArray(set) && set.size() == atomCount * 3) {
             for (unsigned int j = 0; j < set.size() / 3; ++j) {
               setArray.push_back(
                 Vector3(set[3 * j], set[3 * j + 1], set[3 * j + 2]));
@@ -308,7 +326,8 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
       json displacements = vib["displacement"];
       if (displacements.is_array()) {
         for (auto arr : displacements) {
-          if (isNumericArray(arr)) {
+          // each mode is a displacement vector for every atom
+          if (isNumericArray(arr) && arr.size() == atomCount * 3) {
             Array<Vector3> mode;
             mode.resize(arr.size() / 3);
             double* ptr = &mode[0][0];
@@ -346,7 +365,8 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
       json excitedStates = properties["excited_states"];
       // check units (defaults to nm)
       std::string units = "nm";
-      if (excitedStates.find("units") != excitedStates.end()) {
+      if (excitedStates.find("units") != excitedStates.end() &&
+          excitedStates["units"].is_string()) {
         units = excitedStates["units"].get<std::string>();
       }
       std::vector<double> energies;
@@ -357,21 +377,23 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
         json transition_energies = excitedStates["transition_energies"];
         if (isNumericArray(transition_energies)) {
           for (auto& i : transition_energies) {
-            if (units == "nm")
+            double value = static_cast<double>(i);
+            if (units == "nm") {
               // convert to eV, i.e. eV = 1239.8 / wavelength
-              energies.push_back(1239.841984 / static_cast<double>(i));
-            else if (units == "cm^-1")
-              energies.push_back(static_cast<double>(i) / 8065.544);
+              if (value != 0.0)
+                energies.push_back(1239.841984 / value);
+            } else if (units == "cm^-1")
+              energies.push_back(value / 8065.544);
             else if (units == "eV")
-              energies.push_back(static_cast<double>(i));
+              energies.push_back(value);
           }
         }
       }
       if (excitedStates.find("intensities") != excitedStates.end() &&
           excitedStates["intensities"].is_array()) {
-        json intensities = excitedStates["intensities"];
-        if (isNumericArray(intensities)) {
-          for (auto& i : intensities) {
+        json jsonIntensities = excitedStates["intensities"];
+        if (isNumericArray(jsonIntensities)) {
+          for (auto& i : jsonIntensities) {
             intensities.push_back(static_cast<double>(i));
           }
         }
@@ -409,11 +431,13 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
         }
       }
 
-      MatrixX nmrData(nmrShiftsIsotropic.size(), 1);
-      for (std::size_t i = 0; i < nmrShiftsIsotropic.size(); ++i) {
-        nmrData(i, 0) = nmrShiftsIsotropic[i];
+      if (!nmrShiftsIsotropic.empty()) {
+        MatrixX nmrData(nmrShiftsIsotropic.size(), 1);
+        for (std::size_t i = 0; i < nmrShiftsIsotropic.size(); ++i) {
+          nmrData(i, 0) = nmrShiftsIsotropic[i];
+        }
+        molecule.setSpectra("NMR", nmrData);
       }
-      molecule.setSpectra("NMR", nmrData);
     }
 
     // todo

--- a/avogadro/quantumio/qcschema.cpp
+++ b/avogadro/quantumio/qcschema.cpp
@@ -69,6 +69,8 @@ std::vector<std::string> QCSchema::mimeTypes() const
 
 bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
 {
+  float coordinateScale = 1.0; // default to Angstroms
+
   // This should be JSON so look for key attributes
   json root;
   try {
@@ -85,9 +87,16 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
 
   // check for 'schema_name'
   if (root.find("schema_name") == root.end() ||
-      root["schema_name"].get<std::string>() != "QC_JSON") {
+      (root["schema_name"].get<std::string>() != "QC_JSON" &&
+       root["schema_name"].get<std::string>() != "qcschema_molecule")) {
     appendError("Error: Input is not a QC_JSON object.");
     return false;
+  }
+
+  // if the schema_name is qcschema_molecule, then the coordinates are in
+  // bohr
+  if (root["schema_name"].get<std::string>() == "qcschema_molecule") {
+    coordinateScale = BOHR_TO_ANGSTROM;
   }
 
   // get the elements
@@ -127,8 +136,8 @@ bool QCSchema::read(std::istream& in, Core::Molecule& molecule)
   }
   for (Index i = 0; i < molecule.atomCount(); ++i) {
     auto a = molecule.atom(i);
-    a.setPosition3d(
-      Vector3(geometry[3 * i], geometry[3 * i + 1], geometry[3 * i + 2]));
+    Vector3 pos(geometry[3 * i], geometry[3 * i + 1], geometry[3 * i + 2]);
+    a.setPosition3d(pos * coordinateScale);
   }
 
   // check for (optional) connectivity

--- a/avogadro/quantumio/qcschema.h
+++ b/avogadro/quantumio/qcschema.h
@@ -26,7 +26,7 @@ public:
 
   Operations supportedOperations() const override
   {
-    return Read | File | Stream | String;
+    return ReadWrite | File | Stream | String;
   }
 
   FileFormat* newInstance() const override { return new QCSchema; }
@@ -37,18 +37,24 @@ public:
     return "MolSSI QCSchema JSON format.";
   }
 
-  std::string specificationUrl() const override { return ""; }
+  std::string specificationUrl() const override
+  {
+    return "https://molssi-qc-schema.readthedocs.io/en/latest/"
+           "spec_components.html";
+  }
 
   std::vector<std::string> fileExtensions() const override;
   std::vector<std::string> mimeTypes() const override;
 
   [[nodiscard]] bool read(std::istream& in, Core::Molecule& molecule) override;
+
+  /**
+   * Write the molecule as a QCSchema "qcschema_molecule" (schema version 3)
+   * JSON object. Coordinates are converted to bohr, and connectivity is
+   * written with zero-based atom indices as required by the specification.
+   */
   [[nodiscard]] bool write(std::ostream& out,
-                           const Core::Molecule& molecule) override
-  {
-    // Empty, as we do not currently write QC_SCHEMA files.
-    return false;
-  }
+                           const Core::Molecule& molecule) override;
 };
 
 } // namespace QuantumIO

--- a/tests/quantumio/CMakeLists.txt
+++ b/tests/quantumio/CMakeLists.txt
@@ -5,8 +5,8 @@ set(tests
   gaussiansettools
   molden
   orca
+  qcschema
   # TODO
-  # qcschema
   # GAMESS US
   # GAMESS UK
   # NWChem log
@@ -39,7 +39,7 @@ message(STATUS "Test source files: ${testSrcs}")
 # Add a single executable for all of our tests.
 add_executable(AvogadroQuantumIOTests ${testSrcs})
 target_link_libraries(AvogadroQuantumIOTests Avogadro::IO Avogadro::QuantumIO
-  ${GTEST_BOTH_LIBRARIES} ${EXTRA_LINK_LIB})
+  nlohmann_json::nlohmann_json ${GTEST_BOTH_LIBRARIES} ${EXTRA_LINK_LIB})
 
 # Now add all of the tests, using the gtest_filter argument so that only those
 # cases are run in each test invocation.

--- a/tests/quantumio/qcschematest.cpp
+++ b/tests/quantumio/qcschematest.cpp
@@ -8,27 +8,190 @@
 #include <gtest/gtest.h>
 
 #include <avogadro/core/atom.h>
+#include <avogadro/core/avogadrocore.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/vector.h>
 
 #include <avogadro/quantumio/qcschema.h>
 
+#include <nlohmann/json.hpp>
+
 #include <fstream>
 #include <sstream>
 #include <string>
 
+using Avogadro::Index;
 using Avogadro::Vector3;
 using Avogadro::Core::Atom;
 using Avogadro::Core::Molecule;
 using Avogadro::Io::FileFormat;
 using Avogadro::QuantumIO::QCSchema;
 
-// does the basic read work?
-TEST(QCSchemaTest, basicRead)
+using json = nlohmann::json;
+
+namespace {
+
+// cyclohexane (twist-boat), written by WebMO as the older "QC_JSON" variant
+const char* webmoFile = AVOGADRO_DATA "/data/qcschema/output_json_1734401.json";
+
+// build a water molecule directly, so the tests do not depend on a reader
+Molecule water()
+{
+  Molecule molecule;
+  molecule.addAtom(8).setPosition3d(Vector3(0.0, 0.0, 0.117));
+  molecule.addAtom(1).setPosition3d(Vector3(0.0, 0.757, -0.469));
+  molecule.addAtom(1).setPosition3d(Vector3(0.0, -0.757, -0.469));
+  molecule.addBond(0, 1, 1);
+  molecule.addBond(0, 2, 1);
+  return molecule;
+}
+
+} // namespace
+
+// the WebMO variant is in Angstroms with one-based connectivity indices
+TEST(QCSchemaTest, readWebMO)
 {
   QCSchema qcs;
   Molecule molecule;
-  EXPECT_TRUE(qcs.readFile(
-    AVOGADRO_DATA "/data/qcschema/output_json_1734290.json", molecule));
-  ASSERT_EQ(qcs.error(), std::string());
+  ASSERT_TRUE(qcs.readFile(webmoFile, molecule));
+  EXPECT_EQ(qcs.error(), std::string());
+
+  EXPECT_EQ(molecule.atomCount(), static_cast<Index>(18));
+  EXPECT_EQ(molecule.bondCount(), static_cast<Index>(18));
+  // the first bond is written as [1, 2, 1], and those one-based indices must
+  // become the first and second atoms
+  EXPECT_EQ(molecule.bond(0).atom1().index(), static_cast<Index>(0));
+  EXPECT_EQ(molecule.bond(0).atom2().index(), static_cast<Index>(1));
+  EXPECT_EQ(molecule.bond(0).order(), 1);
+  // coordinates are already in Angstroms, so they are used as-is
+  EXPECT_NEAR(molecule.atomPositions3d()[0].x(), 0.661709, 1e-6);
+  EXPECT_NEAR(molecule.atomPositions3d()[0].y(), -1.220277, 1e-6);
+}
+
+// the MolSSI variant is in bohr with zero-based connectivity indices
+TEST(QCSchemaTest, readMolSSI)
+{
+  const char* input = R"({
+    "schema_name": "qcschema_molecule",
+    "schema_version": 3,
+    "symbols": ["O", "H", "H"],
+    "geometry": [0.0, 0.0, 0.2211, 0.0, 1.4306, -0.8863,
+                 0.0, -1.4306, -0.8863],
+    "molecular_charge": 0.0,
+    "molecular_multiplicity": 1.0,
+    "connectivity": [[0, 1, 1.0], [0, 2, 1.0]]
+  })";
+
+  QCSchema qcs;
+  Molecule molecule;
+  ASSERT_TRUE(qcs.readString(input, molecule));
+  EXPECT_EQ(qcs.error(), std::string());
+
+  ASSERT_EQ(molecule.atomCount(), static_cast<Index>(3));
+  ASSERT_EQ(molecule.bondCount(), static_cast<Index>(2));
+  EXPECT_EQ(molecule.bond(0).atom1().index(), static_cast<Index>(0));
+  EXPECT_EQ(molecule.bond(0).atom2().index(), static_cast<Index>(1));
+  // 0.2211 bohr converted to Angstroms
+  EXPECT_NEAR(molecule.atomPositions3d()[0].z(),
+              0.2211 * Avogadro::BOHR_TO_ANGSTROM, 1e-6);
+}
+
+// the written file must conform to the MolSSI qcschema_molecule specification
+TEST(QCSchemaTest, write)
+{
+  Molecule molecule = water();
+  molecule.setData("name", std::string("water"));
+
+  QCSchema qcs;
+  std::string output;
+  ASSERT_TRUE(qcs.writeString(output, molecule));
+
+  json root = json::parse(output, nullptr, false);
+  ASSERT_FALSE(root.is_discarded());
+
+  EXPECT_EQ(root["schema_name"], "qcschema_molecule");
+  EXPECT_EQ(root["schema_version"], 3);
+  EXPECT_EQ(root["name"], "water");
+  EXPECT_EQ(root["symbols"], json({ "O", "H", "H" }));
+
+  // geometry is a flat array of 3 * nat coordinates in bohr
+  ASSERT_TRUE(root["geometry"].is_array());
+  ASSERT_EQ(root["geometry"].size(), 9u);
+  EXPECT_NEAR(root["geometry"][2].get<double>(),
+              0.117 / Avogadro::BOHR_TO_ANGSTROM, 1e-8);
+
+  EXPECT_DOUBLE_EQ(root["molecular_charge"].get<double>(), 0.0);
+  EXPECT_DOUBLE_EQ(root["molecular_multiplicity"].get<double>(), 1.0);
+
+  // connectivity indices are zero-based
+  ASSERT_EQ(root["connectivity"].size(), 2u);
+  EXPECT_EQ(root["connectivity"][0], json({ 0, 1, 1.0 }));
+  EXPECT_EQ(root["connectivity"][1], json({ 0, 2, 1.0 }));
+
+  EXPECT_EQ(root["provenance"]["creator"], "Avogadro");
+}
+
+// connectivity has a minimum length of one, so it must be left out entirely
+TEST(QCSchemaTest, writeWithoutBonds)
+{
+  Molecule molecule;
+  molecule.addAtom(10).setPosition3d(Vector3(0.0, 0.0, 0.0));
+
+  QCSchema qcs;
+  std::string output;
+  ASSERT_TRUE(qcs.writeString(output, molecule));
+
+  json root = json::parse(output, nullptr, false);
+  ASSERT_FALSE(root.is_discarded());
+  EXPECT_EQ(root.find("connectivity"), root.end());
+}
+
+// custom elements have no symbol, so they cannot be represented
+TEST(QCSchemaTest, writeCustomElementFails)
+{
+  Molecule molecule;
+  molecule.addAtom(Avogadro::CustomElementMin).setPosition3d(Vector3::Zero());
+
+  QCSchema qcs;
+  std::string output;
+  EXPECT_FALSE(qcs.writeString(output, molecule));
+  EXPECT_NE(qcs.error(), std::string());
+}
+
+TEST(QCSchemaTest, writeEmptyFails)
+{
+  Molecule molecule;
+  QCSchema qcs;
+  std::string output;
+  EXPECT_FALSE(qcs.writeString(output, molecule));
+}
+
+// reading back what we wrote must give the same molecule
+TEST(QCSchemaTest, roundTrip)
+{
+  QCSchema reader;
+  Molecule original;
+  ASSERT_TRUE(reader.readFile(webmoFile, original));
+
+  QCSchema writer;
+  std::string output;
+  ASSERT_TRUE(writer.writeString(output, original));
+
+  QCSchema rereader;
+  Molecule result;
+  ASSERT_TRUE(rereader.readString(output, result));
+
+  ASSERT_EQ(result.atomCount(), original.atomCount());
+  ASSERT_EQ(result.bondCount(), original.bondCount());
+  for (Index i = 0; i < original.atomCount(); ++i) {
+    EXPECT_EQ(result.atom(i).atomicNumber(), original.atom(i).atomicNumber());
+    EXPECT_LT(
+      (result.atomPositions3d()[i] - original.atomPositions3d()[i]).norm(),
+      1e-8);
+  }
+  for (Index i = 0; i < original.bondCount(); ++i) {
+    EXPECT_EQ(result.bond(i).atom1().index(), original.bond(i).atom1().index());
+    EXPECT_EQ(result.bond(i).atom2().index(), original.bond(i).atom2().index());
+    EXPECT_EQ(result.bond(i).order(), original.bond(i).order());
+  }
 }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading and writing MolSSI QCSchema molecule files.
  * Added automatic handling of coordinate units, connectivity indexing, charge, spin multiplicity, and molecule names.
  * Added a link to the official QCSchema specification.

* **Bug Fixes**
  * Improved validation and handling of connectivity and schema metadata.
  * Added reliable provenance version formatting when exporting QCSchema data.

* **Tests**
  * Expanded coverage for reading, writing, validation, and round-trip conversion of QCSchema molecules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->