### PR TITLE
Add internal support for SMILES

### DIFF
--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -66,6 +66,7 @@ avogadro_headers(Core
   slaterset.h
   slatersettools.h
   spacegroups.h
+  stereo.h
   symbolatomtyper.h
   unitcell.h
   variant.h
@@ -101,6 +102,7 @@ target_sources(Core PRIVATE
   slaterset.cpp
   slatersettools.cpp
   spacegroups.cpp
+  stereo.cpp
   symbolatomtyper.cpp
   unitcell.cpp
   variantmap.cpp

--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -53,6 +53,7 @@ avogadro_headers(Core
   gaussiansettools.h
   graph.h
   internalcoordinates.h
+  kekulize.h
   layer.h
   layermanager.h
   mesh.h
@@ -89,6 +90,7 @@ target_sources(Core PRIVATE
   gaussiansettools.cpp
   graph.cpp
   internalcoordinates.cpp
+  kekulize.cpp
   layer.cpp
   layermanager.cpp
   mesh.cpp

--- a/avogadro/core/CMakeLists.txt
+++ b/avogadro/core/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(Headers PUBLIC
   FILES
     angletools.h
     angleiterator.h
+  aromaticity.h
     array.h
     avogadrocore.h
     color3f.h
@@ -77,6 +78,7 @@ avogadro_headers(Core
 
 target_sources(Core PRIVATE
   angleiterator.cpp
+  aromaticity.cpp
   atomutilities.cpp
   coordinateblockgenerator.cpp
   crystaltools.cpp

--- a/avogadro/core/aromaticity.cpp
+++ b/avogadro/core/aromaticity.cpp
@@ -1,0 +1,286 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "aromaticity.h"
+
+#include "graph.h"
+#include "molecule.h"
+#include "ringperceiver.h"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+
+namespace Avogadro::Core {
+
+namespace {
+
+/** What the atom's double bonds, if any, are doing. */
+struct BondContext
+{
+  bool ringDouble = false; //!< Double bond to another atom in the same ring.
+  bool exocyclicDouble = false; //!< Double bond leaving the ring.
+  Index connections = 0;
+};
+
+/**
+ * Pi electrons this atom contributes to a ring it belongs to.
+ *
+ * Hand-transcribed chemistry; each case names the structure it is there for.
+ * Returns NotAromaticCandidate when the atom has no p orbital to lend, which
+ * disqualifies every ring it is in.
+ */
+signed char contribution(unsigned char atomicNumber, signed char charge,
+                         const BondContext& context)
+{
+  switch (atomicNumber) {
+    case 6: // C
+      if (charge == 0) {
+        if (context.ringDouble)
+          return 1; // benzene
+        if (context.exocyclicDouble)
+          return 0; // the carbonyl of 2-pyridone, or of tropone
+        return NotAromaticCandidate; // saturated, as in cyclohexane
+      }
+      if (charge == -1)
+        return context.ringDouble ? 1 : 2; // cyclopentadienyl anion
+      if (charge == 1)
+        return context.ringDouble ? 1 : 0; // tropylium
+      return NotAromaticCandidate;
+
+    case 7:  // N
+    case 15: // P
+      if (charge == 0) {
+        if (context.ringDouble)
+          return 1; // pyridine
+        if (context.exocyclicDouble)
+          return 0; // an N-oxide drawn with a double bond
+        if (context.connections == 3)
+          return 2; // pyrrole
+        return NotAromaticCandidate;
+      }
+      if (charge == 1) {
+        if (context.ringDouble)
+          return 1; // pyridinium
+        if (context.connections == 3)
+          return 2;
+        return NotAromaticCandidate; // quaternary, no lone pair left
+      }
+      if (charge == -1)
+        return 2; // deprotonated pyrrole
+      return NotAromaticCandidate;
+
+    case 8: // O
+      if (charge == 0)
+        return context.connections == 2 ? 2 : NotAromaticCandidate; // furan
+      if (charge == 1)
+        return context.ringDouble ? 1 : 0; // pyrylium
+      return NotAromaticCandidate;
+
+    case 16: // S
+    case 34: // Se
+      if (charge == 0) {
+        if (context.exocyclicDouble)
+          return 0; // a sulfoxide or sulfone in the ring
+        return context.connections == 2 ? 2 : NotAromaticCandidate; // thiophene
+      }
+      if (charge == 1)
+        return context.ringDouble ? 1 : 2;
+      return NotAromaticCandidate;
+
+    default:
+      // Everything else, boron included. Borazine comes out non-aromatic,
+      // which is the answer the default model is meant to give and which also
+      // keeps it from depending on how the input drew the B-N bonds.
+      return NotAromaticCandidate;
+  }
+}
+
+bool huckel(int piElectrons)
+{
+  // 4n+2 for n >= 0.
+  return piElectrons >= 2 && ((piElectrons - 2) % 4) == 0;
+}
+
+} // namespace
+
+AromaticityPerceiver::AromaticityPerceiver(const Molecule* m, Model model)
+  : m_molecule(m), m_model(model), m_perceived(false)
+{
+}
+
+void AromaticityPerceiver::setMolecule(const Molecule* m)
+{
+  m_molecule = m;
+  m_perceived = false;
+  m_ringSystems.clear();
+  m_piContributions.clear();
+  m_aromaticAtoms.clear();
+  m_aromaticBonds.clear();
+}
+
+const std::vector<std::vector<Index>>& AromaticityPerceiver::ringSystems() const
+{
+  perceive();
+  return m_ringSystems;
+}
+
+const std::vector<signed char>& AromaticityPerceiver::piContributions() const
+{
+  perceive();
+  return m_piContributions;
+}
+
+const std::vector<bool>& AromaticityPerceiver::aromaticAtoms() const
+{
+  perceive();
+  return m_aromaticAtoms;
+}
+
+const std::vector<bool>& AromaticityPerceiver::aromaticBonds() const
+{
+  perceive();
+  return m_aromaticBonds;
+}
+
+void AromaticityPerceiver::perceive() const
+{
+  if (m_perceived)
+    return;
+  m_perceived = true;
+
+  if (m_molecule == nullptr)
+    return;
+
+  const Index atomCount = m_molecule->atomCount();
+  const Index bondCount = m_molecule->bondCount();
+  const Array<std::pair<Index, Index>>& pairs = m_molecule->bondPairs();
+  const Array<unsigned char>& orders = m_molecule->bondOrders();
+  const Array<unsigned char>& numbers = m_molecule->atomicNumbers();
+
+  m_piContributions.assign(atomCount, NotAromaticCandidate);
+  m_aromaticAtoms.assign(atomCount, false);
+  m_aromaticBonds.assign(bondCount, false);
+  if (atomCount == 0)
+    return;
+
+  RingPerceiver perceiver(m_molecule);
+  const std::vector<std::vector<size_t>>& rings = perceiver.rings();
+  if (rings.empty())
+    return;
+
+  // Which bonds close a ring. Every bond between atoms adjacent in some
+  // smallest ring qualifies, which is what separates a double bond inside the
+  // ring from one leaving it.
+  std::vector<bool> ringBond(bondCount, false);
+  std::map<std::pair<Index, Index>, Index> bondLookup;
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    const std::pair<Index, Index>& ends = pairs[bond];
+    bondLookup[{ std::min(ends.first, ends.second),
+                 std::max(ends.first, ends.second) }] = bond;
+  }
+  const auto findBond = [&](Index a, Index b) -> Index {
+    const auto it = bondLookup.find({ std::min(a, b), std::max(a, b) });
+    return it == bondLookup.end() ? MaxIndex : it->second;
+  };
+
+  for (const std::vector<size_t>& ring : rings) {
+    for (size_t i = 0; i < ring.size(); ++i) {
+      const Index bond = findBond(ring[i], ring[(i + 1) % ring.size()]);
+      if (bond != MaxIndex)
+        ringBond[bond] = true;
+    }
+  }
+
+  // Per-atom pi contribution.
+  std::vector<BondContext> context(atomCount);
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    const std::pair<Index, Index>& ends = pairs[bond];
+    ++context[ends.first].connections;
+    ++context[ends.second].connections;
+    if (orders[bond] != 2)
+      continue;
+    if (ringBond[bond]) {
+      context[ends.first].ringDouble = true;
+      context[ends.second].ringDouble = true;
+    } else {
+      context[ends.first].exocyclicDouble = true;
+      context[ends.second].exocyclicDouble = true;
+    }
+  }
+
+  std::vector<bool> inRing(atomCount, false);
+  for (const std::vector<size_t>& ring : rings)
+    for (size_t atom : ring)
+      inRing[atom] = true;
+
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    if (!inRing[atom])
+      continue;
+    m_piContributions[atom] = contribution(
+      numbers[atom], m_molecule->formalCharge(atom), context[atom]);
+  }
+
+  // Fused ring systems: connected components of the ring bonds.
+  std::vector<Index> system(atomCount, MaxIndex);
+  Index systemCount = 0;
+  for (Index seed = 0; seed < atomCount; ++seed) {
+    if (!inRing[seed] || system[seed] != MaxIndex)
+      continue;
+    std::vector<Index> queue(1, seed);
+    system[seed] = systemCount;
+    m_ringSystems.emplace_back();
+    while (!queue.empty()) {
+      const Index atom = queue.back();
+      queue.pop_back();
+      m_ringSystems.back().push_back(atom);
+      for (Index bond : m_molecule->graph().edges(atom)) {
+        if (!ringBond[bond])
+          continue;
+        const std::pair<Index, Index>& ends = pairs[bond];
+        const Index other = (ends.first == atom) ? ends.second : ends.first;
+        if (system[other] == MaxIndex) {
+          system[other] = systemCount;
+          queue.push_back(other);
+        }
+      }
+    }
+    ++systemCount;
+  }
+
+  // A set of atoms is aromatic when every one can contribute and the total
+  // satisfies Huckel. Individual rings are tested first, then whole fused
+  // systems, which is what catches azulene.
+  std::set<Index> aromatic;
+  const auto test = [&](const std::vector<Index>& atoms) {
+    int total = 0;
+    for (Index atom : atoms) {
+      if (m_piContributions[atom] == NotAromaticCandidate)
+        return;
+      total += m_piContributions[atom];
+    }
+    if (huckel(total))
+      aromatic.insert(atoms.begin(), atoms.end());
+  };
+
+  for (const std::vector<size_t>& ring : rings)
+    test(std::vector<Index>(ring.begin(), ring.end()));
+  for (const std::vector<Index>& fused : m_ringSystems) {
+    if (fused.size() > 1)
+      test(fused);
+  }
+
+  for (Index atom : aromatic)
+    m_aromaticAtoms[atom] = true;
+
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    const std::pair<Index, Index>& ends = pairs[bond];
+    m_aromaticBonds[bond] = ringBond[bond] && m_aromaticAtoms[ends.first] &&
+                            m_aromaticAtoms[ends.second];
+  }
+}
+
+} // namespace Avogadro::Core

--- a/avogadro/core/aromaticity.cpp
+++ b/avogadro/core/aromaticity.cpp
@@ -6,6 +6,7 @@
 #include "aromaticity.h"
 
 #include "graph.h"
+#include "mdlvalence_p.h"
 #include "molecule.h"
 #include "ringperceiver.h"
 
@@ -21,7 +22,8 @@ struct BondContext
 {
   bool ringDouble = false; //!< Double bond to another atom in the same ring.
   bool exocyclicDouble = false; //!< Double bond leaving the ring.
-  Index connections = 0;
+  Index connections = 0;        //!< Neighbours, implicit hydrogens included.
+  unsigned int orderSum = 0;    //!< Sum of the orders of the explicit bonds.
 };
 
 /**
@@ -252,6 +254,8 @@ void AromaticityPerceiver::perceive() const
     const std::pair<Index, Index>& ends = pairs[bond];
     ++context[ends.first].connections;
     ++context[ends.second].connections;
+    context[ends.first].orderSum += orders[bond];
+    context[ends.second].orderSum += orders[bond];
     if (orders[bond] != 2)
       continue;
     if (ringBond[bond]) {
@@ -274,8 +278,21 @@ void AromaticityPerceiver::perceive() const
   for (Index atom = 0; atom < atomCount; ++atom) {
     if (!inRing[atom])
       continue;
-    m_piContributions[atom] = contribution(
-      numbers[atom], m_molecule->formalCharge(atom), context[atom]);
+
+    // Hydrogens are not always present as atoms -- a structure imported in two
+    // dimensions, or from a file that omits them, carries them implicitly. The
+    // contribution rules ask how many neighbours an atom has, so count those
+    // too, or pyrrole read without its N-H would not be aromatic. An atom whose
+    // hydrogens are already explicit is unaffected: its bonds account for the
+    // whole valence, leaving nothing implied.
+    const signed char charge = m_molecule->formalCharge(atom);
+    const unsigned int valence =
+      atomValence(numbers[atom], charge, context[atom].connections);
+    if (valence > context[atom].orderSum)
+      context[atom].connections += valence - context[atom].orderSum;
+
+    m_piContributions[atom] =
+      contribution(numbers[atom], charge, context[atom]);
   }
 
   // Fused ring systems: connected components of the ring bonds.

--- a/avogadro/core/aromaticity.cpp
+++ b/avogadro/core/aromaticity.cpp
@@ -10,8 +10,6 @@
 #include "ringperceiver.h"
 
 #include <algorithm>
-#include <map>
-#include <set>
 #include <utility>
 
 namespace Avogadro::Core {
@@ -105,6 +103,83 @@ bool huckel(int piElectrons)
   return piElectrons >= 2 && ((piElectrons - 2) % 4) == 0;
 }
 
+/**
+ * Mark every bond that lies on a cycle, by finding the bridges: a bond is on a
+ * cycle exactly when removing it would not disconnect its two ends.
+ *
+ * This is the iterative form of Tarjan's algorithm, in O(atoms + bonds). It
+ * replaces asking RingPerceiver, which is far more expensive and answers a
+ * harder question -- see the note on ring systems in perceive().
+ */
+std::vector<bool> findRingBonds(const Molecule& mol)
+{
+  const Index atomCount = mol.atomCount();
+  const Core::Array<std::pair<Index, Index>>& pairs = mol.bondPairs();
+  std::vector<bool> ringBond(mol.bondCount(), false);
+
+  std::vector<Index> discovery(atomCount, MaxIndex);
+  std::vector<Index> low(atomCount, MaxIndex);
+  Index timer = 0;
+
+  // Depth first, with an explicit stack: molecules can be long enough that
+  // recursing once per atom would overflow it.
+  struct Frame
+  {
+    Index atom;
+    Index parentBond;
+    Index next; //!< Cursor into this atom's incident bonds.
+  };
+  std::vector<Frame> stack;
+  std::vector<std::vector<size_t>> incident(atomCount);
+  for (Index bond = 0; bond < mol.bondCount(); ++bond) {
+    incident[pairs[bond].first].push_back(bond);
+    incident[pairs[bond].second].push_back(bond);
+  }
+
+  for (Index root = 0; root < atomCount; ++root) {
+    if (discovery[root] != MaxIndex)
+      continue;
+    discovery[root] = low[root] = timer++;
+    stack.push_back(Frame{ root, MaxIndex, 0 });
+
+    while (!stack.empty()) {
+      Frame& frame = stack.back();
+      if (frame.next >= incident[frame.atom].size()) {
+        const Index atom = frame.atom;
+        const Index parentBond = frame.parentBond;
+        stack.pop_back();
+        if (!stack.empty()) {
+          const Index parent = stack.back().atom;
+          low[parent] = std::min(low[parent], low[atom]);
+          // A bridge is a tree bond whose subtree reaches no further back.
+          if (low[atom] <= discovery[parent] && parentBond != MaxIndex)
+            ringBond[parentBond] = true;
+        }
+        continue;
+      }
+
+      const Index bond = incident[frame.atom][frame.next++];
+      if (bond == frame.parentBond)
+        continue;
+      const std::pair<Index, Index>& ends = pairs[bond];
+      const Index other = (ends.first == frame.atom) ? ends.second : ends.first;
+      if (other == frame.atom)
+        continue;
+
+      if (discovery[other] != MaxIndex) {
+        // Back edge: it closes a cycle, so it and the tree path are ring bonds.
+        low[frame.atom] = std::min(low[frame.atom], discovery[other]);
+        ringBond[bond] = true;
+      } else {
+        discovery[other] = low[other] = timer++;
+        stack.push_back(Frame{ other, bond, 0 });
+      }
+    }
+  }
+
+  return ringBond;
+}
+
 } // namespace
 
 AromaticityPerceiver::AromaticityPerceiver(const Molecule* m, Model model)
@@ -167,33 +242,9 @@ void AromaticityPerceiver::perceive() const
   if (atomCount == 0)
     return;
 
-  RingPerceiver perceiver(m_molecule);
-  const std::vector<std::vector<size_t>>& rings = perceiver.rings();
-  if (rings.empty())
-    return;
-
-  // Which bonds close a ring. Every bond between atoms adjacent in some
-  // smallest ring qualifies, which is what separates a double bond inside the
-  // ring from one leaving it.
-  std::vector<bool> ringBond(bondCount, false);
-  std::map<std::pair<Index, Index>, Index> bondLookup;
-  for (Index bond = 0; bond < bondCount; ++bond) {
-    const std::pair<Index, Index>& ends = pairs[bond];
-    bondLookup[{ std::min(ends.first, ends.second),
-                 std::max(ends.first, ends.second) }] = bond;
-  }
-  const auto findBond = [&](Index a, Index b) -> Index {
-    const auto it = bondLookup.find({ std::min(a, b), std::max(a, b) });
-    return it == bondLookup.end() ? MaxIndex : it->second;
-  };
-
-  for (const std::vector<size_t>& ring : rings) {
-    for (size_t i = 0; i < ring.size(); ++i) {
-      const Index bond = findBond(ring[i], ring[(i + 1) % ring.size()]);
-      if (bond != MaxIndex)
-        ringBond[bond] = true;
-    }
-  }
+  // Which bonds lie on a cycle. This separates a double bond inside a ring
+  // from one leaving it, and bounds all the work below to the ring systems.
+  const std::vector<bool> ringBond = findRingBonds(*m_molecule);
 
   // Per-atom pi contribution.
   std::vector<BondContext> context(atomCount);
@@ -213,9 +264,12 @@ void AromaticityPerceiver::perceive() const
   }
 
   std::vector<bool> inRing(atomCount, false);
-  for (const std::vector<size_t>& ring : rings)
-    for (size_t atom : ring)
-      inRing[atom] = true;
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    if (ringBond[bond]) {
+      inRing[pairs[bond].first] = true;
+      inRing[pairs[bond].second] = true;
+    }
+  }
 
   for (Index atom = 0; atom < atomCount; ++atom) {
     if (!inRing[atom])
@@ -254,7 +308,6 @@ void AromaticityPerceiver::perceive() const
   // A set of atoms is aromatic when every one can contribute and the total
   // satisfies Huckel. Individual rings are tested first, then whole fused
   // systems, which is what catches azulene.
-  std::set<Index> aromatic;
   const auto test = [&](const std::vector<Index>& atoms) {
     int total = 0;
     for (Index atom : atoms) {
@@ -262,19 +315,54 @@ void AromaticityPerceiver::perceive() const
         return;
       total += m_piContributions[atom];
     }
-    if (huckel(total))
-      aromatic.insert(atoms.begin(), atoms.end());
+    if (!huckel(total))
+      return;
+    for (Index atom : atoms)
+      m_aromaticAtoms[atom] = true;
   };
 
-  for (const std::vector<size_t>& ring : rings)
-    test(std::vector<Index>(ring.begin(), ring.end()));
-  for (const std::vector<Index>& fused : m_ringSystems) {
-    if (fused.size() > 1)
-      test(fused);
+  // The ring bonds of each system, so the loop below does not rescan them all.
+  std::vector<std::vector<Index>> systemBonds(m_ringSystems.size());
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    if (!ringBond[bond])
+      continue;
+    const Index id = system[pairs[bond].first];
+    if (id != MaxIndex)
+      systemBonds[id].push_back(bond);
   }
 
-  for (Index atom : aromatic)
-    m_aromaticAtoms[atom] = true;
+  // RingPerceiver's cost climbs steeply with the size of the graph it is
+  // handed -- steeply enough to hang on a molecule with a dozen rings -- so
+  // give it one ring system at a time. A ring never spans two systems, so the
+  // answer is the same, and systems stay small even when molecules do not.
+  std::vector<Index> local(atomCount, MaxIndex);
+  std::vector<Index> ringAtoms;
+  for (Index id = 0; id < m_ringSystems.size(); ++id) {
+    const std::vector<Index>& fused = m_ringSystems[id];
+
+    Molecule subset;
+    for (Index atom : fused) {
+      local[atom] = subset.atomCount();
+      subset.addAtom(numbers[atom]);
+    }
+    for (Index bond : systemBonds[id]) {
+      const std::pair<Index, Index>& ends = pairs[bond];
+      subset.addBond(local[ends.first], local[ends.second], orders[bond]);
+    }
+
+    RingPerceiver perceiver(&subset);
+    for (const std::vector<size_t>& ring : perceiver.rings()) {
+      ringAtoms.clear();
+      for (size_t atom : ring)
+        ringAtoms.push_back(fused[atom]);
+      test(ringAtoms);
+    }
+    if (fused.size() > 1)
+      test(fused);
+
+    for (Index atom : fused)
+      local[atom] = MaxIndex;
+  }
 
   for (Index bond = 0; bond < bondCount; ++bond) {
     const std::pair<Index, Index>& ends = pairs[bond];

--- a/avogadro/core/aromaticity.h
+++ b/avogadro/core/aromaticity.h
@@ -17,7 +17,7 @@ namespace Avogadro::Core {
 class Molecule;
 
 /** Reported for an atom that cannot take part in an aromatic system. */
-const signed char NotAromaticCandidate = -1;
+constexpr signed char NotAromaticCandidate = -1;
 
 /**
  * @class AromaticityPerceiver aromaticity.h <avogadro/core/aromaticity.h>

--- a/avogadro/core/aromaticity.h
+++ b/avogadro/core/aromaticity.h
@@ -1,0 +1,97 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CORE_AROMATICITY_H
+#define AVOGADRO_CORE_AROMATICITY_H
+
+#include "avogadrocoreexport.h"
+
+#include "avogadrocore.h"
+
+#include <vector>
+
+namespace Avogadro::Core {
+
+class Molecule;
+
+/** Reported for an atom that cannot take part in an aromatic system. */
+const signed char NotAromaticCandidate = -1;
+
+/**
+ * @class AromaticityPerceiver aromaticity.h <avogadro/core/aromaticity.h>
+ * @brief Perceive which atoms and bonds belong to an aromatic system.
+ *
+ * Results are derived, not stored: like RingPerceiver, this takes a molecule
+ * and answers questions about it, leaving the molecule untouched. Perception
+ * runs on first use and is cached until setMolecule() is called again.
+ *
+ * The molecule is read in its Kekule form -- alternating single and double
+ * bond orders, which is how Avogadro stores structures -- so no kekulization
+ * is required or performed.
+ *
+ * Each candidate atom is assigned a pi electron contribution, and a ring is
+ * aromatic when its contributions sum to 4n+2 and every atom is a candidate.
+ * Fused rings are also tested as a whole, which is what makes azulene aromatic
+ * even though neither of its rings satisfies the rule alone.
+ *
+ * The contribution table is hand-transcribed chemistry and is the part of this
+ * class most in need of review; piContributions() exposes it directly so it
+ * can be tested without going through the ring arithmetic.
+ */
+class AVOGADROCORE_EXPORT AromaticityPerceiver
+{
+public:
+  /**
+   * Which set of rules to apply. Only Default exists so far; the enum is here
+   * so that adding a model later does not change this class's interface.
+   */
+  enum class Model
+  {
+    Default //!< Broadly the model RDKit applies by default.
+  };
+
+  explicit AromaticityPerceiver(const Molecule* m = nullptr,
+                                Model model = Model::Default);
+  ~AromaticityPerceiver() = default;
+
+  void setMolecule(const Molecule* m);
+  const Molecule* molecule() const { return m_molecule; }
+  Model model() const { return m_model; }
+
+  /**
+   * Atoms grouped into fused ring systems: the connected components of the
+   * ring bonds. Aromaticity is decided over these as well as over individual
+   * rings.
+   */
+  const std::vector<std::vector<Index>>& ringSystems() const;
+
+  /**
+   * Per-atom pi electron contribution, or NotAromaticCandidate for an atom
+   * that cannot be part of an aromatic system at all.
+   */
+  const std::vector<signed char>& piContributions() const;
+
+  /** One entry per atom, true where the atom is in an aromatic system. */
+  const std::vector<bool>& aromaticAtoms() const;
+
+  /** One entry per bond, true where both ends share an aromatic system. */
+  const std::vector<bool>& aromaticBonds() const;
+
+private:
+  void perceive() const;
+
+  const Molecule* m_molecule;
+  Model m_model;
+
+  mutable bool m_perceived;
+  mutable std::vector<std::vector<Index>> m_ringSystems;
+  mutable std::vector<signed char> m_piContributions;
+  mutable std::vector<bool> m_aromaticAtoms;
+  mutable std::vector<bool> m_aromaticBonds;
+};
+
+} // namespace Avogadro::Core
+
+#endif // AVOGADRO_CORE_AROMATICITY_H

--- a/avogadro/core/kekulize.cpp
+++ b/avogadro/core/kekulize.cpp
@@ -100,12 +100,17 @@ private:
       if (aromaticCount[atom] == 0)
         continue; // Not part of an aromatic system at all.
 
+      // "current" is a bond order sum, not a bond count: non-aromatic bonds
+      // contribute their real order, and each aromatic bond counts as 1.
+      // atomValence() takes that sum as its selector among the valences an
+      // element has (nitrogen's 3 and 5, sulfur's 2, 4 and 6).
       const unsigned int current = otherOrderSum[atom] + aromaticCount[atom];
       const unsigned int target =
         atomValence(numbers[atom], molecule.formalCharge(atom), current);
-      // An overbonded atom -- target < current, from bad input -- also fails
-      // this test, and so is simply treated as not needing a double bond
-      // rather than as a separate error case.
+      // The atom needs a double bond when it has room for one more unit of
+      // bond order. An overbonded atom -- target < current, from bad input --
+      // also fails this test, and so is simply treated as not needing a
+      // double bond rather than as a separate error case.
       m_needsDouble[atom] = (current + 1 <= target);
     }
   }

--- a/avogadro/core/kekulize.cpp
+++ b/avogadro/core/kekulize.cpp
@@ -1,0 +1,443 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "kekulize.h"
+
+#include "mdlvalence_p.h"
+#include "molecule.h"
+
+#include <string>
+#include <utility>
+
+namespace Avogadro::Core {
+
+namespace {
+
+/**
+ * A ceiling on backtracking steps, so a pathological input fails cleanly
+ * instead of hanging. Ordinary fused aromatics never approach it: they
+ * resolve through forced moves alone, with no backtracking at all.
+ */
+constexpr std::size_t MaxBacktrackSteps = 300000;
+
+/**
+ * Solves the "which aromatic bonds are double" problem for one molecule.
+ *
+ * The state is a set of candidate edges (aromatic bonds whose both endpoints
+ * still need a double bond) with a trail-based undo log, so that both the
+ * forced-move propagation and the backtracking search share one commit
+ * routine, and the search can walk back a failed guess without recursion.
+ */
+class Solver
+{
+public:
+  explicit Solver(const Molecule& molecule,
+                  const std::vector<bool>& aromaticBonds)
+    : m_pairs(molecule.bondPairs()), m_aromaticBonds(aromaticBonds),
+      m_atomCount(molecule.atomCount()), m_bondCount(molecule.bondCount()),
+      m_needsDouble(m_atomCount, false), m_alive(m_bondCount, false),
+      m_committed(m_bondCount, false), m_satisfied(m_atomCount, false),
+      m_degree(m_atomCount, 0), m_candidates(m_atomCount)
+  {
+    classify(molecule);
+    buildCandidates();
+  }
+
+  /** Runs the whole algorithm. See kekulize() for what the result means. */
+  bool solve(Index* failedAtom)
+  {
+    std::vector<Index> queue;
+    Index contradiction = MaxIndex;
+
+    for (Index atom = 0; atom < m_atomCount; ++atom) {
+      if (!m_needsDouble[atom])
+        continue;
+      if (m_degree[atom] == 0) {
+        if (failedAtom != nullptr)
+          *failedAtom = atom;
+        return false;
+      }
+      if (m_degree[atom] == 1)
+        queue.push_back(atom);
+    }
+
+    if (!propagate(queue, contradiction)) {
+      if (failedAtom != nullptr)
+        *failedAtom = contradiction;
+      return false;
+    }
+
+    return backtrack(failedAtom);
+  }
+
+  /** One entry per bond: true where this bond was committed as double. */
+  const std::vector<bool>& committed() const { return m_committed; }
+
+private:
+  /** Step 1: which atoms need exactly one double bond. See kekulize.h. */
+  void classify(const Molecule& molecule)
+  {
+    std::vector<unsigned int> aromaticCount(m_atomCount, 0);
+    std::vector<unsigned int> otherOrderSum(m_atomCount, 0);
+    const Array<unsigned char>& orders = molecule.bondOrders();
+
+    for (Index bond = 0; bond < m_bondCount; ++bond) {
+      const Index a = m_pairs[bond].first;
+      const Index b = m_pairs[bond].second;
+      if (m_aromaticBonds[bond]) {
+        ++aromaticCount[a];
+        ++aromaticCount[b];
+      } else {
+        otherOrderSum[a] += orders[bond];
+        otherOrderSum[b] += orders[bond];
+      }
+    }
+
+    const Array<unsigned char>& numbers = molecule.atomicNumbers();
+    for (Index atom = 0; atom < m_atomCount; ++atom) {
+      if (aromaticCount[atom] == 0)
+        continue; // Not part of an aromatic system at all.
+
+      const unsigned int current = otherOrderSum[atom] + aromaticCount[atom];
+      const unsigned int target =
+        atomValence(numbers[atom], molecule.formalCharge(atom), current);
+      // An overbonded atom -- target < current, from bad input -- also fails
+      // this test, and so is simply treated as not needing a double bond
+      // rather than as a separate error case.
+      m_needsDouble[atom] = (current + 1 <= target);
+    }
+  }
+
+  /** Step 2 setup: aromatic bonds between two atoms that both need one. */
+  void buildCandidates()
+  {
+    for (Index bond = 0; bond < m_bondCount; ++bond) {
+      if (!m_aromaticBonds[bond])
+        continue;
+      const Index a = m_pairs[bond].first;
+      const Index b = m_pairs[bond].second;
+      if (!m_needsDouble[a] || !m_needsDouble[b])
+        continue;
+      m_alive[bond] = true;
+      m_candidates[a].push_back(bond);
+      m_candidates[b].push_back(bond);
+      ++m_degree[a];
+      ++m_degree[b];
+    }
+  }
+
+  Index otherEnd(Index bond, Index atom) const
+  {
+    return (m_pairs[bond].first == atom) ? m_pairs[bond].second
+                                         : m_pairs[bond].first;
+  }
+
+  // ------------------------------------------------------------------
+  // Trail: every mutation the search makes is logged here with its previous
+  // value, so undoTo() can walk a failed guess back without recursion.
+
+  enum class TrailKind
+  {
+    Alive,
+    Committed,
+    Satisfied,
+    Degree
+  };
+
+  struct TrailEntry
+  {
+    TrailKind kind;
+    Index index;
+    int previous;
+  };
+
+  std::vector<TrailEntry> m_trail;
+
+  void setAlive(Index bond, bool value)
+  {
+    m_trail.push_back({ TrailKind::Alive, bond, m_alive[bond] ? 1 : 0 });
+    m_alive[bond] = value;
+  }
+
+  void setCommitted(Index bond)
+  {
+    m_trail.push_back(
+      { TrailKind::Committed, bond, m_committed[bond] ? 1 : 0 });
+    m_committed[bond] = true;
+  }
+
+  void setSatisfied(Index atom)
+  {
+    m_trail.push_back(
+      { TrailKind::Satisfied, atom, m_satisfied[atom] ? 1 : 0 });
+    m_satisfied[atom] = true;
+  }
+
+  void decrementDegree(Index atom)
+  {
+    m_trail.push_back({ TrailKind::Degree, atom, m_degree[atom] });
+    --m_degree[atom];
+  }
+
+  void undoTo(size_t mark)
+  {
+    while (m_trail.size() > mark) {
+      const TrailEntry entry = m_trail.back();
+      m_trail.pop_back();
+      switch (entry.kind) {
+        case TrailKind::Alive:
+          m_alive[entry.index] = entry.previous != 0;
+          break;
+        case TrailKind::Committed:
+          m_committed[entry.index] = entry.previous != 0;
+          break;
+        case TrailKind::Satisfied:
+          m_satisfied[entry.index] = entry.previous != 0;
+          break;
+        case TrailKind::Degree:
+          m_degree[entry.index] = entry.previous;
+          break;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Committing an edge as double removes every other candidate at either
+  // endpoint, since both are now satisfied; a neighbour left with a single
+  // remaining candidate becomes forced in turn, which is what makes ordinary
+  // fused aromatics resolve without any backtracking at all.
+
+  /** Kills every other candidate at @a hub, queuing or failing its far ends. */
+  bool removeRivals(Index hub, Index keepBond, std::vector<Index>& queue,
+                    Index& contradiction)
+  {
+    for (Index rival : m_candidates[hub]) {
+      if (rival == keepBond || !m_alive[rival])
+        continue;
+      setAlive(rival, false);
+      const Index far = otherEnd(rival, hub);
+      if (m_satisfied[far])
+        continue;
+      decrementDegree(far);
+      if (m_degree[far] == 0) {
+        contradiction = far;
+        return false;
+      }
+      if (m_degree[far] == 1)
+        queue.push_back(far);
+    }
+    return true;
+  }
+
+  bool commitAndCascade(Index bond, std::vector<Index>& queue,
+                        Index& contradiction)
+  {
+    const Index a = m_pairs[bond].first;
+    const Index b = m_pairs[bond].second;
+    setAlive(bond, false);
+    setCommitted(bond);
+    setSatisfied(a);
+    setSatisfied(b);
+    if (!removeRivals(a, bond, queue, contradiction))
+      return false;
+    if (!removeRivals(b, bond, queue, contradiction))
+      return false;
+    return true;
+  }
+
+  /** Drains a queue of atoms forced down to exactly one candidate. */
+  bool propagate(std::vector<Index>& queue, Index& contradiction)
+  {
+    while (!queue.empty()) {
+      const Index atom = queue.back();
+      queue.pop_back();
+      if (m_satisfied[atom])
+        continue;
+      if (m_degree[atom] == 0) {
+        contradiction = atom;
+        return false;
+      }
+      if (m_degree[atom] != 1)
+        continue; // No longer forced -- an earlier step already used it up.
+
+      Index bond = MaxIndex;
+      for (Index candidate : m_candidates[atom]) {
+        if (m_alive[candidate]) {
+          bond = candidate;
+          break;
+        }
+      }
+      if (bond == MaxIndex) { // Degree and candidate list disagree: bail out.
+        contradiction = atom;
+        return false;
+      }
+      if (!commitAndCascade(bond, queue, contradiction))
+        return false;
+    }
+    return true;
+  }
+
+  /** The unsatisfied atom needing a double bond with the fewest options. */
+  Index pickMostConstrained() const
+  {
+    Index best = MaxIndex;
+    int bestDegree = 0;
+    for (Index atom = 0; atom < m_atomCount; ++atom) {
+      if (!m_needsDouble[atom] || m_satisfied[atom])
+        continue;
+      if (best == MaxIndex || m_degree[atom] < bestDegree) {
+        best = atom;
+        bestDegree = m_degree[atom];
+      }
+    }
+    return best;
+  }
+
+  std::vector<Index> aliveEdgesAt(Index atom) const
+  {
+    std::vector<Index> result;
+    for (Index bond : m_candidates[atom]) {
+      if (m_alive[bond])
+        result.push_back(bond);
+    }
+    return result;
+  }
+
+  // ------------------------------------------------------------------
+  // Step 3: bounded backtracking, explicit stack rather than recursion so a
+  // large fused system cannot overflow the call stack.
+
+  struct Frame
+  {
+    std::vector<Index> options;
+    size_t cursor = 0;
+    size_t trailMark = 0;
+  };
+
+  bool backtrack(Index* failedAtom)
+  {
+    std::vector<Frame> stack;
+    std::size_t steps = 0;
+    Index lastContradiction = MaxIndex;
+    bool descending = true;
+
+    for (;;) {
+      if (descending) {
+        const Index atom = pickMostConstrained();
+        if (atom == MaxIndex)
+          break; // Nothing left unsatisfied: every candidate is resolved.
+
+        if (steps >= MaxBacktrackSteps) {
+          if (failedAtom != nullptr)
+            *failedAtom = MaxIndex; // A resource limit, not one atom's fault.
+          return false;
+        }
+        ++steps;
+
+        Frame frame;
+        frame.options = aliveEdgesAt(atom);
+        frame.cursor = 0;
+        frame.trailMark = m_trail.size();
+        stack.push_back(std::move(frame));
+        descending = false;
+      }
+
+      Frame& top = stack.back();
+      if (top.cursor >= top.options.size()) {
+        // Every option at this atom has failed: undo it entirely and let the
+        // atom that chose the edge leading here try its next option.
+        undoTo(top.trailMark);
+        stack.pop_back();
+        if (stack.empty()) {
+          if (failedAtom != nullptr)
+            *failedAtom = lastContradiction;
+          return false;
+        }
+        ++stack.back().cursor;
+        continue;
+      }
+
+      // Clear whatever the previous cursor left, which also restores m_alive
+      // to exactly the state options was collected in -- so every option is
+      // still alive here and there is nothing to re-check.
+      undoTo(top.trailMark);
+      const Index bond = top.options[top.cursor];
+
+      std::vector<Index> queue;
+      Index contradiction = MaxIndex;
+      const bool ok = commitAndCascade(bond, queue, contradiction) &&
+                      propagate(queue, contradiction);
+      if (ok) {
+        descending = true;
+      } else {
+        lastContradiction = contradiction;
+        undoTo(top.trailMark);
+        ++top.cursor;
+      }
+    }
+
+    return true;
+  }
+
+  const Array<std::pair<Index, Index>>& m_pairs;
+  const std::vector<bool>& m_aromaticBonds;
+  Index m_atomCount;
+  Index m_bondCount;
+
+  std::vector<bool> m_needsDouble;
+  std::vector<bool> m_alive;     //!< Still-available candidate edges.
+  std::vector<bool> m_committed; //!< Result: which edges became double bonds.
+  std::vector<bool> m_satisfied; //!< Atoms whose double bond is decided.
+  std::vector<int> m_degree;     //!< Remaining alive candidates per atom.
+  std::vector<std::vector<Index>> m_candidates; //!< Candidate bonds per atom.
+};
+
+} // namespace
+
+bool kekulize(Molecule& molecule, const std::vector<bool>& aromaticBonds,
+              Index* failedAtom)
+{
+  if (failedAtom != nullptr)
+    *failedAtom = MaxIndex;
+
+  const Index bondCount = molecule.bondCount();
+  if (aromaticBonds.size() != bondCount)
+    return false; // Caller error: one entry per bond is required.
+
+  bool anyAromatic = false;
+  for (bool aromatic : aromaticBonds) {
+    if (aromatic) {
+      anyAromatic = true;
+      break;
+    }
+  }
+  if (!anyAromatic)
+    return true; // Nothing to do, and nothing to touch.
+
+  Solver solver(molecule, aromaticBonds);
+  if (!solver.solve(failedAtom))
+    return false;
+
+  // Step 4: nothing is written until the whole assignment has succeeded.
+  const std::vector<bool>& committed = solver.committed();
+  for (Index bond = 0; bond < bondCount; ++bond) {
+    if (aromaticBonds[bond])
+      molecule.setBondOrder(bond, committed[bond] ? 2 : 1);
+  }
+  return true;
+}
+
+std::string kekulizeFailureMessage(Index failedAtom)
+{
+  std::string message =
+    "Could not kekulize aromatic bonds: no valid arrangement of alternating "
+    "single and double bonds exists";
+  // MaxIndex means the failure was not attributable to any one atom.
+  if (failedAtom != MaxIndex)
+    message += " that satisfies atom " + std::to_string(failedAtom);
+  return message + ".";
+}
+
+} // namespace Avogadro::Core

--- a/avogadro/core/kekulize.h
+++ b/avogadro/core/kekulize.h
@@ -1,0 +1,111 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CORE_KEKULIZE_H
+#define AVOGADRO_CORE_KEKULIZE_H
+
+#include "avogadrocoreexport.h"
+
+#include "avogadrocore.h"
+
+#include <string>
+#include <vector>
+
+namespace Avogadro::Core {
+
+class Molecule;
+
+/**
+ * Replace aromatic bond flags with alternating single and double bond orders.
+ *
+ * This is the inverse of AromaticityPerceiver: that class reads a molecule
+ * already in Kekule form and says which of its bonds are aromatic; this
+ * function takes a molecule whose aromatic bonds are not yet distinguished
+ * into single and double and commits to one of the (possibly several) valid
+ * alternations.
+ *
+ * Every atom incident to an aromatic bond is first classified as needing
+ * exactly one double bond, or none, by asking Core::atomValence() whether it
+ * has room for one more unit of bond order once its aromatic bonds are each
+ * counted as contributing one. This is the chemistry a reviewer most needs to
+ * check, so here is the rule applied by hand to the cases it must get right:
+ *
+ * | Atom                                    | current | target | double? |
+ * |------------------------------------------|:-------:|:------:|:-------:|
+ * | Thiophene S (two ring bonds)              |    2    |   2    |   no    |
+ * | Furan O (two ring bonds)                  |    2    |   2    |   no    |
+ * | Pyridine N (two ring bonds, lone pair)     |    2    |   3    |   yes   |
+ * | Pyrrole [nH] N (two ring bonds + N-H)      |    3    |   3    |   no    |
+ * | Benzene C (two ring bonds + H)             |    3    |   4    |   yes   |
+ * | Naphthalene bridgehead C (three ring bonds)|    3    |   4    |   yes   |
+ * | N-methylpyrrole N (two ring bonds + methyl)|    3    |   3    |   no    |
+ * | N-methylpyridinium N+ (two ring + methyl)  |    3    |   4    |   yes   |
+ * | Cyclopentadienyl [cH-] C (two ring + H)    |    3    |   3    |   no    |
+ * | Tropylium [cH+] C (two ring bonds + H)     |    3    |   3    |   no    |
+ * | 2-pyridone carbonyl C (two ring + exo C=O) |    4    |   4    |   no    |
+ *
+ * The last row is why an exocyclic double bond matters here even though this
+ * function never assigns one: the carbon's bond to its oxygen is not aromatic,
+ * so it counts its full order of 2, which together with its two ring bonds
+ * already fills carbon's valence and leaves no room for a ring double bond.
+ * Getting that wrong is what makes pyridinone the classic case toolkits
+ * disagree on.
+ *
+ * Formally: for an atom with @a n aromatic bonds and non-aromatic bonds whose
+ * orders sum to @a s,
+ * @code
+ *   current = s + n
+ *   target  = Core::atomValence(atomicNumber, formalCharge, current)
+ *   needsDouble = (current + 1 <= target)
+ * @endcode
+ * An atom already at or beyond its target valence -- overbonded input --
+ * simply comes out not needing a double bond: the same inequality answers
+ * false in that case too, since target <= current < current + 1. That is a
+ * deliberate leniency rather than a validity check; overbonded input is not
+ * this function's problem to reject.
+ *
+ * Candidate double bonds are then the aromatic bonds whose both endpoints
+ * need one. An atom that needs a double bond but has no candidate at all
+ * fails immediately. Otherwise this is exact cover by forced moves where
+ * possible (an atom with exactly one candidate commits it, which cascades)
+ * and bounded backtracking, most-constrained-atom first, over whatever forced
+ * moves do not resolve. Fused aromatic systems ordinarily resolve entirely by
+ * forced moves; backtracking exists for the harder cases (azulene-like
+ * systems, or an odd-membered all-carbon aromatic ring, which cannot be
+ * satisfied at all).
+ *
+ * Classification reads the molecule as it stands, and there is no separate
+ * "hydrogens this atom will get later" argument. Any bond that contributes to
+ * an atom's valence must therefore already be present before calling this --
+ * including hydrogens whose count is known, since an N-H is what separates
+ * pyrrole-type nitrogen from pyridine-type. A caller that materializes
+ * hydrogens from the bond orders this produces has to do so in two passes,
+ * which is what SmilesParser does.
+ *
+ * @param molecule The molecule to modify; bond orders are the only thing
+ * changed, and only for bonds flagged aromatic. Nothing is written unless
+ * every aromatic bond can be assigned.
+ * @param aromaticBonds One entry per bond, true where the bond is aromatic.
+ * Aromatic atoms are the atoms these bonds connect.
+ * @param failedAtom If given, set to the atom that could not be satisfied when
+ * this returns false, or MaxIndex if the failure was not attributable to one
+ * (for example, the backtracking step budget was exhausted).
+ * @return True if every aromatic bond was assigned an order.
+ */
+AVOGADROCORE_EXPORT bool kekulize(Molecule& molecule,
+                                  const std::vector<bool>& aromaticBonds,
+                                  Index* failedAtom = nullptr);
+
+/**
+ * A human readable description of why kekulize() failed, for a reader to
+ * report. Shared so that every format says the same thing about the same
+ * failure.
+ * @param failedAtom The value kekulize() reported, MaxIndex included.
+ */
+AVOGADROCORE_EXPORT std::string kekulizeFailureMessage(Index failedAtom);
+
+} // namespace Avogadro::Core
+
+#endif // AVOGADRO_CORE_KEKULIZE_H

--- a/avogadro/core/ringperceiver.cpp
+++ b/avogadro/core/ringperceiver.cpp
@@ -317,7 +317,9 @@ bool Sssr::isUnique(const std::vector<size_t>& path) const
     if (ring.size() >= path.size())
       continue;
 
-    for (size_t i = 0; i < ring.size(); i++) {
+    // Stop one short: ring[i + 1] would run off the end on the last atom, and
+    // the bond that closes the ring is erased separately below.
+    for (size_t i = 0; i + 1 < ring.size(); i++) {
       pathBonds.erase(std::make_pair(std::min(ring[i], ring[i + 1]),
                                      std::max(ring[i], ring[i + 1])));
     }

--- a/avogadro/core/ringperceiver.h
+++ b/avogadro/core/ringperceiver.h
@@ -27,6 +27,13 @@ public:
   const Molecule* molecule() const;
 
   // ring perception
+
+  /**
+   * The smallest set of smallest rings, each as a list of atom indices in the
+   * order they are traversed. A ring is not defined below three atoms, so
+   * every entry holds at least three and the bond closing it joins the last
+   * atom back to the first.
+   */
   std::vector<std::vector<size_t>>& rings();
 
 private:

--- a/avogadro/core/stereo.cpp
+++ b/avogadro/core/stereo.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "stereo.h"
+
+#include "molecule.h"
+
+namespace Avogadro::Core {
+
+const char* StereoUnspecifiedProperty = "stereoUnspecified";
+
+namespace {
+
+bool unspecified(const PropertyMap& properties, Index index)
+{
+  const std::optional<int> value =
+    properties.getInt(StereoUnspecifiedProperty, index);
+  return value.has_value() && *value != 0;
+}
+
+} // namespace
+
+bool atomStereoUnspecified(const Molecule& molecule, Index atom)
+{
+  return unspecified(molecule.atomProperties(), atom);
+}
+
+void setAtomStereoUnspecified(Molecule& molecule, Index atom, bool value)
+{
+  molecule.atomProperties().setInt(StereoUnspecifiedProperty, atom,
+                                   value ? 1 : 0);
+}
+
+bool bondStereoUnspecified(const Molecule& molecule, Index bond)
+{
+  return unspecified(molecule.bondProperties(), bond);
+}
+
+void setBondStereoUnspecified(Molecule& molecule, Index bond, bool value)
+{
+  molecule.bondProperties().setInt(StereoUnspecifiedProperty, bond,
+                                   value ? 1 : 0);
+}
+
+} // namespace Avogadro::Core

--- a/avogadro/core/stereo.cpp
+++ b/avogadro/core/stereo.cpp
@@ -9,7 +9,7 @@
 
 namespace Avogadro::Core {
 
-const char* StereoUnspecifiedProperty = "stereoUnspecified";
+const char* const StereoUnspecifiedProperty = "stereoUnspecified";
 
 namespace {
 

--- a/avogadro/core/stereo.h
+++ b/avogadro/core/stereo.h
@@ -42,7 +42,7 @@ class Molecule;
  * Property column recording that an atom's configuration is undefined. Part of
  * the on-disk CJSON format, so it must stay stable.
  */
-AVOGADROCORE_EXPORT extern const char* StereoUnspecifiedProperty;
+AVOGADROCORE_EXPORT extern const char* const StereoUnspecifiedProperty;
 
 /** @return true if @a atom is marked as having an undefined configuration. */
 AVOGADROCORE_EXPORT bool atomStereoUnspecified(const Molecule& molecule,

--- a/avogadro/core/stereo.h
+++ b/avogadro/core/stereo.h
@@ -1,0 +1,67 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CORE_STEREO_H
+#define AVOGADRO_CORE_STEREO_H
+
+#include "avogadrocoreexport.h"
+
+#include "avogadrocore.h"
+
+#include <string>
+
+namespace Avogadro::Core {
+
+class Molecule;
+
+/**
+ * @file stereo.h
+ * @brief Marking stereochemistry as deliberately undefined.
+ *
+ * A molecule always has coordinates, so any stereocentre in it has some
+ * geometry -- but that geometry is not always meaningful. A structure drawn in
+ * two dimensions, or imported from a file whose author marked a centre
+ * "unknown", has atoms placed somewhere without any claim about the
+ * configuration. Reading such a placement as though it were real invents
+ * stereochemistry the source never asserted.
+ *
+ * These mark the cases where that has happened, so consumers can tell "no
+ * stereochemistry here" from "stereochemistry not stated". The configuration
+ * itself is not stored: where it is meaningful, it is read from the
+ * coordinates.
+ *
+ * The values live in Molecule::atomProperties() and bondProperties(), so they
+ * follow atoms and bonds through insertion and deletion, and round-trip
+ * through CJSON. They are *not* carried by CML, which does not serialize
+ * custom properties.
+ */
+
+/**
+ * Property column recording that an atom's configuration is undefined. Part of
+ * the on-disk CJSON format, so it must stay stable.
+ */
+AVOGADROCORE_EXPORT extern const char* StereoUnspecifiedProperty;
+
+/** @return true if @a atom is marked as having an undefined configuration. */
+AVOGADROCORE_EXPORT bool atomStereoUnspecified(const Molecule& molecule,
+                                               Index atom);
+
+/** Mark, or unmark, @a atom as having an undefined configuration. */
+AVOGADROCORE_EXPORT void setAtomStereoUnspecified(Molecule& molecule,
+                                                  Index atom,
+                                                  bool unspecified = true);
+
+/** @return true if @a bond is marked as having an undefined configuration. */
+AVOGADROCORE_EXPORT bool bondStereoUnspecified(const Molecule& molecule,
+                                               Index bond);
+
+/** Mark, or unmark, @a bond as having an undefined configuration. */
+AVOGADROCORE_EXPORT void setBondStereoUnspecified(Molecule& molecule,
+                                                  Index bond,
+                                                  bool unspecified = true);
+
+} // namespace Avogadro::Core
+
+#endif // AVOGADRO_CORE_STEREO_H

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -12,9 +12,7 @@ avogadro_headers(IO
   lammpsformat.h
   pdbformat.h
   sdfformat.h
-  atomequivalence_p.h
   smilesformat.h
-  smilesvalence_p.h
   smileswriter.h
   trrformat.h
   turbomoleformat.h
@@ -34,7 +32,9 @@ target_sources(IO PRIVATE
   mdlformat.cpp
   pdbformat.cpp
   sdfformat.cpp
+  atomequivalence_p.h
   smilesformat.cpp
+  smilesvalence_p.h
   smileswriter.cpp
   trrformat.cpp
   turbomoleformat.cpp

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -13,6 +13,7 @@ avogadro_headers(IO
   pdbformat.h
   sdfformat.h
   smilesformat.h
+  smilesparser.h
   smileswriter.h
   trrformat.h
   turbomoleformat.h
@@ -34,6 +35,7 @@ target_sources(IO PRIVATE
   sdfformat.cpp
   atomequivalence_p.h
   smilesformat.cpp
+  smilesparser.cpp
   smilesvalence_p.h
   smileswriter.cpp
   trrformat.cpp

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -12,7 +12,9 @@ avogadro_headers(IO
   lammpsformat.h
   pdbformat.h
   sdfformat.h
+  atomequivalence_p.h
   smilesformat.h
+  smilesvalence_p.h
   smileswriter.h
   trrformat.h
   turbomoleformat.h

--- a/avogadro/io/CMakeLists.txt
+++ b/avogadro/io/CMakeLists.txt
@@ -12,6 +12,8 @@ avogadro_headers(IO
   lammpsformat.h
   pdbformat.h
   sdfformat.h
+  smilesformat.h
+  smileswriter.h
   trrformat.h
   turbomoleformat.h
   vaspformat.h
@@ -30,6 +32,8 @@ target_sources(IO PRIVATE
   mdlformat.cpp
   pdbformat.cpp
   sdfformat.cpp
+  smilesformat.cpp
+  smileswriter.cpp
   trrformat.cpp
   turbomoleformat.cpp
   vaspformat.cpp

--- a/avogadro/io/atomequivalence_p.h
+++ b/avogadro/io/atomequivalence_p.h
@@ -32,16 +32,17 @@ namespace Avogadro::Io {
  * - The refinement is purely constitutional, so it cannot separate branches
  *   that differ only in their own stereochemistry. Meso compounds and
  *   pseudo-asymmetric centres come out symmetric.
- * - Ring cis/trans centres are missed. In 4-methylcyclohexanol the two ring
- *   branches leaving C1 really are constitutionally identical -- the molecule
- *   has a symmetry plane through C1 and C4 -- so they share a class, even
- *   though the ring makes the centre stereogenic. Detecting these needs
- *   pairwise reasoning about which centres depend on each other, since the
- *   same test must still reject plain cyclohexanol.
+ * - Ring cis/trans centres share a class here even though they are
+ *   stereogenic. In 4-methylcyclohexanol the two ring branches leaving C1
+ *   really are constitutionally identical -- the molecule has a symmetry plane
+ *   through C1 and C4 -- so this function cannot separate them. Callers that
+ *   care handle it on top: the SMILES writer treats a tie between two ring
+ *   neighbours as stereogenic when another such centre shares the ring system,
+ *   which is what tells 4-methylcyclohexanol apart from cyclohexanol.
  *
- * Both are resolved the same way, by re-running the refinement with stereo
- * descriptors folded into the invariant until it settles. That is deliberately
- * not done here.
+ * The first is resolved by re-running the refinement with stereo descriptors
+ * folded into the invariant until it settles. That is deliberately not done
+ * here.
  *
  * Hydrogens participate like any other atom, so the caller may run this over
  * the molecule as stored without suppressing them first.

--- a/avogadro/io/atomequivalence_p.h
+++ b/avogadro/io/atomequivalence_p.h
@@ -120,8 +120,14 @@ inline std::vector<Index> atomEquivalenceClasses(const Core::Molecule& mol)
   Index classCount = rankByKeys();
 
   // Each round can only split classes, so the count is strictly increasing
-  // until it settles; it cannot exceed the atom count.
-  for (Index round = 0; round < atomCount; ++round) {
+  // until it settles. Refinement normally settles within a few rounds, but a
+  // long chain needs one round per bond to tell its ends apart, which would
+  // make this quadratic on a polymer or a protein backbone. Capping the rounds
+  // bounds that: atoms whose environments only differ further away than the
+  // cap stay in one class, which loses stereocentres rather than inventing
+  // them -- the same direction as this function's other limits.
+  const Index maxRounds = std::min<Index>(atomCount, 32);
+  for (Index round = 0; round < maxRounds; ++round) {
     for (Index atom = 0; atom < atomCount; ++atom) {
       uint64_t* key = &keys[atom * stride];
       key[0] = classes[atom];

--- a/avogadro/io/atomequivalence_p.h
+++ b/avogadro/io/atomequivalence_p.h
@@ -1,0 +1,148 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_ATOMEQUIVALENCE_P_H
+#define AVOGADRO_IO_ATOMEQUIVALENCE_P_H
+
+#include <avogadro/core/molecule.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+namespace Avogadro::Io {
+
+/**
+ * Partition the atoms of @a mol into constitutional equivalence classes by
+ * Morgan-style iterative refinement: atoms start out separated by element,
+ * degree, charge and isotope, and are then repeatedly re-separated by the
+ * multiset of their neighbours' classes until the partition stops growing.
+ *
+ * Two atoms share a class when nothing about the connectivity around them
+ * tells them apart. That is what makes this usable as a stereocentre test: an
+ * atom whose neighbours all land in different classes has four constitutionally
+ * distinct substituents.
+ *
+ * Known limitations, all of which lose stereocentres rather than invent them:
+ *
+ * - The refinement is purely constitutional, so it cannot separate branches
+ *   that differ only in their own stereochemistry. Meso compounds and
+ *   pseudo-asymmetric centres come out symmetric.
+ * - Ring cis/trans centres are missed. In 4-methylcyclohexanol the two ring
+ *   branches leaving C1 really are constitutionally identical -- the molecule
+ *   has a symmetry plane through C1 and C4 -- so they share a class, even
+ *   though the ring makes the centre stereogenic. Detecting these needs
+ *   pairwise reasoning about which centres depend on each other, since the
+ *   same test must still reject plain cyclohexanol.
+ *
+ * Both are resolved the same way, by re-running the refinement with stereo
+ * descriptors folded into the invariant until it settles. That is deliberately
+ * not done here.
+ *
+ * Hydrogens participate like any other atom, so the caller may run this over
+ * the molecule as stored without suppressing them first.
+ *
+ * @return A class index per atom, in the range [0, class count).
+ */
+inline std::vector<Index> atomEquivalenceClasses(const Core::Molecule& mol)
+{
+  const Index atomCount = mol.atomCount();
+  std::vector<Index> classes(atomCount, 0);
+  if (atomCount == 0)
+    return classes;
+
+  const Core::Array<std::pair<Index, Index>>& pairs = mol.bondPairs();
+  const Core::Array<unsigned char>& numbers = mol.atomicNumbers();
+  const Core::Array<unsigned char>& orders = mol.bondOrders();
+
+  // Flat adjacency, so the refinement rounds below allocate nothing.
+  std::vector<Index> start(atomCount + 1, 0);
+  for (const std::pair<Index, Index>& ends : pairs) {
+    ++start[ends.first + 1];
+    ++start[ends.second + 1];
+  }
+  for (Index atom = 0; atom < atomCount; ++atom)
+    start[atom + 1] += start[atom];
+
+  std::vector<Index> neighbor(2 * pairs.size());
+  std::vector<unsigned char> neighborOrder(2 * pairs.size());
+  std::vector<Index> cursor(start.begin(), start.end() - 1);
+  for (Index bond = 0; bond < pairs.size(); ++bond) {
+    const std::pair<Index, Index>& ends = pairs[bond];
+    neighborOrder[cursor[ends.first]] = orders[bond];
+    neighbor[cursor[ends.first]++] = ends.second;
+    neighborOrder[cursor[ends.second]] = orders[bond];
+    neighbor[cursor[ends.second]++] = ends.first;
+  }
+
+  Index maxDegree = 0;
+  for (Index atom = 0; atom < atomCount; ++atom)
+    maxDegree = std::max(maxDegree, start[atom + 1] - start[atom]);
+
+  // One key per atom: its own invariant, then its neighbours' sorted codes,
+  // zero padded so every key compares as a fixed-width tuple.
+  const Index stride = maxDegree + 1;
+  std::vector<uint64_t> keys(atomCount * stride, 0);
+  std::vector<Index> order(atomCount);
+
+  const auto rankByKeys = [&]() -> Index {
+    std::iota(order.begin(), order.end(), Index(0));
+    std::sort(order.begin(), order.end(), [&](Index a, Index b) {
+      return std::lexicographical_compare(
+        keys.begin() + a * stride, keys.begin() + (a + 1) * stride,
+        keys.begin() + b * stride, keys.begin() + (b + 1) * stride);
+    });
+
+    Index rank = 0;
+    for (Index i = 0; i < atomCount; ++i) {
+      if (i > 0 && !std::equal(keys.begin() + order[i] * stride,
+                               keys.begin() + (order[i] + 1) * stride,
+                               keys.begin() + order[i - 1] * stride)) {
+        ++rank;
+      }
+      classes[order[i]] = rank;
+    }
+    return rank + 1;
+  };
+
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    keys[atom * stride] =
+      (static_cast<uint64_t>(numbers[atom]) << 48) |
+      (static_cast<uint64_t>(start[atom + 1] - start[atom]) << 32) |
+      (static_cast<uint64_t>(mol.formalCharge(atom) + 128) << 16) |
+      static_cast<uint64_t>(mol.isotope(atom));
+  }
+  Index classCount = rankByKeys();
+
+  // Each round can only split classes, so the count is strictly increasing
+  // until it settles; it cannot exceed the atom count.
+  for (Index round = 0; round < atomCount; ++round) {
+    for (Index atom = 0; atom < atomCount; ++atom) {
+      uint64_t* key = &keys[atom * stride];
+      key[0] = classes[atom];
+      Index slot = 1;
+      for (Index e = start[atom]; e < start[atom + 1]; ++e) {
+        key[slot++] =
+          (static_cast<uint64_t>(classes[neighbor[e]]) << 8) | neighborOrder[e];
+      }
+      std::sort(key + 1, key + slot);
+      for (; slot < stride; ++slot)
+        key[slot] = 0;
+    }
+
+    const Index refined = rankByKeys();
+    if (refined == classCount)
+      break;
+    classCount = refined;
+  }
+
+  return classes;
+}
+
+} // namespace Avogadro::Io
+
+#endif // AVOGADRO_IO_ATOMEQUIVALENCE_P_H

--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -11,6 +11,7 @@
 
 #include <avogadro/core/crystaltools.h>
 #include <avogadro/core/elements.h>
+#include <avogadro/core/kekulize.h>
 #include <avogadro/core/matrix.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/spacegroups.h>
@@ -293,6 +294,11 @@ public:
 
     xml_node node = bondArray.child("bond");
 
+    // One entry per bond added below; kekulize() at the end replaces the
+    // order-1 placeholder every aromatic bond was given with a real one.
+    std::vector<bool> aromaticBonds;
+    bool anyAromaticBond = false;
+
     while (node) {
       xml_attribute attribute = node.attribute("atomRefs2");
       Bond bond;
@@ -321,8 +327,10 @@ public:
       }
 
       attribute = node.attribute("order");
-      if (attribute && strlen(attribute.value()) == 1) {
-        char o = attribute.value()[0];
+      bool aromatic = false;
+      const std::string orderStr = attribute ? attribute.value() : "";
+      if (orderStr.size() == 1) {
+        char o = orderStr[0];
         switch (o) {
           case '1':
           case 'S':
@@ -348,15 +356,35 @@ public:
           case '6':
             bond.setOrder(6);
             break;
+          case 'A':
+          case 'a':
+            // Aromatic: order 1 is a placeholder: kekulize() below assigns
+            // its real order.
+            bond.setOrder(1);
+            aromatic = true;
+            break;
           default:
             bond.setOrder(1);
         }
+      } else if (orderStr == "aromatic") {
+        bond.setOrder(1);
+        aromatic = true;
       } else {
         bond.setOrder(1);
       }
+      aromaticBonds.push_back(aromatic);
+      anyAromaticBond = anyAromaticBond || aromatic;
 
       // Move on to the next bond node (if there is one).
       node = node.next_sibling("bond");
+    }
+
+    if (anyAromaticBond) {
+      Index failedAtom = MaxIndex;
+      if (!Core::kekulize(*molecule, aromaticBonds, &failedAtom)) {
+        error += Core::kekulizeFailureMessage(failedAtom);
+        return false;
+      }
     }
 
     return true;

--- a/avogadro/io/fileformatmanager.cpp
+++ b/avogadro/io/fileformatmanager.cpp
@@ -16,6 +16,7 @@
 #include "mdlformat.h"
 #include "pdbformat.h"
 #include "sdfformat.h"
+#include "smilesformat.h"
 #include "trrformat.h"
 #include "turbomoleformat.h"
 #include "vaspformat.h"
@@ -295,6 +296,9 @@ FileFormatManager::FileFormatManager()
   addFormat(new PdbFormat);
   addFormat(new PoscarFormat);
   addFormat(new SdfFormat);
+  // Write only, so the Open Babel plugin stays the reader for "smi": a SMILES
+  // string carries no coordinates, and generating them is still its job.
+  addFormat(new SmilesFormat);
   addFormat(new TrrFormat);
   addFormat(new TurbomoleFormat);
   addFormat(new XyzFormat);

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -821,6 +821,9 @@ bool MdlFormat::readV3000(std::istream& in, Core::Molecule& mol)
     appendError("Error parsing V3000 bond block.");
     return false;
   }
+  std::vector<bool> aromaticBonds;
+  aromaticBonds.reserve(numBonds);
+  bool anyAromaticBond = false;
   for (int i = 0; i < numBonds; ++i) {
     getline(in, buffer);
     std::vector<string> bondData = split(trimmed(buffer), ' ');
@@ -843,9 +846,28 @@ bool MdlFormat::readV3000(std::istream& in, Core::Molecule& mol)
       appendError("Failed to parse bond atom2: " + bondData[5]);
       return false;
     }
-    mol.addBond(mol.atom(atom1), mol.atom(atom2),
-                static_cast<unsigned char>(order));
+    // Order 4 is aromatic here exactly as it is in V2000: add a single bond
+    // as a placeholder and let kekulize() below assign the real order.
+    unsigned char bondOrder = static_cast<unsigned char>(order);
+    bool aromatic = false;
+    if (order == 4) {
+      aromatic = true;
+      anyAromaticBond = true;
+      bondOrder = 1;
+    }
+    mol.addBond(mol.atom(atom1), mol.atom(atom2), bondOrder);
+    aromaticBonds.push_back(aromatic);
   } // end of bond block
+
+  // Unlike V2000, charges arrive with the atoms (CHG= in the atom block), so
+  // by here everything kekulize() classifies from is already in place.
+  if (anyAromaticBond) {
+    Index failedAtom = MaxIndex;
+    if (!Core::kekulize(mol, aromaticBonds, &failedAtom)) {
+      appendError(Core::kekulizeFailureMessage(failedAtom));
+      return false;
+    }
+  }
 
   // look for M  END
   while (getline(in, buffer)) {

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -8,6 +8,7 @@
 #include "fileformatmanager.h"
 
 #include <avogadro/core/elements.h>
+#include <avogadro/core/kekulize.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/stereo.h>
 #include <avogadro/core/utilities.h>
@@ -266,6 +267,9 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
   }
 
   // Parse the bond block.
+  std::vector<bool> aromaticBonds;
+  aromaticBonds.reserve(numBonds);
+  bool anyAromaticBond = false;
   for (int i = 0; i < numBonds; ++i) {
     // Bond atom indices start at 1, -1 for C++.
     getline(in, buffer);
@@ -294,8 +298,19 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
       appendError("Bond read in with out of bounds index.");
       return false;
     }
-    Bond newBond = mol.addBond(mol.atom(begin), mol.atom(end),
-                               static_cast<unsigned char>(order));
+    // Bond type 4 is aromatic. It used to be passed straight through to
+    // addBond(), which made it a quadruple bond; add it as a single-bond
+    // placeholder instead and let kekulize() assign its real order below.
+    // Query types 5-8 are left exactly as they were: out of scope here.
+    unsigned char bondOrder = static_cast<unsigned char>(order);
+    bool aromatic = false;
+    if (order == 4) {
+      aromatic = true;
+      anyAromaticBond = true;
+      bondOrder = 1;
+    }
+    Bond newBond = mol.addBond(mol.atom(begin), mol.atom(end), bondOrder);
+    aromaticBonds.push_back(aromatic);
 
     // The stereo column is optional, and a file that omits it is simply
     // saying nothing about configuration.
@@ -422,6 +437,18 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
     size_t index = i.first;
     signed int charge = i.second;
     mol.setFormalCharge(index, charge);
+  }
+
+  // Aromatic (type 4) bonds were added above as single-bond placeholders;
+  // replace them with a real alternation now. This has to wait until here,
+  // after charges are applied, since a charged aromatic atom (a pyridinium
+  // nitrogen, for instance) classifies differently than a neutral one.
+  if (anyAromaticBond) {
+    Index failedAtom = MaxIndex;
+    if (!Core::kekulize(mol, aromaticBonds, &failedAtom)) {
+      appendError(Core::kekulizeFailureMessage(failedAtom));
+      return false;
+    }
   }
 
   // Set the total spin multiplicity

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -946,10 +946,21 @@ bool MdlFormat::write(std::ostream& out, const Core::Molecule& mol)
   // Bond block.
   for (size_t i = 0; i < mol.bondCount(); ++i) {
     Bond bond = mol.bond(i);
+
+    // Carry an undefined configuration back out. Writing 0 here would assert
+    // that the coordinates mean something, which is the claim reading the flag
+    // was meant to avoid making.
+    int stereo = 0;
+    if (bond.order() == 2 && bondStereoUnspecified(mol, i))
+      stereo = 3; // cis or trans, either
+    else if (bond.order() == 1 &&
+             atomStereoUnspecified(mol, bond.atom1().index()))
+      stereo = 4; // a wedge drawn as either
+
     out.unsetf(std::ios::floatfield);
     out << setw(3) << std::right << bond.atom1().index() + 1 << setw(3)
         << bond.atom2().index() + 1 << setw(3) << static_cast<int>(bond.order())
-        << "  0  0  0  0\n";
+        << setw(3) << stereo << "  0  0  0\n";
   }
   // Properties block.
   for (auto& i : chargeList) {

--- a/avogadro/io/mdlformat.cpp
+++ b/avogadro/io/mdlformat.cpp
@@ -9,6 +9,7 @@
 
 #include <avogadro/core/elements.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/stereo.h>
 #include <avogadro/core/utilities.h>
 #include <avogadro/core/vector.h>
 
@@ -293,8 +294,23 @@ bool MdlFormat::read(std::istream& in, Core::Molecule& mol)
       appendError("Bond read in with out of bounds index.");
       return false;
     }
-    mol.addBond(mol.atom(begin), mol.atom(end),
-                static_cast<unsigned char>(order));
+    Bond newBond = mol.addBond(mol.atom(begin), mol.atom(end),
+                               static_cast<unsigned char>(order));
+
+    // The stereo column is optional, and a file that omits it is simply
+    // saying nothing about configuration.
+    if (buffer.size() >= 12) {
+      const int stereo(lexicalCast<int>(buffer.substr(9, 3), ok));
+      if (ok) {
+        // 3 on a double bond is "cis or trans, either", and 4 on a single bond
+        // is a wedge drawn as "either". Both mean the author declined to state
+        // a configuration, so the coordinates must not be read as one.
+        if (order == 2 && stereo == 3)
+          setBondStereoUnspecified(mol, newBond.index());
+        else if (order == 1 && stereo == 4)
+          setAtomStereoUnspecified(mol, static_cast<Index>(begin));
+      }
+    }
   }
 
   // Parse the properties block until the end of the file.

--- a/avogadro/io/smilesformat.cpp
+++ b/avogadro/io/smilesformat.cpp
@@ -49,6 +49,7 @@ bool SmilesFormat::write(std::ostream& outStream,
   SmilesWriter writer;
   writer.setHydrogenMode(m_hydrogenMode);
   writer.setAtomMaps(opts.value("atomMaps", m_atomMaps));
+  writer.setAromatic(opts.value("aromatic", m_aromatic));
 
   if (opts.contains("hydrogens")) {
     const std::string hydrogens = opts.value("hydrogens", std::string());

--- a/avogadro/io/smilesformat.cpp
+++ b/avogadro/io/smilesformat.cpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "smilesformat.h"
+
+#include "smileswriter.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace Avogadro::Io {
+
+std::vector<std::string> SmilesFormat::fileExtensions() const
+{
+  std::vector<std::string> ext;
+  ext.emplace_back("smi");
+  ext.emplace_back("smiles");
+  return ext;
+}
+
+std::vector<std::string> SmilesFormat::mimeTypes() const
+{
+  std::vector<std::string> mime;
+  mime.emplace_back("chemical/x-daylight-smiles");
+  return mime;
+}
+
+bool SmilesFormat::read(std::istream&, Core::Molecule&)
+{
+  appendError("Reading SMILES is not supported by this format.");
+  return false;
+}
+
+bool SmilesFormat::write(std::ostream& outStream,
+                         const Core::Molecule& molecule)
+{
+  json opts;
+  if (!options().empty())
+    opts = json::parse(options(), nullptr, false);
+  else
+    opts = json::object();
+
+  SmilesWriter writer;
+
+  const std::string hydrogens =
+    opts.value("hydrogens", std::string("implicit"));
+  if (hydrogens == "implicit") {
+    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Implicit);
+  } else if (hydrogens == "bracket") {
+    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Bracket);
+  } else if (hydrogens == "explicit") {
+    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Explicit);
+  } else {
+    appendError("Unknown value for the \"hydrogens\" option: " + hydrogens);
+    return false;
+  }
+
+  writer.setAtomMaps(opts.value("atomMaps", false));
+
+  std::string smiles;
+  if (!writer.write(molecule, smiles)) {
+    appendError(writer.error());
+    return false;
+  }
+
+  outStream << smiles << "\n";
+  return true;
+}
+
+} // namespace Avogadro::Io

--- a/avogadro/io/smilesformat.cpp
+++ b/avogadro/io/smilesformat.cpp
@@ -46,13 +46,38 @@ bool SmilesFormat::write(std::ostream& outStream,
   if (!opts.is_object())
     opts = json::object();
 
-  SmilesWriter writer;
-  writer.setHydrogenMode(m_hydrogenMode);
-  writer.setAtomMaps(opts.value("atomMaps", m_atomMaps));
-  writer.setAromatic(opts.value("aromatic", m_aromatic));
+  SmilesWriter writer = m_writer;
+
+  // Every option is type checked before it is read: json::value() throws when
+  // the stored type does not match, and this code must not throw.
+  bool valid = true;
+  const auto boolOption = [&](const char* name, bool& out) {
+    if (!opts.contains(name))
+      return;
+    if (!opts[name].is_boolean()) {
+      appendError(std::string("The \"") + name +
+                  "\" option must be a boolean.");
+      valid = false;
+      return;
+    }
+    out = opts[name].get<bool>();
+  };
+
+  bool atomMaps = writer.atomMaps();
+  bool aromatic = writer.aromatic();
+  boolOption("atomMaps", atomMaps);
+  boolOption("aromatic", aromatic);
+  if (!valid)
+    return false;
+  writer.setAtomMaps(atomMaps);
+  writer.setAromatic(aromatic);
 
   if (opts.contains("hydrogens")) {
-    const std::string hydrogens = opts.value("hydrogens", std::string());
+    if (!opts["hydrogens"].is_string()) {
+      appendError("The \"hydrogens\" option must be a string.");
+      return false;
+    }
+    const std::string hydrogens = opts["hydrogens"].get<std::string>();
     if (hydrogens == "implicit")
       writer.setHydrogenMode(SmilesWriter::HydrogenMode::Implicit);
     else if (hydrogens == "bracket")

--- a/avogadro/io/smilesformat.cpp
+++ b/avogadro/io/smilesformat.cpp
@@ -40,28 +40,29 @@ bool SmilesFormat::read(std::istream&, Core::Molecule&)
 bool SmilesFormat::write(std::ostream& outStream,
                          const Core::Molecule& molecule)
 {
-  json opts;
-  if (!options().empty())
-    opts = json::parse(options(), nullptr, false);
-  else
+  // A malformed options string parses to a discarded value, on which value()
+  // would throw; fall back to the typed settings instead.
+  json opts = json::parse(options(), nullptr, false);
+  if (!opts.is_object())
     opts = json::object();
 
   SmilesWriter writer;
+  writer.setHydrogenMode(m_hydrogenMode);
+  writer.setAtomMaps(opts.value("atomMaps", m_atomMaps));
 
-  const std::string hydrogens =
-    opts.value("hydrogens", std::string("implicit"));
-  if (hydrogens == "implicit") {
-    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Implicit);
-  } else if (hydrogens == "bracket") {
-    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Bracket);
-  } else if (hydrogens == "explicit") {
-    writer.setHydrogenMode(SmilesWriter::HydrogenMode::Explicit);
-  } else {
-    appendError("Unknown value for the \"hydrogens\" option: " + hydrogens);
-    return false;
+  if (opts.contains("hydrogens")) {
+    const std::string hydrogens = opts.value("hydrogens", std::string());
+    if (hydrogens == "implicit")
+      writer.setHydrogenMode(SmilesWriter::HydrogenMode::Implicit);
+    else if (hydrogens == "bracket")
+      writer.setHydrogenMode(SmilesWriter::HydrogenMode::Bracket);
+    else if (hydrogens == "explicit")
+      writer.setHydrogenMode(SmilesWriter::HydrogenMode::Explicit);
+    else {
+      appendError("Unknown value for the \"hydrogens\" option: " + hydrogens);
+      return false;
+    }
   }
-
-  writer.setAtomMaps(opts.value("atomMaps", false));
 
   std::string smiles;
   if (!writer.write(molecule, smiles)) {

--- a/avogadro/io/smilesformat.h
+++ b/avogadro/io/smilesformat.h
@@ -8,6 +8,8 @@
 
 #include "fileformat.h"
 
+#include "smileswriter.h"
+
 namespace Avogadro::Io {
 
 /**
@@ -19,11 +21,14 @@ namespace Avogadro::Io {
  * coordinates natively, reading stays with the Open Babel plugin and this
  * format deliberately does not advertise Read.
  *
- * Behaviour is controlled through setOptions() with a JSON object:
+ * Behaviour is controlled either through the typed setters below, or -- for
+ * generic callers that only have a FileFormat -- through setOptions() with a
+ * JSON object:
  * @code
  * { "hydrogens": "implicit" | "bracket" | "explicit", "atomMaps": false }
  * @endcode
- * See SmilesWriter for what those mean. Note that "atomMaps" implies
+ * Keys present in the options string override the typed setters. See
+ * SmilesWriter for what the values mean. Note that "atomMaps" implies
  * "explicit", and that both default to the interchange-safe values, since
  * this format's output is pasted into other programs and sent to web
  * services.
@@ -56,10 +61,24 @@ public:
   std::vector<std::string> fileExtensions() const override;
   std::vector<std::string> mimeTypes() const override;
 
+  /** @copydoc SmilesWriter::setHydrogenMode() */
+  void setHydrogenMode(SmilesWriter::HydrogenMode mode)
+  {
+    m_hydrogenMode = mode;
+  }
+
+  /** @copydoc SmilesWriter::setAtomMaps() */
+  void setAtomMaps(bool enable) { m_atomMaps = enable; }
+
   [[nodiscard]] bool read(std::istream& inStream,
                           Core::Molecule& molecule) override;
   [[nodiscard]] bool write(std::ostream& outStream,
                            const Core::Molecule& molecule) override;
+
+private:
+  SmilesWriter::HydrogenMode m_hydrogenMode =
+    SmilesWriter::HydrogenMode::Implicit;
+  bool m_atomMaps = false;
 };
 
 } // namespace Avogadro::Io

--- a/avogadro/io/smilesformat.h
+++ b/avogadro/io/smilesformat.h
@@ -25,7 +25,8 @@ namespace Avogadro::Io {
  * generic callers that only have a FileFormat -- through setOptions() with a
  * JSON object:
  * @code
- * { "hydrogens": "implicit" | "bracket" | "explicit", "atomMaps": false }
+ * { "hydrogens": "implicit" | "bracket" | "explicit", "atomMaps": false,
+ *   "aromatic": true }
  * @endcode
  * Keys present in the options string override the typed setters. See
  * SmilesWriter for what the values mean. Note that "atomMaps" implies
@@ -70,6 +71,9 @@ public:
   /** @copydoc SmilesWriter::setAtomMaps() */
   void setAtomMaps(bool enable) { m_atomMaps = enable; }
 
+  /** @copydoc SmilesWriter::setAromatic() */
+  void setAromatic(bool enable) { m_aromatic = enable; }
+
   [[nodiscard]] bool read(std::istream& inStream,
                           Core::Molecule& molecule) override;
   [[nodiscard]] bool write(std::ostream& outStream,
@@ -79,6 +83,7 @@ private:
   SmilesWriter::HydrogenMode m_hydrogenMode =
     SmilesWriter::HydrogenMode::Implicit;
   bool m_atomMaps = false;
+  bool m_aromatic = true;
 };
 
 } // namespace Avogadro::Io

--- a/avogadro/io/smilesformat.h
+++ b/avogadro/io/smilesformat.h
@@ -65,14 +65,14 @@ public:
   /** @copydoc SmilesWriter::setHydrogenMode() */
   void setHydrogenMode(SmilesWriter::HydrogenMode mode)
   {
-    m_hydrogenMode = mode;
+    m_writer.setHydrogenMode(mode);
   }
 
   /** @copydoc SmilesWriter::setAtomMaps() */
-  void setAtomMaps(bool enable) { m_atomMaps = enable; }
+  void setAtomMaps(bool enable) { m_writer.setAtomMaps(enable); }
 
   /** @copydoc SmilesWriter::setAromatic() */
-  void setAromatic(bool enable) { m_aromatic = enable; }
+  void setAromatic(bool enable) { m_writer.setAromatic(enable); }
 
   [[nodiscard]] bool read(std::istream& inStream,
                           Core::Molecule& molecule) override;
@@ -80,10 +80,8 @@ public:
                            const Core::Molecule& molecule) override;
 
 private:
-  SmilesWriter::HydrogenMode m_hydrogenMode =
-    SmilesWriter::HydrogenMode::Implicit;
-  bool m_atomMaps = false;
-  bool m_aromatic = true;
+  //! Holds the settings; write() applies any options() on top of a copy.
+  SmilesWriter m_writer;
 };
 
 } // namespace Avogadro::Io

--- a/avogadro/io/smilesformat.h
+++ b/avogadro/io/smilesformat.h
@@ -1,0 +1,67 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_SMILESFORMAT_H
+#define AVOGADRO_IO_SMILESFORMAT_H
+
+#include "fileformat.h"
+
+namespace Avogadro::Io {
+
+/**
+ * @class SmilesFormat smilesformat.h <avogadro/io/smilesformat.h>
+ * @brief Implementation of the SMILES line notation.
+ *
+ * Writing only. A SMILES string carries no coordinates, so reading one yields
+ * a molecule with every atom at the origin; until Avogadro can generate
+ * coordinates natively, reading stays with the Open Babel plugin and this
+ * format deliberately does not advertise Read.
+ *
+ * Behaviour is controlled through setOptions() with a JSON object:
+ * @code
+ * { "hydrogens": "implicit" | "bracket" | "explicit", "atomMaps": false }
+ * @endcode
+ * See SmilesWriter for what those mean. Note that "atomMaps" implies
+ * "explicit", and that both default to the interchange-safe values, since
+ * this format's output is pasted into other programs and sent to web
+ * services.
+ */
+
+class AVOGADROIO_EXPORT SmilesFormat : public FileFormat
+{
+public:
+  SmilesFormat() = default;
+  ~SmilesFormat() override = default;
+
+  Operations supportedOperations() const override
+  {
+    return Write | File | Stream | String;
+  }
+
+  FileFormat* newInstance() const override { return new SmilesFormat; }
+  std::string identifier() const override { return "Avogadro: SMILES"; }
+  std::string name() const override { return "SMILES"; }
+  std::string description() const override
+  {
+    return "Line notation describing molecular connectivity.";
+  }
+
+  std::string specificationUrl() const override
+  {
+    return "http://opensmiles.org/opensmiles.html";
+  }
+
+  std::vector<std::string> fileExtensions() const override;
+  std::vector<std::string> mimeTypes() const override;
+
+  [[nodiscard]] bool read(std::istream& inStream,
+                          Core::Molecule& molecule) override;
+  [[nodiscard]] bool write(std::ostream& outStream,
+                           const Core::Molecule& molecule) override;
+};
+
+} // namespace Avogadro::Io
+
+#endif // AVOGADRO_IO_SMILESFORMAT_H

--- a/avogadro/io/smilesparser.cpp
+++ b/avogadro/io/smilesparser.cpp
@@ -1,0 +1,881 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "smilesparser.h"
+
+#include "smilesvalence_p.h"
+
+#include <avogadro/core/elements.h>
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/utilities.h>
+
+#include <string>
+#include <vector>
+
+namespace Avogadro::Io {
+
+using Core::Elements;
+using Core::Molecule;
+
+namespace {
+
+/** SMILES can express ring bond numbers 0-9 bare and 10-99 as %nn. */
+const int MaxRingNumber = 99;
+
+bool isAsciiDigit(char c)
+{
+  return c >= '0' && c <= '9';
+}
+
+bool isAsciiUpper(char c)
+{
+  return c >= 'A' && c <= 'Z';
+}
+
+bool isAsciiLower(char c)
+{
+  return c >= 'a' && c <= 'z';
+}
+
+char toAsciiUpper(char c)
+{
+  return isAsciiLower(c) ? static_cast<char>(c - 'a' + 'A') : c;
+}
+
+/** The five multi-letter chirality classes OpenSMILES defines. Anything else
+ *  after a lone '@' is not part of the chirality symbol at all. */
+bool isChiralClassCode(char a, char b)
+{
+  static const char* const codes[] = { "TH", "AL", "SP", "TB", "OH" };
+  for (const char* code : codes) {
+    if (a == code[0] && b == code[1])
+      return true;
+  }
+  return false;
+}
+
+/** One written atom, before hydrogens are materialized. */
+struct ParsedAtom
+{
+  unsigned char atomicNumber = 0;
+  signed char charge = 0;
+  unsigned short isotope = 0;
+  size_t mapClass = 0;
+  bool bracket = false;          //!< [...], where a hydrogen count is explicit.
+  bool aromatic = false;         //!< Written lower case.
+  unsigned char explicitH = 0;   //!< Bracket hydrogen count; unused otherwise.
+  unsigned int bondOrderSum = 0; //!< Sum of orders of the bonds written to it.
+};
+
+/** One written bond, whether from the chain or a ring closure. */
+struct ParsedBond
+{
+  Index a;
+  Index b;
+  unsigned char order;
+};
+
+/** A bond symbol read from the input, waiting to attach to what follows it. */
+struct PendingBond
+{
+  bool set = false;
+  unsigned char order = 1; //!< Meaningless when aromatic is true.
+  bool aromatic = false;
+  bool directional = false; //!< '/' or '\', discarded but tracked for a
+                            //!< warning.
+  size_t position = 0;
+};
+
+/** One ring bond number, 0-99, while it is open (or just after it closes). */
+struct RingSlot
+{
+  bool open = false;
+  Index atom = 0;
+  int order = -1; //!< -1 means unspecified.
+  bool aromatic = false;
+  size_t openPosition = 0;
+};
+
+/**
+ * Turns a SMILES string into local plain structs describing a molecule, then
+ * -- only once the whole string has parsed without error -- builds the real
+ * Core::Molecule from them. Building at the end, rather than as the string is
+ * read, is what lets a failure partway through leave the caller's molecule
+ * untouched at no extra cost.
+ *
+ * There is no recursion anywhere here, matching SmilesWriter: a branch stack
+ * takes the place of one recursive call per '(', so a long, deeply nested
+ * string cannot overflow the stack.
+ */
+class Parser
+{
+public:
+  explicit Parser(const std::string& smiles) : m_input(smiles) {}
+
+  bool run(Molecule& molecule, std::string& error, size_t& errorPosition,
+           std::vector<std::string>& warnings, std::vector<size_t>& atomMaps);
+
+private:
+  bool parseStructure();
+  bool parseBracketAtom(size_t bracketStart);
+  bool parseBareAtom();
+  bool consumeRingClosure();
+  bool readDigits(size_t& i, unsigned long maxValue, unsigned long& value);
+
+  void finishAtom(Index atom, size_t atomStart);
+  void addRealBond(Index a, Index b, unsigned char order);
+  bool bondExists(Index a, Index b) const;
+  void noteAromatic(size_t position);
+
+  void fail(const std::string& message, size_t position);
+
+  void buildMolecule(Molecule& molecule, std::vector<size_t>& atomMaps) const;
+
+  const std::string& m_input;
+  size_t m_pos = 0;
+
+  std::vector<ParsedAtom> m_atoms;
+  std::vector<ParsedBond> m_bonds;
+
+  // previousAtom, position of the '(' -- for "never closed" and "opened with
+  // no preceding atom" diagnostics.
+  std::vector<std::pair<Index, size_t>> m_branchStack;
+  Index m_previousAtom = MaxIndex;
+  PendingBond m_pendingBond;
+
+  RingSlot m_ringSlots[MaxRingNumber + 1];
+
+  bool m_sawAromatic = false;
+  size_t m_aromaticPosition = 0;
+  bool m_sawStereo = false;
+
+  std::string m_error;
+  size_t m_errorPosition = 0;
+};
+
+void Parser::fail(const std::string& message, size_t position)
+{
+  // The caller returns false immediately after calling this, so the first
+  // failure is always the one that sticks.
+  m_error = message;
+  m_errorPosition = position;
+}
+
+void Parser::noteAromatic(size_t position)
+{
+  if (!m_sawAromatic) {
+    m_sawAromatic = true;
+    m_aromaticPosition = position;
+  }
+}
+
+bool Parser::bondExists(Index a, Index b) const
+{
+  for (const ParsedBond& bond : m_bonds) {
+    if ((bond.a == a && bond.b == b) || (bond.a == b && bond.b == a))
+      return true;
+  }
+  return false;
+}
+
+void Parser::addRealBond(Index a, Index b, unsigned char order)
+{
+  m_bonds.push_back(ParsedBond{ a, b, order });
+  m_atoms[a].bondOrderSum += order;
+  m_atoms[b].bondOrderSum += order;
+}
+
+/**
+ * Read a run of digits at @a i into @a value, advancing @a i past it.
+ *
+ * Returns false both for "no digits here" and for "the number is larger than
+ * @a maxValue". Every caller checks for a digit before calling, so a false
+ * return always means overflow -- keep that check when adding one.
+ */
+bool Parser::readDigits(size_t& i, unsigned long maxValue, unsigned long& value)
+{
+  value = 0;
+  bool any = false;
+  while (i < m_input.size() && isAsciiDigit(m_input[i])) {
+    any = true;
+    const unsigned long digit = static_cast<unsigned long>(m_input[i] - '0');
+    if (value > (maxValue - digit) / 10) {
+      // Consume the rest of the run so the caller's position tracking still
+      // lands past the offending number, then report the overflow.
+      while (i < m_input.size() && isAsciiDigit(m_input[i]))
+        ++i;
+      return false;
+    }
+    value = value * 10 + digit;
+    ++i;
+  }
+  return any;
+}
+
+void Parser::finishAtom(Index atom, size_t atomStart)
+{
+  if (m_atoms[atom].aromatic)
+    noteAromatic(atomStart);
+
+  if (m_previousAtom != MaxIndex) {
+    // Nothing written between two atoms means a single bond, except between
+    // two lower case atoms, where it means an aromatic one -- but both of
+    // those already tripped noteAromatic() through their own symbols, so the
+    // order recorded for such a bond is never reached.
+    unsigned char order = 1;
+    if (m_pendingBond.set) {
+      order = m_pendingBond.order;
+      if (m_pendingBond.aromatic)
+        noteAromatic(m_pendingBond.position);
+      if (m_pendingBond.directional)
+        m_sawStereo = true;
+    }
+    addRealBond(m_previousAtom, atom, order);
+  }
+
+  m_previousAtom = atom;
+  m_pendingBond = PendingBond{};
+}
+
+bool Parser::parseBareAtom()
+{
+  const size_t start = m_pos;
+  const char c = m_input[start];
+  unsigned char atomicNumber = 0;
+  bool aromatic = false;
+  bool wildcard = false;
+  size_t consumed = 0;
+
+  // Cl and Br have to be matched before the single letter forms C and B.
+  if (c == '*') {
+    wildcard = true;
+    consumed = 1;
+  } else if (c == 'C' && start + 1 < m_input.size() &&
+             m_input[start + 1] == 'l') {
+    atomicNumber = 17;
+    consumed = 2;
+  } else if (c == 'B' && start + 1 < m_input.size() &&
+             m_input[start + 1] == 'r') {
+    atomicNumber = 35;
+    consumed = 2;
+  } else {
+    switch (c) {
+      case 'B':
+        atomicNumber = 5;
+        consumed = 1;
+        break;
+      case 'C':
+        atomicNumber = 6;
+        consumed = 1;
+        break;
+      case 'N':
+        atomicNumber = 7;
+        consumed = 1;
+        break;
+      case 'O':
+        atomicNumber = 8;
+        consumed = 1;
+        break;
+      case 'P':
+        atomicNumber = 15;
+        consumed = 1;
+        break;
+      case 'S':
+        atomicNumber = 16;
+        consumed = 1;
+        break;
+      case 'F':
+        atomicNumber = 9;
+        consumed = 1;
+        break;
+      case 'I':
+        atomicNumber = 53;
+        consumed = 1;
+        break;
+      case 'b':
+        atomicNumber = 5;
+        aromatic = true;
+        consumed = 1;
+        break;
+      case 'c':
+        atomicNumber = 6;
+        aromatic = true;
+        consumed = 1;
+        break;
+      case 'n':
+        atomicNumber = 7;
+        aromatic = true;
+        consumed = 1;
+        break;
+      case 'o':
+        atomicNumber = 8;
+        aromatic = true;
+        consumed = 1;
+        break;
+      case 'p':
+        atomicNumber = 15;
+        aromatic = true;
+        consumed = 1;
+        break;
+      case 's':
+        atomicNumber = 16;
+        aromatic = true;
+        consumed = 1;
+        break;
+      default:
+        fail("Unexpected character.", start);
+        return false;
+    }
+  }
+
+  m_pos += consumed;
+
+  ParsedAtom atom;
+  atom.atomicNumber = wildcard ? 0 : atomicNumber;
+  atom.aromatic = aromatic;
+  atom.bracket = false;
+  m_atoms.push_back(atom);
+  finishAtom(static_cast<Index>(m_atoms.size() - 1), start);
+  return true;
+}
+
+bool Parser::parseBracketAtom(size_t bracketStart)
+{
+  size_t i = bracketStart + 1;
+  const size_t n = m_input.size();
+
+  if (i >= n) {
+    fail("Unterminated bracket atom.", bracketStart);
+    return false;
+  }
+  if (m_input[i] == ']') {
+    fail("Empty bracket atom.", bracketStart);
+    return false;
+  }
+
+  ParsedAtom atom;
+  atom.bracket = true;
+
+  // Isotope: one or more digits immediately after '['.
+  if (isAsciiDigit(m_input[i])) {
+    const size_t digitsStart = i;
+    unsigned long value = 0;
+    if (!readDigits(i, 65535UL, value)) {
+      fail("Isotope number is too large.", digitsStart);
+      return false;
+    }
+    atom.isotope = static_cast<unsigned short>(value);
+  }
+
+  if (i >= n) {
+    fail("Unterminated bracket atom.", bracketStart);
+    return false;
+  }
+
+  // Symbol: any element symbol, the lower case aromatic forms, '*', or 'H'.
+  const size_t symbolStart = i;
+  bool wildcard = false;
+  unsigned char atomicNumber = InvalidElement;
+  bool aromatic = false;
+
+  if (m_input[i] == '*') {
+    wildcard = true;
+    ++i;
+  } else if (isAsciiUpper(m_input[i])) {
+    // Try the two letter form first -- the second letter of a real element
+    // symbol is always lower case -- and fall back to one letter.
+    unsigned char found = InvalidElement;
+    size_t consumed = 0;
+    if (i + 1 < n && isAsciiLower(m_input[i + 1])) {
+      found = Elements::atomicNumberFromSymbol(m_input.substr(i, 2));
+      if (found != InvalidElement)
+        consumed = 2;
+    }
+    if (consumed == 0) {
+      found = Elements::atomicNumberFromSymbol(m_input.substr(i, 1));
+      if (found != InvalidElement)
+        consumed = 1;
+    }
+    if (consumed == 0) {
+      fail("Unknown element symbol in bracket atom.", symbolStart);
+      return false;
+    }
+    atomicNumber = found;
+    i += consumed;
+  } else if (isAsciiLower(m_input[i])) {
+    // The aromatic forms: two letter (se, as, si, te) tried before one
+    // letter, exactly as the bare atom grammar does.
+    unsigned char found = InvalidElement;
+    size_t consumed = 0;
+    if (i + 1 < n) {
+      const std::string candidate = m_input.substr(i, 2);
+      if (candidate == "se" || candidate == "as" || candidate == "si" ||
+          candidate == "te") {
+        std::string proper = candidate;
+        proper[0] = toAsciiUpper(proper[0]);
+        found = Elements::atomicNumberFromSymbol(proper);
+        if (found != InvalidElement)
+          consumed = 2;
+      }
+    }
+    if (consumed == 0 &&
+        (m_input[i] == 'b' || m_input[i] == 'c' || m_input[i] == 'n' ||
+         m_input[i] == 'o' || m_input[i] == 'p' || m_input[i] == 's')) {
+      const std::string proper(1, toAsciiUpper(m_input[i]));
+      found = Elements::atomicNumberFromSymbol(proper);
+      if (found != InvalidElement)
+        consumed = 1;
+    }
+    if (consumed == 0) {
+      fail("Unknown element symbol in bracket atom.", symbolStart);
+      return false;
+    }
+    atomicNumber = found;
+    aromatic = true;
+    i += consumed;
+  } else {
+    fail("Expected an element symbol in bracket atom.", symbolStart);
+    return false;
+  }
+
+  atom.atomicNumber = wildcard ? 0 : atomicNumber;
+  atom.aromatic = aromatic;
+
+  // Chirality: "@", "@@", or "@" plus one of the named classes plus one or
+  // two digits. Parsed only to be discarded -- see the class comment.
+  if (i < n && m_input[i] == '@') {
+    m_sawStereo = true;
+    ++i;
+    if (i < n && m_input[i] == '@') {
+      ++i;
+    } else if (i + 1 < n && isChiralClassCode(m_input[i], m_input[i + 1])) {
+      i += 2;
+      size_t digits = 0;
+      while (i < n && isAsciiDigit(m_input[i]) && digits < 2) {
+        ++i;
+        ++digits;
+      }
+    }
+  }
+
+  // Hydrogen count: never inferred inside a bracket, so no 'H' means zero.
+  if (i < n && m_input[i] == 'H') {
+    ++i;
+    atom.explicitH = 1;
+    if (i < n && isAsciiDigit(m_input[i])) {
+      atom.explicitH = static_cast<unsigned char>(m_input[i] - '0');
+      ++i;
+    }
+  }
+
+  // Charge: a digit run ("+2"), or the sign repeated ("++").
+  if (i < n && (m_input[i] == '+' || m_input[i] == '-')) {
+    const char sign = m_input[i];
+    const size_t chargeStart = i;
+    ++i;
+    unsigned long magnitude = 1;
+    if (i < n && isAsciiDigit(m_input[i])) {
+      if (!readDigits(i, 127UL, magnitude)) {
+        fail("Formal charge is too large.", chargeStart);
+        return false;
+      }
+    } else {
+      while (i < n && m_input[i] == sign) {
+        ++magnitude;
+        ++i;
+      }
+      if (magnitude > 127) {
+        fail("Formal charge is too large.", chargeStart);
+        return false;
+      }
+    }
+    atom.charge =
+      static_cast<signed char>(sign == '+' ? static_cast<long>(magnitude)
+                                           : -static_cast<long>(magnitude));
+  }
+
+  // Atom class: ':' followed by digits.
+  if (i < n && m_input[i] == ':') {
+    const size_t classStart = i;
+    ++i;
+    if (i >= n || !isAsciiDigit(m_input[i])) {
+      fail("Expected digits after ':' for an atom class.", classStart);
+      return false;
+    }
+    unsigned long value = 0;
+    if (!readDigits(i, 999999999UL, value)) {
+      fail("Atom class number is too large.", classStart);
+      return false;
+    }
+    atom.mapClass = static_cast<size_t>(value);
+  }
+
+  if (i >= n) {
+    fail("Unterminated bracket atom.", bracketStart);
+    return false;
+  }
+  if (m_input[i] != ']') {
+    fail("Unexpected character inside bracket atom.", i);
+    return false;
+  }
+  ++i;
+
+  m_pos = i;
+  m_atoms.push_back(atom);
+  finishAtom(static_cast<Index>(m_atoms.size() - 1), bracketStart);
+  return true;
+}
+
+bool Parser::consumeRingClosure()
+{
+  const size_t start = m_pos;
+  int number = 0;
+  if (m_input[m_pos] == '%') {
+    ++m_pos;
+    if (m_pos + 1 >= m_input.size() || !isAsciiDigit(m_input[m_pos]) ||
+        !isAsciiDigit(m_input[m_pos + 1])) {
+      fail("'%' must be followed by exactly two digits.", start);
+      return false;
+    }
+    number = (m_input[m_pos] - '0') * 10 + (m_input[m_pos + 1] - '0');
+    m_pos += 2;
+  } else {
+    number = m_input[m_pos] - '0';
+    ++m_pos;
+  }
+
+  if (m_previousAtom == MaxIndex) {
+    fail("Ring closure with no preceding atom.", start);
+    return false;
+  }
+
+  RingSlot& slot = m_ringSlots[number];
+  if (!slot.open) {
+    slot.open = true;
+    slot.atom = m_previousAtom;
+    slot.openPosition = start;
+    if (m_pendingBond.set) {
+      slot.order = m_pendingBond.order;
+      slot.aromatic = m_pendingBond.aromatic;
+      if (m_pendingBond.aromatic)
+        noteAromatic(m_pendingBond.position);
+      if (m_pendingBond.directional)
+        m_sawStereo = true;
+    } else {
+      slot.order = -1;
+      slot.aromatic = false;
+    }
+    m_pendingBond = PendingBond{};
+    return true;
+  }
+
+  // Closing: pair this occurrence with the one that opened it.
+  const Index openAtom = slot.atom;
+  if (openAtom == m_previousAtom) {
+    fail("A ring closure cannot bond an atom to itself.", start);
+    return false;
+  }
+
+  int closeOrder = -1;
+  bool closeAromatic = false;
+  if (m_pendingBond.set) {
+    closeOrder = m_pendingBond.order;
+    closeAromatic = m_pendingBond.aromatic;
+    if (m_pendingBond.aromatic)
+      noteAromatic(m_pendingBond.position);
+    if (m_pendingBond.directional)
+      m_sawStereo = true;
+  }
+
+  const bool openSpecified = slot.order != -1 || slot.aromatic;
+  const bool closeSpecified = closeOrder != -1 || closeAromatic;
+  if (openSpecified && closeSpecified) {
+    const bool disagree = (slot.aromatic != closeAromatic) ||
+                          (!slot.aromatic && slot.order != closeOrder);
+    if (disagree) {
+      fail("The two ends of this ring closure specify different bonds.",
+           m_pendingBond.set ? m_pendingBond.position : start);
+      return false;
+    }
+  }
+
+  // Aromatic bond orders are never used past the rejection in run(), so
+  // recording them as plain single bonds here is harmless.
+  unsigned char order = 1;
+  if (openSpecified)
+    order = slot.aromatic ? 1 : static_cast<unsigned char>(slot.order);
+  else if (closeSpecified)
+    order = closeAromatic ? 1 : static_cast<unsigned char>(closeOrder);
+  else if (m_atoms[openAtom].aromatic && m_atoms[m_previousAtom].aromatic)
+    order = 1; // Aromatic by default; already noted through the atoms.
+
+  if (bondExists(openAtom, m_previousAtom)) {
+    fail("This ring closure duplicates a bond that already exists between "
+         "these two atoms.",
+         start);
+    return false;
+  }
+
+  addRealBond(openAtom, m_previousAtom, order);
+  slot.open = false;
+  m_pendingBond = PendingBond{};
+  return true;
+}
+
+bool Parser::parseStructure()
+{
+  const size_t n = m_input.size();
+
+  while (m_pos < n) {
+    const char c = m_input[m_pos];
+
+    if (c == '(') {
+      if (m_pendingBond.set) {
+        fail("A bond symbol must be followed by an atom or ring closure.",
+             m_pendingBond.position);
+        return false;
+      }
+      if (m_previousAtom == MaxIndex) {
+        fail("'(' with no preceding atom to branch from.", m_pos);
+        return false;
+      }
+      m_branchStack.emplace_back(m_previousAtom, m_pos);
+      ++m_pos;
+      continue;
+    }
+
+    if (c == ')') {
+      if (m_pendingBond.set) {
+        fail("A bond symbol must be followed by an atom or ring closure.",
+             m_pendingBond.position);
+        return false;
+      }
+      if (m_branchStack.empty()) {
+        fail("')' has no matching '('.", m_pos);
+        return false;
+      }
+      m_previousAtom = m_branchStack.back().first;
+      m_branchStack.pop_back();
+      ++m_pos;
+      continue;
+    }
+
+    if (c == '.') {
+      if (m_pendingBond.set) {
+        fail("A bond symbol must be followed by an atom or ring closure.",
+             m_pendingBond.position);
+        return false;
+      }
+      m_previousAtom = MaxIndex;
+      ++m_pos;
+      continue;
+    }
+
+    if (c == '-' || c == '=' || c == '#' || c == '$' || c == ':' || c == '/' ||
+        c == '\\') {
+      if (m_pendingBond.set) {
+        fail("Unexpected character.", m_pos);
+        return false;
+      }
+      if (m_previousAtom == MaxIndex) {
+        fail("Bond symbol with no preceding atom.", m_pos);
+        return false;
+      }
+      PendingBond pending;
+      pending.set = true;
+      pending.position = m_pos;
+      switch (c) {
+        case '-':
+          pending.order = 1;
+          break;
+        case '=':
+          pending.order = 2;
+          break;
+        case '#':
+          pending.order = 3;
+          break;
+        case '$':
+          pending.order = 4;
+          break;
+        case ':':
+          pending.aromatic = true;
+          break;
+        case '/':
+        case '\\':
+          pending.order = 1;
+          pending.directional = true;
+          break;
+      }
+      m_pendingBond = pending;
+      ++m_pos;
+      continue;
+    }
+
+    if (c == '[') {
+      if (!parseBracketAtom(m_pos))
+        return false;
+      continue;
+    }
+
+    if (c == '%' || isAsciiDigit(c)) {
+      if (!consumeRingClosure())
+        return false;
+      continue;
+    }
+
+    if (!parseBareAtom())
+      return false;
+  }
+
+  if (m_pendingBond.set) {
+    fail("A bond symbol must be followed by an atom or ring closure.",
+         m_pendingBond.position);
+    return false;
+  }
+  if (!m_branchStack.empty()) {
+    fail("'(' was never closed.", m_branchStack.back().second);
+    return false;
+  }
+
+  // Report whichever ring number was opened first if more than one is still
+  // open, since that is the one whose problem the input hit first.
+  bool anyOpen = false;
+  size_t firstOpenPosition = 0;
+  for (int number = 0; number <= MaxRingNumber; ++number) {
+    if (m_ringSlots[number].open &&
+        (!anyOpen || m_ringSlots[number].openPosition < firstOpenPosition)) {
+      anyOpen = true;
+      firstOpenPosition = m_ringSlots[number].openPosition;
+    }
+  }
+  if (anyOpen) {
+    fail("A ring closure was opened but never closed.", firstOpenPosition);
+    return false;
+  }
+
+  return true;
+}
+
+void Parser::buildMolecule(Molecule& molecule,
+                           std::vector<size_t>& atomMaps) const
+{
+  const Index writtenCount = static_cast<Index>(m_atoms.size());
+
+  for (const ParsedAtom& atom : m_atoms) {
+    const Molecule::AtomType added = molecule.addAtom(atom.atomicNumber);
+    if (atom.charge != 0)
+      molecule.setFormalCharge(added.index(), atom.charge);
+    if (atom.isotope != 0)
+      molecule.setIsotope(added.index(), atom.isotope);
+  }
+
+  for (const ParsedBond& bond : m_bonds)
+    molecule.addBond(bond.a, bond.b, bond.order);
+
+  // Second pass: every implied or bracket-counted hydrogen becomes a real
+  // atom, appended after every written atom and grouped by the atom it
+  // belongs to. This has to wait until now because a bare atom's implied
+  // count depends on its bond order sum, which is not final until its ring
+  // closures -- possibly written much later in the string -- have closed.
+  for (Index parent = 0; parent < writtenCount; ++parent) {
+    const ParsedAtom& atom = m_atoms[parent];
+    int hCount = 0;
+    if (atom.bracket) {
+      hCount = atom.explicitH;
+    } else if (atom.atomicNumber != 0) {
+      // Bare, non-wildcard: every bare atom this parser accepts is in the
+      // organic subset, so this always returns a real count.
+      const int implied =
+        smilesImpliedHydrogens(atom.atomicNumber, atom.bondOrderSum);
+      hCount = (implied == SmilesNotOrganicSubset) ? 0 : implied;
+    }
+    // A bare wildcard has no implied hydrogen rule and gets none.
+
+    for (int h = 0; h < hCount; ++h) {
+      const Molecule::AtomType hydrogen = molecule.addAtom(1);
+      molecule.addBond(parent, hydrogen.index(), 1);
+    }
+  }
+
+  atomMaps.assign(molecule.atomCount(), 0);
+  for (Index i = 0; i < writtenCount; ++i)
+    atomMaps[i] = m_atoms[i].mapClass;
+}
+
+bool Parser::run(Molecule& molecule, std::string& error, size_t& errorPosition,
+                 std::vector<std::string>& warnings,
+                 std::vector<size_t>& atomMaps)
+{
+  if (!parseStructure()) {
+    error = m_error;
+    errorPosition = m_errorPosition;
+    return false;
+  }
+
+  // ---------------------------------------------------------------------
+  // Aromatic input is rejected here, as a single block, because turning an
+  // aromatic ring back into alternating single and double bonds requires a
+  // kekulizer that does not exist yet. Once one does, replace this block
+  // with a call to it instead of failing.
+  if (m_sawAromatic) {
+    error = "Aromatic SMILES requires kekulization, which is not yet "
+            "implemented.";
+    errorPosition = m_aromaticPosition;
+    return false;
+  }
+  // ---------------------------------------------------------------------
+
+  if (m_sawStereo) {
+    warnings.push_back(
+      "Stereochemistry (chirality and bond direction markers) was "
+      "discarded: a freshly parsed molecule has no coordinates for it to "
+      "describe.");
+  }
+
+  buildMolecule(molecule, atomMaps);
+  return true;
+}
+
+} // namespace
+
+bool SmilesParser::parse(const std::string& smiles, Core::Molecule& molecule)
+{
+  // clearAtoms() rather than assigning a default Molecule: this takes a
+  // reference to the base class, so assignment would slice a QtGui::Molecule
+  // and leave its derived state behind. clearAtoms() is virtual and clears
+  // everything indexed by atom, leaving only molecule-wide data such as the
+  // name, which the title below overwrites when the string carries one.
+  molecule.clearAtoms();
+  m_error.clear();
+  m_errorPosition = 0;
+  m_warnings.clear();
+  m_atomMaps.clear();
+
+  // The string ends at the first space, tab, CR or LF; anything after that,
+  // trimmed, is a title rather than part of the structure. This is the same
+  // convention xyzformat's comment line uses for a molecule name.
+  const size_t titleStart = smiles.find_first_of(" \t\r\n");
+  const std::string structure =
+    (titleStart == std::string::npos) ? smiles : smiles.substr(0, titleStart);
+  const std::string title = (titleStart == std::string::npos)
+                              ? std::string()
+                              : Core::trimmed(smiles.substr(titleStart));
+
+  Parser parser(structure);
+  if (!parser.run(molecule, m_error, m_errorPosition, m_warnings, m_atomMaps)) {
+    // run() builds nothing until the whole string has parsed, so there is
+    // nothing to undo here; this only restates the guarantee.
+    molecule.clearAtoms();
+    m_atomMaps.clear();
+    return false;
+  }
+
+  if (!title.empty())
+    molecule.setData("name", title);
+
+  return true;
+}
+
+} // namespace Avogadro::Io

--- a/avogadro/io/smilesparser.cpp
+++ b/avogadro/io/smilesparser.cpp
@@ -8,6 +8,7 @@
 #include "smilesvalence_p.h"
 
 #include <avogadro/core/elements.h>
+#include <avogadro/core/kekulize.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/utilities.h>
 
@@ -67,6 +68,7 @@ struct ParsedAtom
   bool aromatic = false;         //!< Written lower case.
   unsigned char explicitH = 0;   //!< Bracket hydrogen count; unused otherwise.
   unsigned int bondOrderSum = 0; //!< Sum of orders of the bonds written to it.
+  bool hasAromaticBond = false;  //!< True once any bond to it is aromatic.
 };
 
 /** One written bond, whether from the chain or a ring closure. */
@@ -75,6 +77,7 @@ struct ParsedBond
   Index a;
   Index b;
   unsigned char order;
+  bool aromatic;
 };
 
 /** A bond symbol read from the input, waiting to attach to what follows it. */
@@ -125,13 +128,15 @@ private:
   bool readDigits(size_t& i, unsigned long maxValue, unsigned long& value);
 
   void finishAtom(Index atom, size_t atomStart);
-  void addRealBond(Index a, Index b, unsigned char order);
+  void addRealBond(Index a, Index b, unsigned char order, bool aromatic);
   bool bondExists(Index a, Index b) const;
   void noteAromatic(size_t position);
+  void notePendingBond();
+  bool rejectDanglingBond();
 
   void fail(const std::string& message, size_t position);
 
-  void buildMolecule(Molecule& molecule, std::vector<size_t>& atomMaps) const;
+  bool buildMolecule(Molecule& molecule, std::vector<size_t>& atomMaps);
 
   const std::string& m_input;
   size_t m_pos = 0;
@@ -171,6 +176,32 @@ void Parser::noteAromatic(size_t position)
   }
 }
 
+/**
+ * Record what a pending bond symbol says beyond its order, for whichever of
+ * the three things a bond can attach to consumes it.
+ */
+void Parser::notePendingBond()
+{
+  if (m_pendingBond.aromatic)
+    noteAromatic(m_pendingBond.position);
+  if (m_pendingBond.directional)
+    m_sawStereo = true;
+}
+
+/**
+ * A bond symbol has to be followed by something to bond to. Call this
+ * wherever the next token cannot be that thing.
+ * @return False if a bond symbol is left dangling, having reported it.
+ */
+bool Parser::rejectDanglingBond()
+{
+  if (!m_pendingBond.set)
+    return true;
+  fail("A bond symbol must be followed by an atom or ring closure.",
+       m_pendingBond.position);
+  return false;
+}
+
 bool Parser::bondExists(Index a, Index b) const
 {
   for (const ParsedBond& bond : m_bonds) {
@@ -180,11 +211,15 @@ bool Parser::bondExists(Index a, Index b) const
   return false;
 }
 
-void Parser::addRealBond(Index a, Index b, unsigned char order)
+void Parser::addRealBond(Index a, Index b, unsigned char order, bool aromatic)
 {
-  m_bonds.push_back(ParsedBond{ a, b, order });
+  m_bonds.push_back(ParsedBond{ a, b, order, aromatic });
   m_atoms[a].bondOrderSum += order;
   m_atoms[b].bondOrderSum += order;
+  if (aromatic) {
+    m_atoms[a].hasAromaticBond = true;
+    m_atoms[b].hasAromaticBond = true;
+  }
 }
 
 /**
@@ -221,18 +256,19 @@ void Parser::finishAtom(Index atom, size_t atomStart)
 
   if (m_previousAtom != MaxIndex) {
     // Nothing written between two atoms means a single bond, except between
-    // two lower case atoms, where it means an aromatic one -- but both of
-    // those already tripped noteAromatic() through their own symbols, so the
-    // order recorded for such a bond is never reached.
+    // two lower case atoms, where it means an aromatic one -- both of those
+    // already tripped noteAromatic() through their own symbols, so this is
+    // just recovering the same fact to flag the bond itself.
     unsigned char order = 1;
+    bool aromatic = false;
     if (m_pendingBond.set) {
       order = m_pendingBond.order;
-      if (m_pendingBond.aromatic)
-        noteAromatic(m_pendingBond.position);
-      if (m_pendingBond.directional)
-        m_sawStereo = true;
+      aromatic = m_pendingBond.aromatic;
+      notePendingBond();
+    } else {
+      aromatic = m_atoms[m_previousAtom].aromatic && m_atoms[atom].aromatic;
     }
-    addRealBond(m_previousAtom, atom, order);
+    addRealBond(m_previousAtom, atom, order, aromatic);
   }
 
   m_previousAtom = atom;
@@ -559,10 +595,7 @@ bool Parser::consumeRingClosure()
     if (m_pendingBond.set) {
       slot.order = m_pendingBond.order;
       slot.aromatic = m_pendingBond.aromatic;
-      if (m_pendingBond.aromatic)
-        noteAromatic(m_pendingBond.position);
-      if (m_pendingBond.directional)
-        m_sawStereo = true;
+      notePendingBond();
     } else {
       slot.order = -1;
       slot.aromatic = false;
@@ -583,10 +616,7 @@ bool Parser::consumeRingClosure()
   if (m_pendingBond.set) {
     closeOrder = m_pendingBond.order;
     closeAromatic = m_pendingBond.aromatic;
-    if (m_pendingBond.aromatic)
-      noteAromatic(m_pendingBond.position);
-    if (m_pendingBond.directional)
-      m_sawStereo = true;
+    notePendingBond();
   }
 
   const bool openSpecified = slot.order != -1 || slot.aromatic;
@@ -601,15 +631,19 @@ bool Parser::consumeRingClosure()
     }
   }
 
-  // Aromatic bond orders are never used past the rejection in run(), so
-  // recording them as plain single bonds here is harmless.
+  // An aromatic bond's order is a placeholder here: kekulize() decides the
+  // real one later, from the aromatic flag recorded alongside it below.
   unsigned char order = 1;
-  if (openSpecified)
-    order = slot.aromatic ? 1 : static_cast<unsigned char>(slot.order);
-  else if (closeSpecified)
-    order = closeAromatic ? 1 : static_cast<unsigned char>(closeOrder);
-  else if (m_atoms[openAtom].aromatic && m_atoms[m_previousAtom].aromatic)
-    order = 1; // Aromatic by default; already noted through the atoms.
+  bool aromatic = false;
+  if (openSpecified) {
+    aromatic = slot.aromatic;
+    order = aromatic ? 1 : static_cast<unsigned char>(slot.order);
+  } else if (closeSpecified) {
+    aromatic = closeAromatic;
+    order = aromatic ? 1 : static_cast<unsigned char>(closeOrder);
+  } else if (m_atoms[openAtom].aromatic && m_atoms[m_previousAtom].aromatic) {
+    aromatic = true; // Aromatic by default; already noted through the atoms.
+  }
 
   if (bondExists(openAtom, m_previousAtom)) {
     fail("This ring closure duplicates a bond that already exists between "
@@ -618,7 +652,7 @@ bool Parser::consumeRingClosure()
     return false;
   }
 
-  addRealBond(openAtom, m_previousAtom, order);
+  addRealBond(openAtom, m_previousAtom, order, aromatic);
   slot.open = false;
   m_pendingBond = PendingBond{};
   return true;
@@ -632,11 +666,8 @@ bool Parser::parseStructure()
     const char c = m_input[m_pos];
 
     if (c == '(') {
-      if (m_pendingBond.set) {
-        fail("A bond symbol must be followed by an atom or ring closure.",
-             m_pendingBond.position);
+      if (!rejectDanglingBond())
         return false;
-      }
       if (m_previousAtom == MaxIndex) {
         fail("'(' with no preceding atom to branch from.", m_pos);
         return false;
@@ -647,11 +678,8 @@ bool Parser::parseStructure()
     }
 
     if (c == ')') {
-      if (m_pendingBond.set) {
-        fail("A bond symbol must be followed by an atom or ring closure.",
-             m_pendingBond.position);
+      if (!rejectDanglingBond())
         return false;
-      }
       if (m_branchStack.empty()) {
         fail("')' has no matching '('.", m_pos);
         return false;
@@ -663,11 +691,8 @@ bool Parser::parseStructure()
     }
 
     if (c == '.') {
-      if (m_pendingBond.set) {
-        fail("A bond symbol must be followed by an atom or ring closure.",
-             m_pendingBond.position);
+      if (!rejectDanglingBond())
         return false;
-      }
       m_previousAtom = MaxIndex;
       ++m_pos;
       continue;
@@ -729,11 +754,8 @@ bool Parser::parseStructure()
       return false;
   }
 
-  if (m_pendingBond.set) {
-    fail("A bond symbol must be followed by an atom or ring closure.",
-         m_pendingBond.position);
+  if (!rejectDanglingBond())
     return false;
-  }
   if (!m_branchStack.empty()) {
     fail("'(' was never closed.", m_branchStack.back().second);
     return false;
@@ -758,8 +780,7 @@ bool Parser::parseStructure()
   return true;
 }
 
-void Parser::buildMolecule(Molecule& molecule,
-                           std::vector<size_t>& atomMaps) const
+bool Parser::buildMolecule(Molecule& molecule, std::vector<size_t>& atomMaps)
 {
   const Index writtenCount = static_cast<Index>(m_atoms.size());
 
@@ -771,16 +792,29 @@ void Parser::buildMolecule(Molecule& molecule,
       molecule.setIsotope(added.index(), atom.isotope);
   }
 
-  for (const ParsedBond& bond : m_bonds)
+  // Every aromatic bond starts out as a placeholder single bond; kekulize()
+  // below assigns its real order. m_bonds[i] and this molecule's bond i
+  // correspond one for one, which the hydrogen pass after kekulization
+  // relies on to read back the orders it produced.
+  std::vector<bool> aromaticBonds;
+  aromaticBonds.reserve(m_bonds.size());
+  bool anyAromatic = false;
+  for (const ParsedBond& bond : m_bonds) {
     molecule.addBond(bond.a, bond.b, bond.order);
+    aromaticBonds.push_back(bond.aromatic);
+    anyAromatic = anyAromatic || bond.aromatic;
+  }
 
-  // Second pass: every implied or bracket-counted hydrogen becomes a real
-  // atom, appended after every written atom and grouped by the atom it
-  // belongs to. This has to wait until now because a bare atom's implied
-  // count depends on its bond order sum, which is not final until its ring
-  // closures -- possibly written much later in the string -- have closed.
+  // First pass: every bracket atom (its count is stated in the string) and
+  // every bare atom with no aromatic bond (its bond order sum is therefore
+  // already final). This has to happen before kekulization, not after: a
+  // bracket atom's stated hydrogen count is part of what kekulize() needs to
+  // classify it correctly -- pyrrole's [nH] would be misread as pyridine's
+  // bare n otherwise.
   for (Index parent = 0; parent < writtenCount; ++parent) {
     const ParsedAtom& atom = m_atoms[parent];
+    if (!atom.bracket && atom.hasAromaticBond)
+      continue; // Bare and aromatic: handled below, once kekulized.
     int hCount = 0;
     if (atom.bracket) {
       hCount = atom.explicitH;
@@ -796,12 +830,57 @@ void Parser::buildMolecule(Molecule& molecule,
     for (int h = 0; h < hCount; ++h) {
       const Molecule::AtomType hydrogen = molecule.addAtom(1);
       molecule.addBond(parent, hydrogen.index(), 1);
+      // kekulize() below requires one aromaticBonds entry per bond in the
+      // molecule at the time it is called, and this hydrogen bond is not
+      // aromatic, so it needs an entry here too even though it has no
+      // ParsedBond of its own.
+      aromaticBonds.push_back(false);
+    }
+  }
+
+  if (anyAromatic) {
+    Index failedAtom = MaxIndex;
+    if (!Core::kekulize(molecule, aromaticBonds, &failedAtom)) {
+      fail("This aromatic system has no valid arrangement of alternating "
+           "single and double bonds.",
+           m_aromaticPosition);
+      return false;
+    }
+  }
+
+  // Second pass: bare atoms that are part of the aromatic system, whose
+  // implied hydrogen count depends on the bond orders kekulization just
+  // assigned. Their sum has to be read back from the molecule -- the
+  // placeholder order recorded in m_bonds is stale now.
+  if (anyAromatic) {
+    std::vector<unsigned int> finalOrderSum(writtenCount, 0);
+    const Core::Array<unsigned char>& orders = molecule.bondOrders();
+    for (Index i = 0; i < static_cast<Index>(m_bonds.size()); ++i) {
+      finalOrderSum[m_bonds[i].a] += orders[i];
+      finalOrderSum[m_bonds[i].b] += orders[i];
+    }
+
+    for (Index parent = 0; parent < writtenCount; ++parent) {
+      const ParsedAtom& atom = m_atoms[parent];
+      if (atom.bracket || !atom.hasAromaticBond)
+        continue; // Already handled in the first pass.
+      int hCount = 0;
+      if (atom.atomicNumber != 0) {
+        const int implied =
+          smilesImpliedHydrogens(atom.atomicNumber, finalOrderSum[parent]);
+        hCount = (implied == SmilesNotOrganicSubset) ? 0 : implied;
+      }
+      for (int h = 0; h < hCount; ++h) {
+        const Molecule::AtomType hydrogen = molecule.addAtom(1);
+        molecule.addBond(parent, hydrogen.index(), 1);
+      }
     }
   }
 
   atomMaps.assign(molecule.atomCount(), 0);
   for (Index i = 0; i < writtenCount; ++i)
     atomMaps[i] = m_atoms[i].mapClass;
+  return true;
 }
 
 bool Parser::run(Molecule& molecule, std::string& error, size_t& errorPosition,
@@ -814,19 +893,6 @@ bool Parser::run(Molecule& molecule, std::string& error, size_t& errorPosition,
     return false;
   }
 
-  // ---------------------------------------------------------------------
-  // Aromatic input is rejected here, as a single block, because turning an
-  // aromatic ring back into alternating single and double bonds requires a
-  // kekulizer that does not exist yet. Once one does, replace this block
-  // with a call to it instead of failing.
-  if (m_sawAromatic) {
-    error = "Aromatic SMILES requires kekulization, which is not yet "
-            "implemented.";
-    errorPosition = m_aromaticPosition;
-    return false;
-  }
-  // ---------------------------------------------------------------------
-
   if (m_sawStereo) {
     warnings.push_back(
       "Stereochemistry (chirality and bond direction markers) was "
@@ -834,7 +900,11 @@ bool Parser::run(Molecule& molecule, std::string& error, size_t& errorPosition,
       "describe.");
   }
 
-  buildMolecule(molecule, atomMaps);
+  if (!buildMolecule(molecule, atomMaps)) {
+    error = m_error;
+    errorPosition = m_errorPosition;
+    return false;
+  }
   return true;
 }
 
@@ -865,8 +935,10 @@ bool SmilesParser::parse(const std::string& smiles, Core::Molecule& molecule)
 
   Parser parser(structure);
   if (!parser.run(molecule, m_error, m_errorPosition, m_warnings, m_atomMaps)) {
-    // run() builds nothing until the whole string has parsed, so there is
-    // nothing to undo here; this only restates the guarantee.
+    // A structural failure builds nothing, but a kekulization failure is
+    // caught only after buildMolecule() has already added atoms and bonds --
+    // clear them so a failed parse always leaves the molecule empty, as
+    // documented.
     molecule.clearAtoms();
     m_atomMaps.clear();
     return false;

--- a/avogadro/io/smilesparser.h
+++ b/avogadro/io/smilesparser.h
@@ -29,10 +29,12 @@ namespace Avogadro::Io {
  * branches, ring closures and dot-disconnected components.
  *
  * Aromatic input -- a lowercase atom, or an aromatic bond, anywhere in the
- * string -- is rejected outright rather than guessed at. Turning an aromatic
- * ring back into alternating single and double bonds (kekulization) is not
- * implemented yet; the rejection is a single block in the .cpp file, marked
- * as the place a future kekulizer replaces.
+ * string -- is accepted: Core::kekulize() turns the aromatic ring or ring
+ * system back into alternating single and double bond orders, which is how
+ * Avogadro stores structures internally. If no assignment satisfies every
+ * aromatic atom's valence -- an unkekulizable input -- parsing fails with an
+ * error positioned at the first aromatic token in the string, and the
+ * molecule is left empty, the same as any other parse failure.
  *
  * Chirality markers and the directional bond markers '/' and '\' are parsed
  * -- so the rest of the string still makes sense -- but the stereochemistry
@@ -44,14 +46,15 @@ namespace Avogadro::Io {
  * Avogadro's convention is that every hydrogen is a real atom in the graph,
  * so every hydrogen this class infers -- from the organic subset valence
  * model on a bare atom, or from a bracket's H count -- is materialized as
- * one. An atom's final bond order sum, and so its implied hydrogen count, is
- * not known until its ring closures have all been seen, so this happens in a
- * second pass after the rest of the molecule is built. As a result, the
- * molecule this class produces orders its atoms as: first, every atom
- * written explicitly in the SMILES, in the order it appears in the string
- * (branches included, depth first); then every hydrogen this class added,
- * grouped by the atom it was added to and in that atom's order, in no
- * particular order within a group (they are interchangeable).
+ * one. A bracket atom's count is stated in the string, but a bare aromatic
+ * atom's implied count depends on the bond orders kekulization produces, so
+ * hydrogens for those atoms are added only after kekulization succeeds. As a
+ * result, the molecule this class produces orders its atoms as: first, every
+ * atom written explicitly in the SMILES, in the order it appears in the
+ * string (branches included, depth first); then every hydrogen this class
+ * added. The order of the added hydrogens themselves is unspecified -- they
+ * are interchangeable -- and does not simply follow their parent atoms'
+ * order, since it is now split across two passes.
  */
 class AVOGADROIO_EXPORT SmilesParser
 {

--- a/avogadro/io/smilesparser.h
+++ b/avogadro/io/smilesparser.h
@@ -1,0 +1,105 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_SMILESPARSER_H
+#define AVOGADRO_IO_SMILESPARSER_H
+
+#include "avogadroioexport.h"
+
+#include <avogadro/core/avogadrocore.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Avogadro::Core {
+class Molecule;
+}
+
+namespace Avogadro::Io {
+
+/**
+ * @class SmilesParser smilesparser.h <avogadro/io/smilesparser.h>
+ * @brief Parse a SMILES string into a molecule.
+ *
+ * This is the inverse of SmilesWriter, and follows the OpenSMILES grammar
+ * (http://opensmiles.org/opensmiles.html): the organic subset, bracket atoms,
+ * branches, ring closures and dot-disconnected components.
+ *
+ * Aromatic input -- a lowercase atom, or an aromatic bond, anywhere in the
+ * string -- is rejected outright rather than guessed at. Turning an aromatic
+ * ring back into alternating single and double bonds (kekulization) is not
+ * implemented yet; the rejection is a single block in the .cpp file, marked
+ * as the place a future kekulizer replaces.
+ *
+ * Chirality markers and the directional bond markers '/' and '\' are parsed
+ * -- so the rest of the string still makes sense -- but the stereochemistry
+ * they describe is discarded: a freshly parsed molecule has no coordinates,
+ * and Avogadro represents stereochemistry through coordinates rather than
+ * through a stored descriptor. warnings() reports this once per parse, not
+ * once per occurrence.
+ *
+ * Avogadro's convention is that every hydrogen is a real atom in the graph,
+ * so every hydrogen this class infers -- from the organic subset valence
+ * model on a bare atom, or from a bracket's H count -- is materialized as
+ * one. An atom's final bond order sum, and so its implied hydrogen count, is
+ * not known until its ring closures have all been seen, so this happens in a
+ * second pass after the rest of the molecule is built. As a result, the
+ * molecule this class produces orders its atoms as: first, every atom
+ * written explicitly in the SMILES, in the order it appears in the string
+ * (branches included, depth first); then every hydrogen this class added,
+ * grouped by the atom it was added to and in that atom's order, in no
+ * particular order within a group (they are interchangeable).
+ */
+class AVOGADROIO_EXPORT SmilesParser
+{
+public:
+  SmilesParser() = default;
+  ~SmilesParser() = default;
+
+  /**
+   * Parse @a smiles into @a molecule, replacing any atoms and bonds it
+   * already had. The molecule is left with none of either on failure.
+   * @return True on success.
+   */
+  bool parse(const std::string& smiles, Core::Molecule& molecule);
+
+  /**
+   * @return A description of the last failure, or an empty string.
+   */
+  const std::string& error() const { return m_error; }
+
+  /**
+   * @return Character offset into the input at which the last failure was
+   * detected.
+   */
+  size_t errorPosition() const { return m_errorPosition; }
+
+  /**
+   * @return Non-fatal notes about information the parse discarded.
+   */
+  const std::vector<std::string>& warnings() const { return m_warnings; }
+
+  /**
+   * Daylight atom map classes, one entry per atom of the molecule produced,
+   * zero where the atom carried none.
+   *
+   * These are exposed but never applied: a map class is data from the input,
+   * and using it to place an atom would let a malformed or hostile string
+   * reorder or alias atoms. Callers wanting to correlate with a mapped write
+   * must subtract one, since SmilesWriter emits index + 1.
+   */
+  const std::vector<size_t>& atomMaps() const { return m_atomMaps; }
+
+private:
+  std::string m_error;
+  size_t m_errorPosition = 0;
+  std::vector<std::string> m_warnings;
+  std::vector<size_t> m_atomMaps;
+};
+
+} // namespace Avogadro::Io
+
+#endif // AVOGADRO_IO_SMILESPARSER_H

--- a/avogadro/io/smilesvalence_p.h
+++ b/avogadro/io/smilesvalence_p.h
@@ -1,0 +1,95 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_SMILESVALENCE_P_H
+#define AVOGADRO_IO_SMILESVALENCE_P_H
+
+namespace Avogadro::Io {
+
+/** Returned when an element has no bare form in the SMILES organic subset. */
+const int SmilesNotOrganicSubset = -1;
+
+/**
+ * Number of hydrogens a SMILES parser will infer for a bare (unbracketed)
+ * organic subset atom whose written bonds sum to @a bondOrderSum.
+ *
+ * The implied count is the smallest normal valence not less than the sum,
+ * minus the sum; a sum beyond the largest normal valence implies no hydrogens.
+ *
+ * This is deliberately *not* Core::atomValence() from mdlvalence_p.h. That
+ * function implements the MDL model: it takes a bond *count* rather than a
+ * bond order sum, and it is charge aware. The two disagree in ordinary cases —
+ * a neutral nitrogen with two double bonds has two bonds but a bond order sum
+ * of four, for which the MDL model answers 3 (implying a negative hydrogen
+ * count) where SMILES answers 5, implying one hydrogen. SMILES needs no charge
+ * handling here because a charged atom is always bracketed.
+ *
+ * @param atomicNumber Atomic number of the atom.
+ * @param bondOrderSum Sum of the orders of the bonds actually written.
+ * @return The implied hydrogen count, or SmilesNotOrganicSubset.
+ */
+inline int smilesImpliedHydrogens(unsigned char atomicNumber,
+                                  unsigned int bondOrderSum)
+{
+  // OpenSMILES 3.1.5, "organic subset" — the only elements with a bare form.
+  static const unsigned int boron[] = { 3 };
+  static const unsigned int carbon[] = { 4 };
+  static const unsigned int nitrogen[] = { 3, 5 };
+  static const unsigned int oxygen[] = { 2 };
+  static const unsigned int phosphorus[] = { 3, 5 };
+  static const unsigned int sulfur[] = { 2, 4, 6 };
+  static const unsigned int halogen[] = { 1 };
+
+  const unsigned int* valences = nullptr;
+  unsigned int possibleValences = 0;
+
+  switch (atomicNumber) {
+    case 5: // B
+      valences = boron;
+      possibleValences = 1;
+      break;
+    case 6: // C
+      valences = carbon;
+      possibleValences = 1;
+      break;
+    case 7: // N
+      valences = nitrogen;
+      possibleValences = 2;
+      break;
+    case 8: // O
+      valences = oxygen;
+      possibleValences = 1;
+      break;
+    case 15: // P
+      valences = phosphorus;
+      possibleValences = 2;
+      break;
+    case 16: // S
+      valences = sulfur;
+      possibleValences = 3;
+      break;
+    case 9:  // F
+    case 17: // Cl
+    case 35: // Br
+    case 53: // I
+      valences = halogen;
+      possibleValences = 1;
+      break;
+    default:
+      // Astatine is excluded on purpose: it is not part of the subset.
+      return SmilesNotOrganicSubset;
+  }
+
+  for (unsigned int i = 0; i < possibleValences; ++i) {
+    if (bondOrderSum <= valences[i])
+      return static_cast<int>(valences[i] - bondOrderSum);
+  }
+
+  return 0;
+}
+
+} // namespace Avogadro::Io
+
+#endif // AVOGADRO_IO_SMILESVALENCE_P_H

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -12,6 +12,7 @@
 #include <avogadro/core/bond.h>
 #include <avogadro/core/graph.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/stereo.h>
 #include <avogadro/core/vector.h>
 
 #include <array>
@@ -178,6 +179,7 @@ private:
   std::vector<Index> m_classes;
   std::vector<Chirality> m_chirality;
   std::vector<bool> m_bondInRing;
+  std::vector<bool> m_bondIsClosure;
   std::vector<Direction> m_bondDirection;
 
   // Bonds incident to each atom, as a flat array indexed by m_adjacencyStart.
@@ -434,10 +436,12 @@ bool Serializer::writtenNeighbors(Index atom, Index neighbors[4]) const
 void Serializer::markRingBonds()
 {
   m_bondInRing.assign(m_mol.bondCount(), false);
+  m_bondIsClosure.assign(m_mol.bondCount(), false);
 
   // A ring closure and every tree bond between its two ends form one cycle.
   for (const RingClosure& closure : m_closures) {
     m_bondInRing[closure.bond] = true;
+    m_bondIsClosure[closure.bond] = true;
     Index atom = closure.close;
     while (atom != closure.open && atom != MaxIndex) {
       const Index bond = m_parentBond[atom];
@@ -512,6 +516,11 @@ void Serializer::assignChirality()
   Index neighbors[4];
   for (Index atom = 0; atom < atomCount; ++atom) {
     if (m_suppressed[atom] || !writtenNeighbors(atom, neighbors))
+      continue;
+
+    // The source placed this atom somewhere without claiming a configuration,
+    // so its geometry is not evidence of one.
+    if (Core::atomStereoUnspecified(m_mol, atom))
       continue;
 
     // Count how many substituents share a class with another. None means a
@@ -596,9 +605,11 @@ void Serializer::assignChirality()
 bool Serializer::directionalBond(Index carbon, Index partner, Index& bond,
                                  Index& substituent) const
 {
-  // A marker can only go on a bond that is actually written as a bond: not a
-  // folded hydrogen, and not a ring bond, whose two halves would each need
-  // their own consistent symbol.
+  // A marker can only go on a bond that is actually written once, as a bond:
+  // not a folded hydrogen, and not a ring closure, whose two occurrences would
+  // each need their own consistent symbol. An ordinary ring bond is fine --
+  // it appears exactly once, and an unsatisfiable set of constraints around
+  // the ring is caught by the agreement check in assignBondStereo().
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
   bool found = false;
 
@@ -607,7 +618,7 @@ bool Serializer::directionalBond(Index carbon, Index partner, Index& bond,
     const Index other = (ends.first == carbon) ? ends.second : ends.first;
     if (other == partner)
       continue;
-    if (m_suppressed[other] || m_bondInRing[candidate])
+    if (m_suppressed[other] || m_bondIsClosure[candidate])
       continue;
 
     // Prefer the lowest bond index, so the choice does not depend on the
@@ -631,6 +642,11 @@ void Serializer::assignBondStereo()
 
   for (Index bond = 0; bond < m_mol.bondCount(); ++bond) {
     if (orders[bond] != 2 || m_bondInRing[bond])
+      continue;
+
+    // Marked "cis or trans, either" upstream: the coordinates say something
+    // the source explicitly did not.
+    if (Core::bondStereoUnspecified(m_mol, bond))
       continue;
 
     const Index first = pairs[bond].first;

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -6,11 +6,11 @@
 #include "smileswriter.h"
 
 #include <avogadro/core/elements.h>
-#include <avogadro/core/graph.h>
 #include <avogadro/core/molecule.h>
 
-#include <set>
-#include <sstream>
+#include <array>
+#include <charconv>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -27,18 +27,29 @@ const int MaxRingNumber = 99;
 /** A bond that is not part of the depth-first spanning tree. */
 struct RingClosure
 {
-  Index open = MaxIndex;  //!< Atom the closure opens at (visited first).
-  Index close = MaxIndex; //!< Atom it closes at.
-  Index bond = MaxIndex;  //!< The molecule bond it stands for.
-  int number = 0;         //!< The ring bond number assigned to it.
+  Index open;      //!< Atom the closure opens at (visited first).
+  Index close;     //!< Atom it closes at.
+  Index bond;      //!< The molecule bond it stands for.
+  int number;      //!< The ring bond number assigned to it.
+  Index nextOpen;  //!< Next closure opening at the same atom.
+  Index nextClose; //!< Next closure closing at the same atom.
 };
 
 /** An edge of the spanning tree, from the perspective of the parent. */
 struct Child
 {
-  Index atom = MaxIndex;
-  Index bond = MaxIndex;
+  Index atom;
+  Index bond;
+  Index next; //!< Next child of the same parent, in discovery order.
 };
+
+void appendUnsigned(std::string& out, unsigned long long value)
+{
+  char buffer[24];
+  const std::to_chars_result result =
+    std::to_chars(buffer, buffer + sizeof(buffer), value);
+  out.append(buffer, result.ptr);
+}
 
 /**
  * Turns a molecule into a SMILES string.
@@ -47,6 +58,10 @@ struct Child
  * recursion: a long chain -- a protein backbone, a polymer -- would otherwise
  * recurse once per atom and overflow the stack on platforms with a small
  * default, and this code must not crash on a valid molecule.
+ *
+ * For the same reason the per-atom collections are flat arrays with intrusive
+ * next links rather than vectors of vectors, which would be one allocation per
+ * atom on a structure that may hold hundreds of thousands of them.
  */
 class Serializer
 {
@@ -54,6 +69,7 @@ public:
   Serializer(const Molecule& mol, bool atomMaps)
     : m_mol(mol), m_atomMaps(atomMaps)
   {
+    m_ringNumberUsed.fill(false);
   }
 
   bool run(std::string& smiles, std::string& error);
@@ -62,65 +78,86 @@ private:
   struct TraversalFrame
   {
     Index atom;
-    size_t next;
-    std::vector<size_t> incident;
+    Index next; //!< Cursor into this atom's slice of m_adjacency.
   };
 
   struct EmitFrame
   {
     Index atom;
-    size_t next;
+    Index child; //!< Index into m_children, or MaxIndex when exhausted.
     bool closeParen;
   };
 
+  void buildAdjacency();
   void traverse();
-  bool numberClosures(std::string& error);
-  void emit(std::string& smiles) const;
-  void emitAtom(std::ostringstream& out, Index atom) const;
-  std::string bondSymbol(Index bond) const;
+  void linkClosures();
+  bool emit(std::string& smiles, std::string& error);
+  bool emitAtom(std::string& out, Index atom, std::string& error);
+  bool takeRingNumber(int& number, std::string& error);
+  const char* bondSymbol(Index bond) const;
+  void appendRingNumber(std::string& out, int number) const;
 
   const Molecule& m_mol;
   bool m_atomMaps;
 
+  // Bonds incident to each atom, as a flat array indexed by m_adjacencyStart.
+  std::vector<Index> m_adjacencyStart;
+  std::vector<Index> m_adjacency;
+
   std::vector<Index> m_roots;
-  std::vector<Index> m_visitOrder;
-  std::vector<std::vector<Child>> m_children;
+  std::vector<Child> m_children;
+  std::vector<Index> m_firstChild;
+
   std::vector<RingClosure> m_closures;
-  std::vector<std::vector<size_t>> m_atomClosures;
+  std::vector<Index> m_firstOpen;
+  std::vector<Index> m_firstClose;
+
+  std::array<bool, MaxRingNumber + 1> m_ringNumberUsed;
 };
-
-std::string ringNumber(int number)
-{
-  if (number < 10)
-    return std::string(1, static_cast<char>('0' + number));
-
-  std::string result("%");
-  result += static_cast<char>('0' + number / 10);
-  result += static_cast<char>('0' + number % 10);
-  return result;
-}
 
 bool Serializer::run(std::string& smiles, std::string& error)
 {
+  buildAdjacency();
   traverse();
-  if (!numberClosures(error))
-    return false;
-  emit(smiles);
-  return true;
+  linkClosures();
+  return emit(smiles, error);
+}
+
+void Serializer::buildAdjacency()
+{
+  const Index atomCount = m_mol.atomCount();
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+
+  m_adjacencyStart.assign(atomCount + 1, 0);
+  for (const std::pair<Index, Index>& ends : pairs) {
+    ++m_adjacencyStart[ends.first + 1];
+    ++m_adjacencyStart[ends.second + 1];
+  }
+  for (Index atom = 0; atom < atomCount; ++atom)
+    m_adjacencyStart[atom + 1] += m_adjacencyStart[atom];
+
+  // Filling in bond order per atom reproduces the order Graph::edges() would
+  // have given, so the traversal -- and the output -- is unchanged.
+  m_adjacency.resize(2 * pairs.size());
+  std::vector<Index> cursor(m_adjacencyStart.begin(),
+                            m_adjacencyStart.end() - 1);
+  for (Index bond = 0; bond < pairs.size(); ++bond) {
+    m_adjacency[cursor[pairs[bond].first]++] = bond;
+    m_adjacency[cursor[pairs[bond].second]++] = bond;
+  }
 }
 
 void Serializer::traverse()
 {
   const Index atomCount = m_mol.atomCount();
-  const Core::Graph& graph = m_mol.graph();
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
 
   std::vector<bool> visited(atomCount, false);
   std::vector<bool> bondUsed(m_mol.bondCount(), false);
-  m_visitOrder.assign(atomCount, MaxIndex);
-  m_children.assign(atomCount, std::vector<Child>());
+  std::vector<Index> lastChild(atomCount, MaxIndex);
+  m_firstChild.assign(atomCount, MaxIndex);
+  m_children.reserve(atomCount);
 
-  Index order = 0;
   std::vector<TraversalFrame> stack;
 
   for (Index root = 0; root < atomCount; ++root) {
@@ -129,18 +166,17 @@ void Serializer::traverse()
 
     m_roots.push_back(root);
     visited[root] = true;
-    m_visitOrder[root] = order++;
-    stack.push_back(TraversalFrame{ root, 0, graph.edges(root) });
+    stack.push_back(TraversalFrame{ root, m_adjacencyStart[root] });
 
     while (!stack.empty()) {
       TraversalFrame& frame = stack.back();
-      if (frame.next >= frame.incident.size()) {
+      const Index current = frame.atom;
+      if (frame.next >= m_adjacencyStart[current + 1]) {
         stack.pop_back();
         continue;
       }
 
-      const Index current = frame.atom;
-      const Index bond = frame.incident[frame.next++];
+      const Index bond = m_adjacency[frame.next++];
       if (bondUsed[bond])
         continue;
 
@@ -153,80 +189,60 @@ void Serializer::traverse()
 
       if (visited[other]) {
         // A non-tree edge in an undirected depth-first search always joins an
-        // atom to one of its own ancestors, so the ancestor -- the one seen
-        // first -- is where the closure opens.
-        RingClosure closure;
-        closure.bond = bond;
-        if (m_visitOrder[other] < m_visitOrder[current]) {
-          closure.open = other;
-          closure.close = current;
-        } else {
-          closure.open = current;
-          closure.close = other;
-        }
-        m_closures.push_back(closure);
+        // atom to one of its own ancestors -- a descendant would have marked
+        // this bond used on its way down -- so the closure opens at the
+        // ancestor, which is the atom already visited.
+        m_closures.push_back(
+          RingClosure{ other, current, bond, 0, MaxIndex, MaxIndex });
       } else {
         visited[other] = true;
-        m_visitOrder[other] = order++;
-        m_children[current].push_back(Child{ other, bond });
+        const Index entry = m_children.size();
+        m_children.push_back(Child{ other, bond, MaxIndex });
+        if (m_firstChild[current] == MaxIndex)
+          m_firstChild[current] = entry;
+        else
+          m_children[lastChild[current]].next = entry;
+        lastChild[current] = entry;
         // Invalidates frame, so nothing above may be used after this point.
-        stack.push_back(TraversalFrame{ other, 0, graph.edges(other) });
+        stack.push_back(TraversalFrame{ other, m_adjacencyStart[other] });
       }
     }
   }
 }
 
-bool Serializer::numberClosures(std::string& error)
+void Serializer::linkClosures()
 {
   const Index atomCount = m_mol.atomCount();
+  m_firstOpen.assign(atomCount, MaxIndex);
+  m_firstClose.assign(atomCount, MaxIndex);
 
-  std::vector<std::vector<size_t>> opensAt(atomCount);
-  std::vector<std::vector<size_t>> closesAt(atomCount);
-  for (size_t i = 0; i < m_closures.size(); ++i) {
-    opensAt[m_closures[i].open].push_back(i);
-    closesAt[m_closures[i].close].push_back(i);
+  // Walking backwards means the head insertions leave each atom's list in
+  // ascending closure order.
+  for (Index i = m_closures.size(); i > 0; --i) {
+    RingClosure& closure = m_closures[i - 1];
+    closure.nextOpen = m_firstOpen[closure.open];
+    m_firstOpen[closure.open] = i - 1;
+    closure.nextClose = m_firstClose[closure.close];
+    m_firstClose[closure.close] = i - 1;
   }
-
-  std::vector<Index> orderToAtom(atomCount, MaxIndex);
-  for (Index atom = 0; atom < atomCount; ++atom)
-    orderToAtom[m_visitOrder[atom]] = atom;
-
-  m_atomClosures.assign(atomCount, std::vector<size_t>());
-  std::set<int> freeNumbers;
-  int nextNumber = 1;
-
-  for (Index position = 0; position < atomCount; ++position) {
-    const Index atom = orderToAtom[position];
-
-    // Allocate before releasing, so a number freed here cannot be reused on
-    // the same atom: "C11" would pair the two digits with each other rather
-    // than with their intended partners.
-    for (size_t closure : opensAt[atom]) {
-      int number = 0;
-      if (!freeNumbers.empty()) {
-        number = *freeNumbers.begin();
-        freeNumbers.erase(freeNumbers.begin());
-      } else if (nextNumber <= MaxRingNumber) {
-        number = nextNumber++;
-      } else {
-        error = "Too many ring closures are open at once; SMILES cannot "
-                "express more than 99.";
-        return false;
-      }
-      m_closures[closure].number = number;
-      m_atomClosures[atom].push_back(closure);
-    }
-
-    for (size_t closure : closesAt[atom]) {
-      freeNumbers.insert(m_closures[closure].number);
-      m_atomClosures[atom].push_back(closure);
-    }
-  }
-
-  return true;
 }
 
-std::string Serializer::bondSymbol(Index bond) const
+bool Serializer::takeRingNumber(int& number, std::string& error)
+{
+  for (int candidate = 1; candidate <= MaxRingNumber; ++candidate) {
+    if (!m_ringNumberUsed[candidate]) {
+      m_ringNumberUsed[candidate] = true;
+      number = candidate;
+      return true;
+    }
+  }
+
+  error = "Too many ring closures are open at once; SMILES cannot express "
+          "more than 99.";
+  return false;
+}
+
+const char* Serializer::bondSymbol(Index bond) const
 {
   switch (m_mol.bondOrders()[bond]) {
     case 2:
@@ -241,88 +257,119 @@ std::string Serializer::bondSymbol(Index bond) const
   }
 }
 
-void Serializer::emitAtom(std::ostringstream& out, Index atom) const
+void Serializer::appendRingNumber(std::string& out, int number) const
+{
+  if (number < 10) {
+    out += static_cast<char>('0' + number);
+    return;
+  }
+  out += '%';
+  out += static_cast<char>('0' + number / 10);
+  out += static_cast<char>('0' + number % 10);
+}
+
+bool Serializer::emitAtom(std::string& out, Index atom, std::string& error)
 {
   const unsigned char atomicNumber = m_mol.atomicNumbers()[atom];
   const int charge = m_mol.formalCharge(atom);
   const unsigned short isotope = m_mol.isotope(atom);
 
-  out << '[';
+  out += '[';
 
   if (isotope != 0)
-    out << isotope;
+    appendUnsigned(out, isotope);
 
   // Anything without a real element symbol -- a dummy atom, a custom element,
   // or InvalidElement from an unrecognized input symbol -- becomes the SMILES
   // wildcard. Elements::symbol() would answer "Xx" for these, which is not
   // valid SMILES, and dropping the atom instead would break the atom mapping.
   if (atomicNumber > 0 && atomicNumber < Core::element_count)
-    out << Elements::symbol(atomicNumber);
+    out += Elements::symbol(atomicNumber);
   else
-    out << '*';
+    out += '*';
 
   if (charge != 0) {
-    out << (charge > 0 ? '+' : '-');
+    out += (charge > 0) ? '+' : '-';
     const int magnitude = (charge > 0) ? charge : -charge;
     if (magnitude > 1)
-      out << magnitude;
+      appendUnsigned(out, magnitude);
   }
 
-  if (m_atomMaps)
-    out << ':' << (atom + 1);
+  if (m_atomMaps) {
+    out += ':';
+    appendUnsigned(out, atom + 1);
+  }
 
-  out << ']';
+  out += ']';
 
   // Ring bond numbers belong to the atom, ahead of any branch it opens.
-  for (size_t closure : m_atomClosures[atom]) {
+  // Numbers are taken before they are released, so one freed here cannot be
+  // reused on the same atom: "C11" would pair the two digits with each other
+  // rather than with their intended partners.
+  for (Index c = m_firstOpen[atom]; c != MaxIndex; c = m_closures[c].nextOpen) {
+    if (!takeRingNumber(m_closures[c].number, error))
+      return false;
     // Daylight allows the bond symbol on either or both occurrences, provided
     // they agree; writing it only where the closure opens keeps them trivially
     // consistent.
-    if (m_closures[closure].open == atom)
-      out << bondSymbol(m_closures[closure].bond);
-    out << ringNumber(m_closures[closure].number);
+    out += bondSymbol(m_closures[c].bond);
+    appendRingNumber(out, m_closures[c].number);
   }
+
+  for (Index c = m_firstClose[atom]; c != MaxIndex;
+       c = m_closures[c].nextClose) {
+    appendRingNumber(out, m_closures[c].number);
+    m_ringNumberUsed[m_closures[c].number] = false;
+  }
+
+  return true;
 }
 
-void Serializer::emit(std::string& smiles) const
+bool Serializer::emit(std::string& smiles, std::string& error)
 {
-  std::ostringstream out;
+  // Roughly a bracket atom plus a map class each, and a few characters per
+  // ring closure; growth from here is rare.
+  smiles.reserve(m_mol.atomCount() * 10 + m_closures.size() * 4 + 8);
+
   std::vector<EmitFrame> stack;
 
-  for (size_t component = 0; component < m_roots.size(); ++component) {
+  for (Index component = 0; component < m_roots.size(); ++component) {
     if (component != 0)
-      out << '.';
+      smiles += '.';
 
-    emitAtom(out, m_roots[component]);
-    stack.push_back(EmitFrame{ m_roots[component], 0, false });
+    const Index root = m_roots[component];
+    if (!emitAtom(smiles, root, error))
+      return false;
+    stack.push_back(EmitFrame{ root, m_firstChild[root], false });
 
     while (!stack.empty()) {
-      const Index atom = stack.back().atom;
-      const size_t childCount = m_children[atom].size();
-
-      if (stack.back().next >= childCount) {
-        const bool closeParen = stack.back().closeParen;
+      EmitFrame& frame = stack.back();
+      if (frame.child == MaxIndex) {
+        const bool closeParen = frame.closeParen;
         stack.pop_back();
         if (closeParen)
-          out << ')';
+          smiles += ')';
         continue;
       }
 
-      const size_t which = stack.back().next++;
-      const Child child = m_children[atom][which];
+      const Child child = m_children[frame.child];
+      frame.child = child.next;
 
       // Every child but the last is a branch; the last one continues the
       // chain, which is what keeps the output free of redundant parentheses.
-      const bool branch = (which + 1 < childCount);
+      const bool branch = (child.next != MaxIndex);
       if (branch)
-        out << '(';
-      out << bondSymbol(child.bond);
-      emitAtom(out, child.atom);
-      stack.push_back(EmitFrame{ child.atom, 0, branch });
+        smiles += '(';
+      smiles += bondSymbol(child.bond);
+      if (!emitAtom(smiles, child.atom, error))
+        return false;
+      // Invalidates frame, so nothing above may be used after this point.
+      stack.push_back(
+        EmitFrame{ child.atom, m_firstChild[child.atom], branch });
     }
   }
 
-  smiles = out.str();
+  return true;
 }
 
 } // namespace

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -8,6 +8,7 @@
 #include "atomequivalence_p.h"
 #include "smilesvalence_p.h"
 
+#include <avogadro/core/aromaticity.h>
 #include <avogadro/core/elements.h>
 #include <avogadro/core/bond.h>
 #include <avogadro/core/graph.h>
@@ -123,8 +124,8 @@ class Serializer
 {
 public:
   Serializer(const Molecule& mol, SmilesWriter::HydrogenMode mode,
-             bool atomMaps)
-    : m_mol(mol), m_mode(mode), m_atomMaps(atomMaps)
+             bool atomMaps, bool aromatic)
+    : m_mol(mol), m_mode(mode), m_atomMaps(atomMaps), m_aromatic(aromatic)
   {
     m_ringNumberUsed.fill(false);
   }
@@ -167,6 +168,10 @@ private:
   const Molecule& m_mol;
   SmilesWriter::HydrogenMode m_mode;
   bool m_atomMaps;
+  bool m_aromatic;
+
+  std::vector<bool> m_aromaticAtom;
+  std::vector<bool> m_aromaticBond;
 
   // Hydrogens folded into a neighbour rather than written as their own atom.
   std::vector<bool> m_suppressed;
@@ -199,6 +204,14 @@ private:
 
 bool Serializer::run(std::string& smiles, std::string& error)
 {
+  m_aromaticAtom.assign(m_mol.atomCount(), false);
+  m_aromaticBond.assign(m_mol.bondCount(), false);
+  if (m_aromatic) {
+    Core::AromaticityPerceiver perceiver(&m_mol);
+    m_aromaticAtom = perceiver.aromaticAtoms();
+    m_aromaticBond = perceiver.aromaticBonds();
+  }
+
   suppressHydrogens();
   buildAdjacency();
   traverse();
@@ -775,6 +788,11 @@ bool Serializer::takeRingNumber(int& number, std::string& error)
 
 const char* Serializer::bondSymbol(Index bond, Index fromAtom) const
 {
+  // Between two lower case atoms the bond is aromatic by implication, and
+  // writing its Kekule order would contradict that.
+  if (m_aromaticBond[bond])
+    return "";
+
   switch (m_mol.bondOrders()[bond]) {
     case 2:
       return "=";
@@ -838,6 +856,13 @@ bool Serializer::needsBrackets(Index atom) const
   if (implied == SmilesNotOrganicSubset)
     return true;
 
+  // A reader has to kekulize an aromatic ring before it can infer hydrogen
+  // counts, but for a heteroatom the hydrogen count is itself what decides the
+  // kekulization. That circularity is why any hydrogen on an aromatic
+  // heteroatom has to be spelled out: pyrrole is "[nH]" where pyridine is "n".
+  if (m_aromaticAtom[atom] && atomicNumber != 6)
+    return m_implicitH[atom] != 0;
+
   // The bare form is only usable when a reader would infer exactly the
   // hydrogens this atom actually has. Where it would not -- a radical, or a
   // valence the model does not know -- the count has to be spelled out, which
@@ -862,10 +887,19 @@ bool Serializer::emitAtom(std::string& out, Index atom, std::string& error)
   // or InvalidElement from an unrecognized input symbol -- becomes the SMILES
   // wildcard. Elements::symbol() would answer "Xx" for these, which is not
   // valid SMILES, and dropping the atom instead would break the atom mapping.
-  if (hasElementSymbol(atomicNumber))
-    out += Elements::symbol(atomicNumber);
-  else
+  if (hasElementSymbol(atomicNumber)) {
+    const char* symbol = Elements::symbol(atomicNumber);
+    if (m_aromaticAtom[atom]) {
+      // Lower case marks membership of an aromatic system; a two letter
+      // symbol only lowers its first character, as in "[se]".
+      out += static_cast<char>(symbol[0] - 'A' + 'a');
+      out += symbol + 1;
+    } else {
+      out += symbol;
+    }
+  } else {
     out += '*';
+  }
 
   if (brackets) {
     // Chirality sits between the symbol and the hydrogen count.
@@ -985,7 +1019,8 @@ bool SmilesWriter::write(const Core::Molecule& molecule, std::string& smiles)
   if (molecule.atomCount() == 0)
     return true;
 
-  Serializer serializer(molecule, effectiveHydrogenMode(), m_atomMaps);
+  Serializer serializer(molecule, effectiveHydrogenMode(), m_atomMaps,
+                        m_aromatic);
   if (!serializer.run(smiles, m_error)) {
     smiles.clear();
     return false;

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -9,6 +9,7 @@
 #include "smilesvalence_p.h"
 
 #include <avogadro/core/elements.h>
+#include <avogadro/core/bond.h>
 #include <avogadro/core/graph.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/vector.h>
@@ -148,6 +149,7 @@ private:
   void traverse();
   void linkClosures();
   void markRingBonds();
+  std::vector<Index> ringSystems() const;
   void assignChirality();
   void assignBondStereo();
   bool writtenNeighbors(Index atom, Index neighbors[4]) const;
@@ -447,25 +449,133 @@ void Serializer::markRingBonds()
   }
 }
 
+std::vector<Index> Serializer::ringSystems() const
+{
+  // Connected components of the ring bonds: two centres in the same component
+  // can constrain each other's configuration.
+  const Index atomCount = m_mol.atomCount();
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+  std::vector<Index> system(atomCount, MaxIndex);
+  std::vector<Index> queue;
+  Index next = 0;
+
+  for (Index seed = 0; seed < atomCount; ++seed) {
+    if (system[seed] != MaxIndex)
+      continue;
+
+    bool inRing = false;
+    for (Index bond : m_mol.graph().edges(seed))
+      inRing = inRing || m_bondInRing[bond];
+    if (!inRing)
+      continue;
+
+    system[seed] = next;
+    queue.push_back(seed);
+    while (!queue.empty()) {
+      const Index atom = queue.back();
+      queue.pop_back();
+      for (Index bond : m_mol.graph().edges(atom)) {
+        if (!m_bondInRing[bond])
+          continue;
+        const std::pair<Index, Index>& ends = pairs[bond];
+        const Index other = (ends.first == atom) ? ends.second : ends.first;
+        if (system[other] == MaxIndex) {
+          system[other] = next;
+          queue.push_back(other);
+        }
+      }
+    }
+    ++next;
+  }
+
+  return system;
+}
+
 void Serializer::assignChirality()
 {
   const Index atomCount = m_mol.atomCount();
   const Core::Array<Vector3>& positions = m_mol.atomPositions3d();
   const std::vector<Index>& classes = m_classes;
 
+  // Which atoms are stereogenic, and on what grounds. A "ring dependent"
+  // centre is one whose two equivalent substituents are the two ways round a
+  // ring: it means nothing by itself, but paired with another such centre it
+  // describes cis/trans across the ring.
+  enum class Candidacy : char
+  {
+    No,
+    Distinct,
+    RingDependent
+  };
+  std::vector<Candidacy> candidacy(atomCount, Candidacy::No);
+
   Index neighbors[4];
   for (Index atom = 0; atom < atomCount; ++atom) {
     if (m_suppressed[atom] || !writtenNeighbors(atom, neighbors))
       continue;
 
-    // Only a centre whose four substituents are all constitutionally
-    // different is stereogenic. Without this test every methyl carbon would
-    // pick up a meaningless "@".
-    bool distinct = true;
-    for (int i = 0; i < 4 && distinct; ++i)
-      for (int j = i + 1; j < 4 && distinct; ++j)
-        distinct = classes[neighbors[i]] != classes[neighbors[j]];
-    if (!distinct)
+    // Count how many substituents share a class with another. None means a
+    // classical stereocentre; exactly two means a single tied pair, which may
+    // still be stereogenic if the tie is a ring closing back on itself.
+    int tied = 0;
+    int tiedIndex[2] = { -1, -1 };
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        if (i != j && classes[neighbors[i]] == classes[neighbors[j]]) {
+          if (tied < 2)
+            tiedIndex[tied] = i;
+          ++tied;
+          break;
+        }
+      }
+    }
+
+    if (tied == 0) {
+      candidacy[atom] = Candidacy::Distinct;
+      continue;
+    }
+    if (tied != 2)
+      continue; // Three or four alike: nothing to orient against.
+
+    // The tie has to be the two directions around a ring. Two equivalent
+    // substituents hanging off separate branches -- the hydrogens of a CH2,
+    // the methyls of an isopropyl -- are interchangeable and mean nothing.
+    bool tiedThroughRing = true;
+    for (int end = 0; end < 2; ++end) {
+      const Core::Bond bond = m_mol.bond(atom, neighbors[tiedIndex[end]]);
+      if (!bond.isValid() || !m_bondInRing[bond.index()])
+        tiedThroughRing = false;
+    }
+    if (tiedThroughRing)
+      candidacy[atom] = Candidacy::RingDependent;
+  }
+
+  // A ring dependent centre needs a partner: cyclohexanol has exactly one and
+  // is achiral, while 4-methylcyclohexanol has two and is cis/trans isomeric.
+  const std::vector<Index> ringSystem = ringSystems();
+  std::vector<Index> dependentCount;
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    if (candidacy[atom] != Candidacy::RingDependent ||
+        ringSystem[atom] == MaxIndex)
+      continue;
+    if (ringSystem[atom] >= dependentCount.size())
+      dependentCount.resize(ringSystem[atom] + 1, 0);
+    ++dependentCount[ringSystem[atom]];
+  }
+
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    if (candidacy[atom] != Candidacy::RingDependent)
+      continue;
+    const Index system = ringSystem[atom];
+    if (system == MaxIndex || system >= dependentCount.size() ||
+        dependentCount[system] < 2)
+      candidacy[atom] = Candidacy::No;
+  }
+
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    if (candidacy[atom] == Candidacy::No)
+      continue;
+    if (!writtenNeighbors(atom, neighbors))
       continue;
 
     // Viewed with the first neighbour between the viewer and the centre, are

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -152,9 +152,10 @@ private:
   void linkClosures();
   void markRingBonds();
   std::vector<Index> ringSystems() const;
-  void assignChirality();
-  void assignBondStereo();
+  void assignChirality(const std::vector<Index>& classes);
+  void assignBondStereo(const std::vector<Index>& classes);
   bool writtenNeighbors(Index atom, Index neighbors[4]) const;
+  bool hasStereoCandidates() const;
   bool directionalBond(Index carbon, Index partner, Index& bond,
                        Index& substituent) const;
   bool emit(std::string& smiles, std::string& error);
@@ -177,11 +178,11 @@ private:
   std::vector<bool> m_suppressed;
   std::vector<unsigned char> m_implicitH;
   std::vector<Index> m_suppressedHydrogen;
+  std::vector<Index> m_degree;
   std::vector<unsigned int> m_bondOrderSum;
 
   std::vector<Index> m_parent;
   std::vector<Index> m_parentBond;
-  std::vector<Index> m_classes;
   std::vector<Chirality> m_chirality;
   std::vector<bool> m_bondInRing;
   std::vector<bool> m_bondIsClosure;
@@ -204,12 +205,13 @@ private:
 
 bool Serializer::run(std::string& smiles, std::string& error)
 {
-  m_aromaticAtom.assign(m_mol.atomCount(), false);
-  m_aromaticBond.assign(m_mol.bondCount(), false);
   if (m_aromatic) {
     Core::AromaticityPerceiver perceiver(&m_mol);
     m_aromaticAtom = perceiver.aromaticAtoms();
     m_aromaticBond = perceiver.aromaticBonds();
+  } else {
+    m_aromaticAtom.assign(m_mol.atomCount(), false);
+    m_aromaticBond.assign(m_mol.bondCount(), false);
   }
 
   suppressHydrogens();
@@ -222,10 +224,13 @@ bool Serializer::run(std::string& smiles, std::string& error)
   // need to know which substituents are constitutionally distinguishable.
   m_chirality.assign(m_mol.atomCount(), Chirality::None);
   m_bondDirection.assign(m_mol.bondCount(), Direction::None);
-  if (m_mol.atomPositions3d().size() == m_mol.atomCount()) {
-    m_classes = atomEquivalenceClasses(m_mol);
-    assignChirality();
-    assignBondStereo();
+  // Equivalence classes cost a refinement over the whole molecule, so only
+  // pay for them when there is something they could decide.
+  if (m_mol.atomPositions3d().size() == m_mol.atomCount() &&
+      hasStereoCandidates()) {
+    const std::vector<Index> classes = atomEquivalenceClasses(m_mol);
+    assignChirality(classes);
+    assignBondStereo(classes);
   }
 
   return emit(smiles, error);
@@ -255,10 +260,10 @@ void Serializer::suppressHydrogens()
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
   const Core::Array<unsigned char>& numbers = m_mol.atomicNumbers();
 
-  std::vector<Index> degree(atomCount, 0);
+  m_degree.assign(atomCount, 0);
   for (const std::pair<Index, Index>& ends : pairs) {
-    ++degree[ends.first];
-    ++degree[ends.second];
+    ++m_degree[ends.first];
+    ++m_degree[ends.second];
   }
 
   for (Index bond = 0; bond < pairs.size(); ++bond) {
@@ -281,7 +286,7 @@ void Serializer::suppressHydrogens()
       // was reached from, and writtenNeighbors() places it there.
       if (numbers[hydrogen] != 1 || numbers[neighbor] == 1)
         continue;
-      if (degree[hydrogen] != 1)
+      if (m_degree[hydrogen] != 1)
         continue;
       if (m_mol.formalCharge(hydrogen) != 0 || m_mol.isotope(hydrogen) != 0)
         continue;
@@ -481,8 +486,8 @@ std::vector<Index> Serializer::ringSystems() const
       continue;
 
     bool inRing = false;
-    for (Index bond : m_mol.graph().edges(seed))
-      inRing = inRing || m_bondInRing[bond];
+    for (Index i = m_adjacencyStart[seed]; i < m_adjacencyStart[seed + 1]; ++i)
+      inRing = inRing || m_bondInRing[m_adjacency[i]];
     if (!inRing)
       continue;
 
@@ -491,7 +496,9 @@ std::vector<Index> Serializer::ringSystems() const
     while (!queue.empty()) {
       const Index atom = queue.back();
       queue.pop_back();
-      for (Index bond : m_mol.graph().edges(atom)) {
+      for (Index i = m_adjacencyStart[atom]; i < m_adjacencyStart[atom + 1];
+           ++i) {
+        const Index bond = m_adjacency[i];
         if (!m_bondInRing[bond])
           continue;
         const std::pair<Index, Index>& ends = pairs[bond];
@@ -508,11 +515,34 @@ std::vector<Index> Serializer::ringSystems() const
   return system;
 }
 
-void Serializer::assignChirality()
+bool Serializer::hasStereoCandidates() const
+{
+  // A centre needs four written neighbours to have a handedness at all.
+  Index neighbors[4];
+  for (Index atom = 0; atom < m_mol.atomCount(); ++atom) {
+    if (!m_suppressed[atom] && writtenNeighbors(atom, neighbors))
+      return true;
+  }
+
+  // A double bond needs a substituent at each end. This rejects the carbonyls
+  // that most molecules are otherwise full of.
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+  const Core::Array<unsigned char>& orders = m_mol.bondOrders();
+  for (Index bond = 0; bond < m_mol.bondCount(); ++bond) {
+    if (orders[bond] != 2 || m_bondInRing[bond])
+      continue;
+    const std::pair<Index, Index>& ends = pairs[bond];
+    if (m_degree[ends.first] > 1 && m_degree[ends.second] > 1)
+      return true;
+  }
+
+  return false;
+}
+
+void Serializer::assignChirality(const std::vector<Index>& classes)
 {
   const Index atomCount = m_mol.atomCount();
   const Core::Array<Vector3>& positions = m_mol.atomPositions3d();
-  const std::vector<Index>& classes = m_classes;
 
   // Which atoms are stereogenic, and on what grounds. A "ring dependent"
   // centre is one whose two equivalent substituents are the two ways round a
@@ -574,7 +604,13 @@ void Serializer::assignChirality()
 
   // A ring dependent centre needs a partner: cyclohexanol has exactly one and
   // is achiral, while 4-methylcyclohexanol has two and is cis/trans isomeric.
-  const std::vector<Index> ringSystem = ringSystems();
+  // Most molecules have no such centre, so do not walk the rings for nothing.
+  bool anyRingDependent = false;
+  for (Index atom = 0; atom < atomCount && !anyRingDependent; ++atom)
+    anyRingDependent = candidacy[atom] == Candidacy::RingDependent;
+
+  const std::vector<Index> ringSystem =
+    anyRingDependent ? ringSystems() : std::vector<Index>(atomCount, MaxIndex);
   std::vector<Index> dependentCount;
   for (Index atom = 0; atom < atomCount; ++atom) {
     if (candidacy[atom] != Candidacy::RingDependent ||
@@ -646,7 +682,7 @@ bool Serializer::directionalBond(Index carbon, Index partner, Index& bond,
   return found;
 }
 
-void Serializer::assignBondStereo()
+void Serializer::assignBondStereo(const std::vector<Index>& classes)
 {
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
   const Core::Array<unsigned char>& orders = m_mol.bondOrders();
@@ -699,7 +735,7 @@ void Serializer::assignBondStereo()
     bool stereogenic = true;
     for (int end = 0; end < 2; ++end) {
       if (substituentCount[end] == 2 &&
-          m_classes[substituents[end][0]] == m_classes[substituents[end][1]])
+          classes[substituents[end][0]] == classes[substituents[end][1]])
         stereogenic = false;
     }
     if (!stereogenic)

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -852,6 +852,14 @@ const char* Serializer::bondSymbol(Index bond, Index fromAtom) const
     return direction == Direction::Up ? "/" : "\\";
   }
 
+  // A single bond joining two aromatic atoms has to say so: OpenSMILES 3.2.1
+  // reads an omitted symbol between two lower case atoms as aromatic, so
+  // leaving it bare would write biphenyl as "c1ccccc1c1ccccc1" and claim the
+  // two rings are one aromatic system.
+  const std::pair<Index, Index>& pair = m_mol.bondPairs()[bond];
+  if (m_aromaticAtom[pair.first] && m_aromaticAtom[pair.second])
+    return "-";
+
   // Order 1, and anything unset, is the SMILES default and written bare.
   return "";
 }

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -5,8 +5,13 @@
 
 #include "smileswriter.h"
 
+#include "atomequivalence_p.h"
+#include "smilesvalence_p.h"
+
 #include <avogadro/core/elements.h>
+#include <avogadro/core/graph.h>
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/vector.h>
 
 #include <array>
 #include <charconv>
@@ -23,6 +28,47 @@ namespace {
 
 /** SMILES can express ring bond numbers 0-9 bare and 10-99 as %nn. */
 const int MaxRingNumber = 99;
+
+/** Tetrahedral parity, in the sense SMILES writes it. */
+enum class Chirality : char
+{
+  None,
+  Anticlockwise, //!< "@"
+  Clockwise      //!< "@@"
+};
+
+/**
+ * Which way a directional single bond points, going from the first to the
+ * second atom of Molecule::bondPairs(). Writing the bond in the other
+ * direction reverses the symbol.
+ */
+enum class Direction : char
+{
+  None,
+  Up,  //!< "/"
+  Down //!< "\"
+};
+
+Direction opposite(Direction direction)
+{
+  return direction == Direction::Up ? Direction::Down : Direction::Up;
+}
+
+/**
+ * A tetrahedron flatter than this is treated as having no usable handedness.
+ * Real centres are far from the threshold -- four bonds of about 1.5 A give a
+ * magnitude in the tens -- so this only catches degenerate input such as a
+ * molecule whose coordinates were never set.
+ */
+const Real MinTetrahedronVolume = 1e-4;
+
+/**
+ * Below this a separation carries no usable direction. Applied to the double
+ * bond axis, and to how far a substituent sits off that axis, so a collinear
+ * or coincident arrangement is reported as having no cis/trans rather than
+ * being assigned one from rounding noise.
+ */
+const Real MinBondLengthSquared = 1e-6;
 
 /** A bond that is not part of the depth-first spanning tree. */
 struct RingClosure
@@ -51,6 +97,14 @@ void appendUnsigned(std::string& out, unsigned long long value)
   out.append(buffer, result.ptr);
 }
 
+/** Whether the element has a symbol that is meaningful in SMILES. */
+bool hasElementSymbol(unsigned char atomicNumber)
+{
+  // Excludes 0, custom elements, and InvalidElement; Elements::symbol() would
+  // answer "Xx" for those, which is not valid SMILES.
+  return atomicNumber > 0 && atomicNumber < Core::element_count;
+}
+
 /**
  * Turns a molecule into a SMILES string.
  *
@@ -66,8 +120,9 @@ void appendUnsigned(std::string& out, unsigned long long value)
 class Serializer
 {
 public:
-  Serializer(const Molecule& mol, bool atomMaps)
-    : m_mol(mol), m_atomMaps(atomMaps)
+  Serializer(const Molecule& mol, SmilesWriter::HydrogenMode mode,
+             bool atomMaps)
+    : m_mol(mol), m_mode(mode), m_atomMaps(atomMaps)
   {
     m_ringNumberUsed.fill(false);
   }
@@ -88,17 +143,40 @@ private:
     bool closeParen;
   };
 
+  void suppressHydrogens();
   void buildAdjacency();
   void traverse();
   void linkClosures();
+  void markRingBonds();
+  void assignChirality();
+  void assignBondStereo();
+  bool writtenNeighbors(Index atom, Index neighbors[4]) const;
+  bool directionalBond(Index carbon, Index partner, Index& bond,
+                       Index& substituent) const;
   bool emit(std::string& smiles, std::string& error);
   bool emitAtom(std::string& out, Index atom, std::string& error);
+  bool needsBrackets(Index atom) const;
   bool takeRingNumber(int& number, std::string& error);
-  const char* bondSymbol(Index bond) const;
+  unsigned int writtenBondOrder(Index bond) const;
+  const char* bondSymbol(Index bond, Index fromAtom) const;
   void appendRingNumber(std::string& out, int number) const;
 
   const Molecule& m_mol;
+  SmilesWriter::HydrogenMode m_mode;
   bool m_atomMaps;
+
+  // Hydrogens folded into a neighbour rather than written as their own atom.
+  std::vector<bool> m_suppressed;
+  std::vector<unsigned char> m_implicitH;
+  std::vector<Index> m_suppressedHydrogen;
+  std::vector<unsigned int> m_bondOrderSum;
+
+  std::vector<Index> m_parent;
+  std::vector<Index> m_parentBond;
+  std::vector<Index> m_classes;
+  std::vector<Chirality> m_chirality;
+  std::vector<bool> m_bondInRing;
+  std::vector<Direction> m_bondDirection;
 
   // Bonds incident to each atom, as a flat array indexed by m_adjacencyStart.
   std::vector<Index> m_adjacencyStart;
@@ -117,10 +195,85 @@ private:
 
 bool Serializer::run(std::string& smiles, std::string& error)
 {
+  suppressHydrogens();
   buildAdjacency();
   traverse();
   linkClosures();
+  markRingBonds();
+
+  // Both kinds of stereochemistry are read out of the coordinates, and both
+  // need to know which substituents are constitutionally distinguishable.
+  m_chirality.assign(m_mol.atomCount(), Chirality::None);
+  m_bondDirection.assign(m_mol.bondCount(), Direction::None);
+  if (m_mol.atomPositions3d().size() == m_mol.atomCount()) {
+    m_classes = atomEquivalenceClasses(m_mol);
+    assignChirality();
+    assignBondStereo();
+  }
+
   return emit(smiles, error);
+}
+
+unsigned int Serializer::writtenBondOrder(Index bond) const
+{
+  // An unset order is written as a single bond, so it counts as one against
+  // the valence model.
+  const unsigned char order = m_mol.bondOrders()[bond];
+  return (order < 1) ? 1u : order;
+}
+
+void Serializer::suppressHydrogens()
+{
+  const Index atomCount = m_mol.atomCount();
+  m_suppressed.assign(atomCount, false);
+  m_implicitH.assign(atomCount, 0);
+  m_suppressedHydrogen.assign(atomCount, MaxIndex);
+
+  // Explicit mode keeps every hydrogen as an atom of its own, which is also
+  // what atom mapping requires -- a folded hydrogen has nowhere to carry a
+  // map class.
+  if (m_mode == SmilesWriter::HydrogenMode::Explicit)
+    return;
+
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+  const Core::Array<unsigned char>& numbers = m_mol.atomicNumbers();
+
+  std::vector<Index> degree(atomCount, 0);
+  for (const std::pair<Index, Index>& ends : pairs) {
+    ++degree[ends.first];
+    ++degree[ends.second];
+  }
+
+  for (Index bond = 0; bond < pairs.size(); ++bond) {
+    if (m_mol.bondOrders()[bond] > 1)
+      continue;
+
+    const std::pair<Index, Index>& ends = pairs[bond];
+    for (int side = 0; side < 2; ++side) {
+      const Index hydrogen = (side == 0) ? ends.first : ends.second;
+      const Index neighbor = (side == 0) ? ends.second : ends.first;
+
+      // A hydrogen bonded to another hydrogen keeps its atom, so H2 stays
+      // "[H][H]" rather than collapsing into something meaningless. More than
+      // one bond means a bridging hydrogen, as in diborane, which also has to
+      // stay written. An isotope or a charge needs a bracket of its own, so
+      // deuterium and hydride survive as atoms without any special case.
+      //
+      // A hydrogen on a chiral atom may be folded away: it keeps a defined
+      // slot in the neighbour ordering, immediately after the atom the centre
+      // was reached from, and writtenNeighbors() places it there.
+      if (numbers[hydrogen] != 1 || numbers[neighbor] == 1)
+        continue;
+      if (degree[hydrogen] != 1)
+        continue;
+      if (m_mol.formalCharge(hydrogen) != 0 || m_mol.isotope(hydrogen) != 0)
+        continue;
+
+      m_suppressed[hydrogen] = true;
+      m_suppressedHydrogen[neighbor] = hydrogen;
+      ++m_implicitH[neighbor];
+    }
+  }
 }
 
 void Serializer::buildAdjacency()
@@ -129,21 +282,33 @@ void Serializer::buildAdjacency()
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
 
   m_adjacencyStart.assign(atomCount + 1, 0);
-  for (const std::pair<Index, Index>& ends : pairs) {
+  m_bondOrderSum.assign(atomCount, 0);
+
+  Index kept = 0;
+  for (Index bond = 0; bond < pairs.size(); ++bond) {
+    const std::pair<Index, Index>& ends = pairs[bond];
+    if (m_suppressed[ends.first] || m_suppressed[ends.second])
+      continue;
     ++m_adjacencyStart[ends.first + 1];
     ++m_adjacencyStart[ends.second + 1];
+    m_bondOrderSum[ends.first] += writtenBondOrder(bond);
+    m_bondOrderSum[ends.second] += writtenBondOrder(bond);
+    ++kept;
   }
   for (Index atom = 0; atom < atomCount; ++atom)
     m_adjacencyStart[atom + 1] += m_adjacencyStart[atom];
 
   // Filling in bond order per atom reproduces the order Graph::edges() would
   // have given, so the traversal -- and the output -- is unchanged.
-  m_adjacency.resize(2 * pairs.size());
+  m_adjacency.resize(2 * kept);
   std::vector<Index> cursor(m_adjacencyStart.begin(),
                             m_adjacencyStart.end() - 1);
   for (Index bond = 0; bond < pairs.size(); ++bond) {
-    m_adjacency[cursor[pairs[bond].first]++] = bond;
-    m_adjacency[cursor[pairs[bond].second]++] = bond;
+    const std::pair<Index, Index>& ends = pairs[bond];
+    if (m_suppressed[ends.first] || m_suppressed[ends.second])
+      continue;
+    m_adjacency[cursor[ends.first]++] = bond;
+    m_adjacency[cursor[ends.second]++] = bond;
   }
 }
 
@@ -156,12 +321,14 @@ void Serializer::traverse()
   std::vector<bool> bondUsed(m_mol.bondCount(), false);
   std::vector<Index> lastChild(atomCount, MaxIndex);
   m_firstChild.assign(atomCount, MaxIndex);
+  m_parent.assign(atomCount, MaxIndex);
+  m_parentBond.assign(atomCount, MaxIndex);
   m_children.reserve(atomCount);
 
   std::vector<TraversalFrame> stack;
 
   for (Index root = 0; root < atomCount; ++root) {
-    if (visited[root])
+    if (visited[root] || m_suppressed[root])
       continue;
 
     m_roots.push_back(root);
@@ -196,6 +363,8 @@ void Serializer::traverse()
           RingClosure{ other, current, bond, 0, MaxIndex, MaxIndex });
       } else {
         visited[other] = true;
+        m_parent[other] = current;
+        m_parentBond[other] = bond;
         const Index entry = m_children.size();
         m_children.push_back(Child{ other, bond, MaxIndex });
         if (m_firstChild[current] == MaxIndex)
@@ -227,6 +396,242 @@ void Serializer::linkClosures()
   }
 }
 
+bool Serializer::writtenNeighbors(Index atom, Index neighbors[4]) const
+{
+  // The order SMILES assigns to a chiral atom's neighbours is the order they
+  // appear in the string: the atom it was reached from, then a hydrogen folded
+  // into the bracket, then the ring closure digits, then the branches. That is
+  // exactly the order this writer emits them in.
+  Index found = 0;
+  const auto add = [&](Index neighbor) {
+    if (found < 4)
+      neighbors[found] = neighbor;
+    ++found;
+  };
+
+  if (m_parent[atom] != MaxIndex)
+    add(m_parent[atom]);
+
+  // Two or more folded hydrogens are indistinguishable, so such an atom is
+  // never a stereocentre and there is no need to order them.
+  if (m_implicitH[atom] == 1)
+    add(m_suppressedHydrogen[atom]);
+  else if (m_implicitH[atom] > 1)
+    return false;
+
+  for (Index c = m_firstOpen[atom]; c != MaxIndex; c = m_closures[c].nextOpen)
+    add(m_closures[c].close);
+  for (Index c = m_firstClose[atom]; c != MaxIndex; c = m_closures[c].nextClose)
+    add(m_closures[c].open);
+  for (Index c = m_firstChild[atom]; c != MaxIndex; c = m_children[c].next)
+    add(m_children[c].atom);
+
+  return found == 4;
+}
+
+void Serializer::markRingBonds()
+{
+  m_bondInRing.assign(m_mol.bondCount(), false);
+
+  // A ring closure and every tree bond between its two ends form one cycle.
+  for (const RingClosure& closure : m_closures) {
+    m_bondInRing[closure.bond] = true;
+    Index atom = closure.close;
+    while (atom != closure.open && atom != MaxIndex) {
+      const Index bond = m_parentBond[atom];
+      if (bond == MaxIndex)
+        break;
+      m_bondInRing[bond] = true;
+      atom = m_parent[atom];
+    }
+  }
+}
+
+void Serializer::assignChirality()
+{
+  const Index atomCount = m_mol.atomCount();
+  const Core::Array<Vector3>& positions = m_mol.atomPositions3d();
+  const std::vector<Index>& classes = m_classes;
+
+  Index neighbors[4];
+  for (Index atom = 0; atom < atomCount; ++atom) {
+    if (m_suppressed[atom] || !writtenNeighbors(atom, neighbors))
+      continue;
+
+    // Only a centre whose four substituents are all constitutionally
+    // different is stereogenic. Without this test every methyl carbon would
+    // pick up a meaningless "@".
+    bool distinct = true;
+    for (int i = 0; i < 4 && distinct; ++i)
+      for (int j = i + 1; j < 4 && distinct; ++j)
+        distinct = classes[neighbors[i]] != classes[neighbors[j]];
+    if (!distinct)
+      continue;
+
+    // Viewed with the first neighbour between the viewer and the centre, are
+    // the other three arranged anticlockwise? That is the sign of the volume
+    // of the tetrahedron they span, taken from the first neighbour.
+    const Vector3& first = positions[neighbors[0]];
+    const Real volume = (positions[neighbors[1]] - first)
+                          .dot((positions[neighbors[2]] - first)
+                                 .cross(positions[neighbors[3]] - first));
+
+    if (volume < -MinTetrahedronVolume)
+      m_chirality[atom] = Chirality::Anticlockwise;
+    else if (volume > MinTetrahedronVolume)
+      m_chirality[atom] = Chirality::Clockwise;
+  }
+}
+
+bool Serializer::directionalBond(Index carbon, Index partner, Index& bond,
+                                 Index& substituent) const
+{
+  // A marker can only go on a bond that is actually written as a bond: not a
+  // folded hydrogen, and not a ring bond, whose two halves would each need
+  // their own consistent symbol.
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+  bool found = false;
+
+  for (Index candidate : m_mol.graph().edges(carbon)) {
+    const std::pair<Index, Index>& ends = pairs[candidate];
+    const Index other = (ends.first == carbon) ? ends.second : ends.first;
+    if (other == partner)
+      continue;
+    if (m_suppressed[other] || m_bondInRing[candidate])
+      continue;
+
+    // Prefer the lowest bond index, so the choice does not depend on the
+    // order the double bonds happen to be visited in.
+    if (!found || candidate < bond) {
+      bond = candidate;
+      substituent = other;
+      found = true;
+    }
+  }
+
+  return found;
+}
+
+void Serializer::assignBondStereo()
+{
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+  const Core::Array<unsigned char>& orders = m_mol.bondOrders();
+  const Core::Array<Vector3>& positions = m_mol.atomPositions3d();
+  const Core::Graph& graph = m_mol.graph();
+
+  for (Index bond = 0; bond < m_mol.bondCount(); ++bond) {
+    if (orders[bond] != 2 || m_bondInRing[bond])
+      continue;
+
+    const Index first = pairs[bond].first;
+    const Index second = pairs[bond].second;
+    if (m_suppressed[first] || m_suppressed[second])
+      continue;
+
+    // Each end has to be a plain sp2 centre with something to orient. More
+    // than one double bond means a cumulated system, whose stereochemistry is
+    // axial rather than cis/trans.
+    bool usable = true;
+    Index substituents[2][2];
+    Index substituentCount[2] = { 0, 0 };
+    const Index carbons[2] = { first, second };
+    for (int end = 0; end < 2 && usable; ++end) {
+      Index doubleBonds = 0;
+      for (Index incident : graph.edges(carbons[end])) {
+        if (orders[incident] == 2)
+          ++doubleBonds;
+        if (incident == bond)
+          continue;
+        const std::pair<Index, Index>& ends = pairs[incident];
+        const Index other =
+          (ends.first == carbons[end]) ? ends.second : ends.first;
+        if (substituentCount[end] < 2)
+          substituents[end][substituentCount[end]] = other;
+        ++substituentCount[end];
+      }
+      usable = (doubleBonds == 1) && substituentCount[end] >= 1 &&
+               substituentCount[end] <= 2;
+    }
+    if (!usable)
+      continue;
+
+    // Two indistinguishable substituents at either end means there is no
+    // cis/trans to describe -- 1,1-dichloroethene, or a terminal =CH2.
+    bool stereogenic = true;
+    for (int end = 0; end < 2; ++end) {
+      if (substituentCount[end] == 2 &&
+          m_classes[substituents[end][0]] == m_classes[substituents[end][1]])
+        stereogenic = false;
+    }
+    if (!stereogenic)
+      continue;
+
+    Index markerBond[2];
+    Index markerAtom[2];
+    if (!directionalBond(first, second, markerBond[0], markerAtom[0]) ||
+        !directionalBond(second, first, markerBond[1], markerAtom[1]))
+      continue;
+
+    // Are the two marked substituents on the same side of the double bond?
+    // Only the component perpendicular to the bond axis carries that.
+    const Vector3 axis = positions[second] - positions[first];
+    const Real axisLengthSquared = axis.squaredNorm();
+    if (axisLengthSquared < MinBondLengthSquared)
+      continue;
+
+    Vector3 offsets[2];
+    bool flat = false;
+    for (int end = 0; end < 2; ++end) {
+      const Vector3 raw = positions[markerAtom[end]] - positions[carbons[end]];
+      offsets[end] = raw - axis * (raw.dot(axis) / axisLengthSquared);
+      if (offsets[end].squaredNorm() < MinBondLengthSquared)
+        flat = true;
+    }
+    if (flat)
+      continue; // Collinear substituent: nothing to be on a side of.
+
+    const bool sameSide = offsets[0].dot(offsets[1]) > 0.0;
+
+    // "Up" is arbitrary, so start by putting the first substituent up. A
+    // marker written substituent-first points away from it, hence the flip.
+    Direction sides[2] = { Direction::Up,
+                           sameSide ? Direction::Up : Direction::Down };
+    Direction wanted[2];
+    for (int end = 0; end < 2; ++end) {
+      const bool substituentFirst =
+        pairs[markerBond[end]].first == markerAtom[end];
+      wanted[end] = substituentFirst ? opposite(sides[end]) : sides[end];
+    }
+
+    // A single bond shared with an earlier double bond -- the middle bond of a
+    // diene -- already carries a symbol, and that fixes which side is "up"
+    // here. Flipping both markers describes the same geometry.
+    for (int end = 0; end < 2; ++end) {
+      if (m_bondDirection[markerBond[end]] != Direction::None &&
+          m_bondDirection[markerBond[end]] != wanted[end]) {
+        wanted[0] = opposite(wanted[0]);
+        wanted[1] = opposite(wanted[1]);
+        break;
+      }
+    }
+
+    // If it still disagrees the constraints cannot all be met, which a ring of
+    // conjugated double bonds can produce. Leave this one unspecified rather
+    // than contradict a bond already written.
+    bool consistent = true;
+    for (int end = 0; end < 2; ++end) {
+      if (m_bondDirection[markerBond[end]] != Direction::None &&
+          m_bondDirection[markerBond[end]] != wanted[end])
+        consistent = false;
+    }
+    if (!consistent)
+      continue;
+
+    m_bondDirection[markerBond[0]] = wanted[0];
+    m_bondDirection[markerBond[1]] = wanted[1];
+  }
+}
+
 bool Serializer::takeRingNumber(int& number, std::string& error)
 {
   for (int candidate = 1; candidate <= MaxRingNumber; ++candidate) {
@@ -242,7 +647,7 @@ bool Serializer::takeRingNumber(int& number, std::string& error)
   return false;
 }
 
-const char* Serializer::bondSymbol(Index bond) const
+const char* Serializer::bondSymbol(Index bond, Index fromAtom) const
 {
   switch (m_mol.bondOrders()[bond]) {
     case 2:
@@ -252,9 +657,21 @@ const char* Serializer::bondSymbol(Index bond) const
     case 4:
       return "$";
     default:
-      // Order 1, and anything unset, is the SMILES default and written bare.
-      return "";
+      break;
   }
+
+  // A single bond next to a stereogenic double bond carries its direction,
+  // which is stated relative to the stored atom order and so reverses when the
+  // traversal writes the bond the other way round.
+  if (m_bondDirection[bond] != Direction::None) {
+    Direction direction = m_bondDirection[bond];
+    if (m_mol.bondPairs()[bond].first != fromAtom)
+      direction = opposite(direction);
+    return direction == Direction::Up ? "/" : "\\";
+  }
+
+  // Order 1, and anything unset, is the SMILES default and written bare.
+  return "";
 }
 
 void Serializer::appendRingNumber(std::string& out, int number) const
@@ -268,39 +685,90 @@ void Serializer::appendRingNumber(std::string& out, int number) const
   out += static_cast<char>('0' + number % 10);
 }
 
+bool Serializer::needsBrackets(Index atom) const
+{
+  // Bracket and Explicit both spell every atom out; only Implicit tries for a
+  // bare form. Atom maps live inside brackets, and already force Explicit.
+  if (m_mode != SmilesWriter::HydrogenMode::Implicit)
+    return true;
+
+  // Chirality can only be written inside a bracket.
+  if (m_chirality[atom] != Chirality::None)
+    return true;
+
+  const unsigned char atomicNumber = m_mol.atomicNumbers()[atom];
+
+  // A wildcard is legal bare, but it carries no implied hydrogen rule, so an
+  // atom with hydrogens would have no bare form at all. Bracketing every
+  // wildcard is simpler than bracketing only some of them.
+  if (!hasElementSymbol(atomicNumber))
+    return true;
+
+  if (m_mol.formalCharge(atom) != 0 || m_mol.isotope(atom) != 0)
+    return true;
+
+  const int implied =
+    smilesImpliedHydrogens(atomicNumber, m_bondOrderSum[atom]);
+  if (implied == SmilesNotOrganicSubset)
+    return true;
+
+  // The bare form is only usable when a reader would infer exactly the
+  // hydrogens this atom actually has. Where it would not -- a radical, or a
+  // valence the model does not know -- the count has to be spelled out, which
+  // is what keeps a methyl radical from being written as methane.
+  return implied != static_cast<int>(m_implicitH[atom]);
+}
+
 bool Serializer::emitAtom(std::string& out, Index atom, std::string& error)
 {
   const unsigned char atomicNumber = m_mol.atomicNumbers()[atom];
   const int charge = m_mol.formalCharge(atom);
   const unsigned short isotope = m_mol.isotope(atom);
+  const bool brackets = needsBrackets(atom);
 
-  out += '[';
-
-  if (isotope != 0)
-    appendUnsigned(out, isotope);
+  if (brackets) {
+    out += '[';
+    if (isotope != 0)
+      appendUnsigned(out, isotope);
+  }
 
   // Anything without a real element symbol -- a dummy atom, a custom element,
   // or InvalidElement from an unrecognized input symbol -- becomes the SMILES
   // wildcard. Elements::symbol() would answer "Xx" for these, which is not
   // valid SMILES, and dropping the atom instead would break the atom mapping.
-  if (atomicNumber > 0 && atomicNumber < Core::element_count)
+  if (hasElementSymbol(atomicNumber))
     out += Elements::symbol(atomicNumber);
   else
     out += '*';
 
-  if (charge != 0) {
-    out += (charge > 0) ? '+' : '-';
-    const int magnitude = (charge > 0) ? charge : -charge;
-    if (magnitude > 1)
-      appendUnsigned(out, magnitude);
-  }
+  if (brackets) {
+    // Chirality sits between the symbol and the hydrogen count.
+    if (m_chirality[atom] == Chirality::Anticlockwise)
+      out += '@';
+    else if (m_chirality[atom] == Chirality::Clockwise)
+      out += "@@";
 
-  if (m_atomMaps) {
-    out += ':';
-    appendUnsigned(out, atom + 1);
-  }
+    // Inside a bracket the hydrogen count is never inferred: no H means none.
+    if (m_implicitH[atom] > 0) {
+      out += 'H';
+      if (m_implicitH[atom] > 1)
+        appendUnsigned(out, m_implicitH[atom]);
+    }
 
-  out += ']';
+    if (charge != 0) {
+      out += (charge > 0) ? '+' : '-';
+      const int magnitude = (charge > 0) ? charge : -charge;
+      if (magnitude > 1)
+        appendUnsigned(out, magnitude);
+    }
+
+    if (m_atomMaps) {
+      out += ':';
+      appendUnsigned(out, atom + 1);
+    }
+
+    out += ']';
+  }
 
   // Ring bond numbers belong to the atom, ahead of any branch it opens.
   // Numbers are taken before they are released, so one freed here cannot be
@@ -312,7 +780,7 @@ bool Serializer::emitAtom(std::string& out, Index atom, std::string& error)
     // Daylight allows the bond symbol on either or both occurrences, provided
     // they agree; writing it only where the closure opens keeps them trivially
     // consistent.
-    out += bondSymbol(m_closures[c].bond);
+    out += bondSymbol(m_closures[c].bond, atom);
     appendRingNumber(out, m_closures[c].number);
   }
 
@@ -352,6 +820,7 @@ bool Serializer::emit(std::string& smiles, std::string& error)
         continue;
       }
 
+      const Index parent = frame.atom;
       const Child child = m_children[frame.child];
       frame.child = child.next;
 
@@ -360,7 +829,7 @@ bool Serializer::emit(std::string& smiles, std::string& error)
       const bool branch = (child.next != MaxIndex);
       if (branch)
         smiles += '(';
-      smiles += bondSymbol(child.bond);
+      smiles += bondSymbol(child.bond, parent);
       if (!emitAtom(smiles, child.atom, error))
         return false;
       // Invalidates frame, so nothing above may be used after this point.
@@ -387,16 +856,10 @@ bool SmilesWriter::write(const Core::Molecule& molecule, std::string& smiles)
   smiles.clear();
   m_error.clear();
 
-  if (effectiveHydrogenMode() != HydrogenMode::Explicit) {
-    m_error = "Only explicit hydrogen output is implemented so far. Call "
-              "setHydrogenMode(HydrogenMode::Explicit) or setAtomMaps(true).";
-    return false;
-  }
-
   if (molecule.atomCount() == 0)
     return true;
 
-  Serializer serializer(molecule, m_atomMaps);
+  Serializer serializer(molecule, effectiveHydrogenMode(), m_atomMaps);
   if (!serializer.run(smiles, m_error)) {
     smiles.clear();
     return false;

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -251,20 +251,22 @@ void Serializer::suppressHydrogens()
   m_implicitH.assign(atomCount, 0);
   m_suppressedHydrogen.assign(atomCount, MaxIndex);
 
-  // Explicit mode keeps every hydrogen as an atom of its own, which is also
-  // what atom mapping requires -- a folded hydrogen has nowhere to carry a
-  // map class.
-  if (m_mode == SmilesWriter::HydrogenMode::Explicit)
-    return;
-
   const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
   const Core::Array<unsigned char>& numbers = m_mol.atomicNumbers();
 
+  // Filled before the early return below: hasStereoCandidates() reads it in
+  // every mode.
   m_degree.assign(atomCount, 0);
   for (const std::pair<Index, Index>& ends : pairs) {
     ++m_degree[ends.first];
     ++m_degree[ends.second];
   }
+
+  // Explicit mode keeps every hydrogen as an atom of its own, which is also
+  // what atom mapping requires -- a folded hydrogen has nowhere to carry a
+  // map class.
+  if (m_mode == SmilesWriter::HydrogenMode::Explicit)
+    return;
 
   for (Index bond = 0; bond < pairs.size(); ++bond) {
     if (m_mol.bondOrders()[bond] > 1)

--- a/avogadro/io/smileswriter.cpp
+++ b/avogadro/io/smileswriter.cpp
@@ -1,0 +1,361 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "smileswriter.h"
+
+#include <avogadro/core/elements.h>
+#include <avogadro/core/graph.h>
+#include <avogadro/core/molecule.h>
+
+#include <set>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace Avogadro::Io {
+
+using Core::Elements;
+using Core::Molecule;
+
+namespace {
+
+/** SMILES can express ring bond numbers 0-9 bare and 10-99 as %nn. */
+const int MaxRingNumber = 99;
+
+/** A bond that is not part of the depth-first spanning tree. */
+struct RingClosure
+{
+  Index open = MaxIndex;  //!< Atom the closure opens at (visited first).
+  Index close = MaxIndex; //!< Atom it closes at.
+  Index bond = MaxIndex;  //!< The molecule bond it stands for.
+  int number = 0;         //!< The ring bond number assigned to it.
+};
+
+/** An edge of the spanning tree, from the perspective of the parent. */
+struct Child
+{
+  Index atom = MaxIndex;
+  Index bond = MaxIndex;
+};
+
+/**
+ * Turns a molecule into a SMILES string.
+ *
+ * Both the traversal and the emission use an explicit stack rather than
+ * recursion: a long chain -- a protein backbone, a polymer -- would otherwise
+ * recurse once per atom and overflow the stack on platforms with a small
+ * default, and this code must not crash on a valid molecule.
+ */
+class Serializer
+{
+public:
+  Serializer(const Molecule& mol, bool atomMaps)
+    : m_mol(mol), m_atomMaps(atomMaps)
+  {
+  }
+
+  bool run(std::string& smiles, std::string& error);
+
+private:
+  struct TraversalFrame
+  {
+    Index atom;
+    size_t next;
+    std::vector<size_t> incident;
+  };
+
+  struct EmitFrame
+  {
+    Index atom;
+    size_t next;
+    bool closeParen;
+  };
+
+  void traverse();
+  bool numberClosures(std::string& error);
+  void emit(std::string& smiles) const;
+  void emitAtom(std::ostringstream& out, Index atom) const;
+  std::string bondSymbol(Index bond) const;
+
+  const Molecule& m_mol;
+  bool m_atomMaps;
+
+  std::vector<Index> m_roots;
+  std::vector<Index> m_visitOrder;
+  std::vector<std::vector<Child>> m_children;
+  std::vector<RingClosure> m_closures;
+  std::vector<std::vector<size_t>> m_atomClosures;
+};
+
+std::string ringNumber(int number)
+{
+  if (number < 10)
+    return std::string(1, static_cast<char>('0' + number));
+
+  std::string result("%");
+  result += static_cast<char>('0' + number / 10);
+  result += static_cast<char>('0' + number % 10);
+  return result;
+}
+
+bool Serializer::run(std::string& smiles, std::string& error)
+{
+  traverse();
+  if (!numberClosures(error))
+    return false;
+  emit(smiles);
+  return true;
+}
+
+void Serializer::traverse()
+{
+  const Index atomCount = m_mol.atomCount();
+  const Core::Graph& graph = m_mol.graph();
+  const Core::Array<std::pair<Index, Index>>& pairs = m_mol.bondPairs();
+
+  std::vector<bool> visited(atomCount, false);
+  std::vector<bool> bondUsed(m_mol.bondCount(), false);
+  m_visitOrder.assign(atomCount, MaxIndex);
+  m_children.assign(atomCount, std::vector<Child>());
+
+  Index order = 0;
+  std::vector<TraversalFrame> stack;
+
+  for (Index root = 0; root < atomCount; ++root) {
+    if (visited[root])
+      continue;
+
+    m_roots.push_back(root);
+    visited[root] = true;
+    m_visitOrder[root] = order++;
+    stack.push_back(TraversalFrame{ root, 0, graph.edges(root) });
+
+    while (!stack.empty()) {
+      TraversalFrame& frame = stack.back();
+      if (frame.next >= frame.incident.size()) {
+        stack.pop_back();
+        continue;
+      }
+
+      const Index current = frame.atom;
+      const Index bond = frame.incident[frame.next++];
+      if (bondUsed[bond])
+        continue;
+
+      const std::pair<Index, Index>& ends = pairs[bond];
+      const Index other = (ends.first == current) ? ends.second : ends.first;
+      if (other == current)
+        continue; // Defensive: a self bond has no SMILES representation.
+
+      bondUsed[bond] = true;
+
+      if (visited[other]) {
+        // A non-tree edge in an undirected depth-first search always joins an
+        // atom to one of its own ancestors, so the ancestor -- the one seen
+        // first -- is where the closure opens.
+        RingClosure closure;
+        closure.bond = bond;
+        if (m_visitOrder[other] < m_visitOrder[current]) {
+          closure.open = other;
+          closure.close = current;
+        } else {
+          closure.open = current;
+          closure.close = other;
+        }
+        m_closures.push_back(closure);
+      } else {
+        visited[other] = true;
+        m_visitOrder[other] = order++;
+        m_children[current].push_back(Child{ other, bond });
+        // Invalidates frame, so nothing above may be used after this point.
+        stack.push_back(TraversalFrame{ other, 0, graph.edges(other) });
+      }
+    }
+  }
+}
+
+bool Serializer::numberClosures(std::string& error)
+{
+  const Index atomCount = m_mol.atomCount();
+
+  std::vector<std::vector<size_t>> opensAt(atomCount);
+  std::vector<std::vector<size_t>> closesAt(atomCount);
+  for (size_t i = 0; i < m_closures.size(); ++i) {
+    opensAt[m_closures[i].open].push_back(i);
+    closesAt[m_closures[i].close].push_back(i);
+  }
+
+  std::vector<Index> orderToAtom(atomCount, MaxIndex);
+  for (Index atom = 0; atom < atomCount; ++atom)
+    orderToAtom[m_visitOrder[atom]] = atom;
+
+  m_atomClosures.assign(atomCount, std::vector<size_t>());
+  std::set<int> freeNumbers;
+  int nextNumber = 1;
+
+  for (Index position = 0; position < atomCount; ++position) {
+    const Index atom = orderToAtom[position];
+
+    // Allocate before releasing, so a number freed here cannot be reused on
+    // the same atom: "C11" would pair the two digits with each other rather
+    // than with their intended partners.
+    for (size_t closure : opensAt[atom]) {
+      int number = 0;
+      if (!freeNumbers.empty()) {
+        number = *freeNumbers.begin();
+        freeNumbers.erase(freeNumbers.begin());
+      } else if (nextNumber <= MaxRingNumber) {
+        number = nextNumber++;
+      } else {
+        error = "Too many ring closures are open at once; SMILES cannot "
+                "express more than 99.";
+        return false;
+      }
+      m_closures[closure].number = number;
+      m_atomClosures[atom].push_back(closure);
+    }
+
+    for (size_t closure : closesAt[atom]) {
+      freeNumbers.insert(m_closures[closure].number);
+      m_atomClosures[atom].push_back(closure);
+    }
+  }
+
+  return true;
+}
+
+std::string Serializer::bondSymbol(Index bond) const
+{
+  switch (m_mol.bondOrders()[bond]) {
+    case 2:
+      return "=";
+    case 3:
+      return "#";
+    case 4:
+      return "$";
+    default:
+      // Order 1, and anything unset, is the SMILES default and written bare.
+      return "";
+  }
+}
+
+void Serializer::emitAtom(std::ostringstream& out, Index atom) const
+{
+  const unsigned char atomicNumber = m_mol.atomicNumbers()[atom];
+  const int charge = m_mol.formalCharge(atom);
+  const unsigned short isotope = m_mol.isotope(atom);
+
+  out << '[';
+
+  if (isotope != 0)
+    out << isotope;
+
+  // Anything without a real element symbol -- a dummy atom, a custom element,
+  // or InvalidElement from an unrecognized input symbol -- becomes the SMILES
+  // wildcard. Elements::symbol() would answer "Xx" for these, which is not
+  // valid SMILES, and dropping the atom instead would break the atom mapping.
+  if (atomicNumber > 0 && atomicNumber < Core::element_count)
+    out << Elements::symbol(atomicNumber);
+  else
+    out << '*';
+
+  if (charge != 0) {
+    out << (charge > 0 ? '+' : '-');
+    const int magnitude = (charge > 0) ? charge : -charge;
+    if (magnitude > 1)
+      out << magnitude;
+  }
+
+  if (m_atomMaps)
+    out << ':' << (atom + 1);
+
+  out << ']';
+
+  // Ring bond numbers belong to the atom, ahead of any branch it opens.
+  for (size_t closure : m_atomClosures[atom]) {
+    // Daylight allows the bond symbol on either or both occurrences, provided
+    // they agree; writing it only where the closure opens keeps them trivially
+    // consistent.
+    if (m_closures[closure].open == atom)
+      out << bondSymbol(m_closures[closure].bond);
+    out << ringNumber(m_closures[closure].number);
+  }
+}
+
+void Serializer::emit(std::string& smiles) const
+{
+  std::ostringstream out;
+  std::vector<EmitFrame> stack;
+
+  for (size_t component = 0; component < m_roots.size(); ++component) {
+    if (component != 0)
+      out << '.';
+
+    emitAtom(out, m_roots[component]);
+    stack.push_back(EmitFrame{ m_roots[component], 0, false });
+
+    while (!stack.empty()) {
+      const Index atom = stack.back().atom;
+      const size_t childCount = m_children[atom].size();
+
+      if (stack.back().next >= childCount) {
+        const bool closeParen = stack.back().closeParen;
+        stack.pop_back();
+        if (closeParen)
+          out << ')';
+        continue;
+      }
+
+      const size_t which = stack.back().next++;
+      const Child child = m_children[atom][which];
+
+      // Every child but the last is a branch; the last one continues the
+      // chain, which is what keeps the output free of redundant parentheses.
+      const bool branch = (which + 1 < childCount);
+      if (branch)
+        out << '(';
+      out << bondSymbol(child.bond);
+      emitAtom(out, child.atom);
+      stack.push_back(EmitFrame{ child.atom, 0, branch });
+    }
+  }
+
+  smiles = out.str();
+}
+
+} // namespace
+
+SmilesWriter::HydrogenMode SmilesWriter::effectiveHydrogenMode() const
+{
+  // Atom maps only exist inside brackets, and a hydrogen folded into a bracket
+  // count has nowhere to carry one. Since Avogadro's hydrogens are real atoms
+  // with real indices, folding them would produce a partial mapping.
+  return m_atomMaps ? HydrogenMode::Explicit : m_hydrogenMode;
+}
+
+bool SmilesWriter::write(const Core::Molecule& molecule, std::string& smiles)
+{
+  smiles.clear();
+  m_error.clear();
+
+  if (effectiveHydrogenMode() != HydrogenMode::Explicit) {
+    m_error = "Only explicit hydrogen output is implemented so far. Call "
+              "setHydrogenMode(HydrogenMode::Explicit) or setAtomMaps(true).";
+    return false;
+  }
+
+  if (molecule.atomCount() == 0)
+    return true;
+
+  Serializer serializer(molecule, m_atomMaps);
+  if (!serializer.run(smiles, m_error)) {
+    smiles.clear();
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace Avogadro::Io

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -74,6 +74,17 @@ public:
   bool atomMaps() const { return m_atomMaps; }
 
   /**
+   * Write perceived aromatic rings in the lowercase form, so benzene is
+   * "c1ccccc1" rather than "C1=CC=CC=C1". Both describe the same molecule;
+   * the lowercase form is what most toolkits produce and expect.
+   *
+   * Perception is Core::AromaticityPerceiver; anything it does not recognise
+   * is written with its bond orders as stored.
+   */
+  void setAromatic(bool enable) { m_aromatic = enable; }
+  bool aromatic() const { return m_aromatic; }
+
+  /**
    * @return The hydrogen mode that will actually be used, after applying the
    * implication described in setAtomMaps().
    */
@@ -94,6 +105,7 @@ public:
 private:
   HydrogenMode m_hydrogenMode = HydrogenMode::Implicit;
   bool m_atomMaps = false;
+  bool m_aromatic = true;
   std::string m_error;
 };
 

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -22,13 +22,15 @@ namespace Avogadro::Io {
  * @class SmilesWriter smileswriter.h <avogadro/io/smileswriter.h>
  * @brief Serialize a molecule to a SMILES string.
  *
- * Output is Kekule only: bond orders are written as they are stored, and no
- * aromatic perception is performed.
+ * Tetrahedral chirality and double bond direction markers are read out of the
+ * molecule's coordinates, so they are written only for a molecule that has
+ * them; a structure without 3D positions is written without stereochemistry
+ * rather than with a guess. Which centres count as stereogenic is decided
+ * constitutionally, within the limits documented in atomequivalence_p.h.
  *
- * Tetrahedral and cis/trans stereochemistry are read from the coordinates and
- * written. There is no way to express "unspecified", so a centre with a
- * definite geometry always gets a definite descriptor. Ring cis/trans centres
- * are not detected -- see atomEquivalenceClasses().
+ * Where a source marked a configuration undefined -- see Core::stereo.h --
+ * that is honoured and no descriptor is written, since the coordinates in that
+ * case are a placement rather than a claim.
  */
 
 class AVOGADROIO_EXPORT SmilesWriter

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -84,7 +84,7 @@ public:
   /**
    * @return A description of the last failure, or an empty string.
    */
-  std::string error() const { return m_error; }
+  const std::string& error() const { return m_error; }
 
 private:
   HydrogenMode m_hydrogenMode = HydrogenMode::Implicit;

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -78,7 +78,8 @@ public:
   /**
    * Write perceived aromatic rings in the lowercase form, so benzene is
    * "c1ccccc1" rather than "C1=CC=CC=C1". Both describe the same molecule;
-   * the lowercase form is what most toolkits produce and expect.
+   * the lowercase form is what most toolkits produce and expect, so it is
+   * enabled by default and callers wanting Kekule output must ask for it.
    *
    * Perception is Core::AromaticityPerceiver; anything it does not recognise
    * is written with its bond orders as stored.

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -1,0 +1,97 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_IO_SMILESWRITER_H
+#define AVOGADRO_IO_SMILESWRITER_H
+
+#include "avogadroioexport.h"
+
+#include <avogadro/core/avogadrocore.h>
+
+#include <string>
+
+namespace Avogadro::Core {
+class Molecule;
+}
+
+namespace Avogadro::Io {
+
+/**
+ * @class SmilesWriter smileswriter.h <avogadro/io/smileswriter.h>
+ * @brief Serialize a molecule to a SMILES string.
+ *
+ * Output is Kekule only: bond orders are written as they are stored, and no
+ * aromatic perception is performed. Stereochemistry is not yet represented.
+ */
+
+class AVOGADROIO_EXPORT SmilesWriter
+{
+public:
+  /**
+   * How hydrogens are represented in the output.
+   */
+  enum class HydrogenMode
+  {
+    /** Inferred from the valence model, so methane is written "C". */
+    Implicit,
+    /** A count inside the bracket, so methane is written "[CH4]". */
+    Bracket,
+    /** Separate atoms, so methane is written "[H][C]([H])([H])[H]". */
+    Explicit
+  };
+
+  SmilesWriter() = default;
+  ~SmilesWriter() = default;
+
+  /**
+   * Set how hydrogens are represented. Note that atomMaps() overrides this,
+   * see setAtomMaps().
+   */
+  void setHydrogenMode(HydrogenMode mode) { m_hydrogenMode = mode; }
+  HydrogenMode hydrogenMode() const { return m_hydrogenMode; }
+
+  /**
+   * Emit each atom's index as a Daylight atom map class, so that the string
+   * can be correlated back to the molecule it came from.
+   *
+   * Classes are written one-based, because Daylight assigns class zero the
+   * meaning "unmapped"; a consumer reading the classes back must subtract one
+   * to recover the Avogadro atom index.
+   *
+   * This implies HydrogenMode::Explicit. A hydrogen folded into a bracket
+   * count has nowhere to carry a class, and in Avogadro that hydrogen is a
+   * real atom with a real index, so folding it would silently produce a
+   * partial mapping.
+   */
+  void setAtomMaps(bool enable) { m_atomMaps = enable; }
+  bool atomMaps() const { return m_atomMaps; }
+
+  /**
+   * @return The hydrogen mode that will actually be used, after applying the
+   * implication described in setAtomMaps().
+   */
+  HydrogenMode effectiveHydrogenMode() const;
+
+  /**
+   * Write @a molecule to @a smiles.
+   * @return True on success, false on failure, in which case error() gives
+   * more detail and @a smiles is left empty.
+   */
+  bool write(const Core::Molecule& molecule, std::string& smiles);
+
+  /**
+   * @return A description of the last failure, or an empty string.
+   */
+  std::string error() const { return m_error; }
+
+private:
+  HydrogenMode m_hydrogenMode = HydrogenMode::Implicit;
+  bool m_atomMaps = false;
+  std::string m_error;
+};
+
+} // namespace Avogadro::Io
+
+#endif // AVOGADRO_IO_SMILESWRITER_H

--- a/avogadro/io/smileswriter.h
+++ b/avogadro/io/smileswriter.h
@@ -23,7 +23,12 @@ namespace Avogadro::Io {
  * @brief Serialize a molecule to a SMILES string.
  *
  * Output is Kekule only: bond orders are written as they are stored, and no
- * aromatic perception is performed. Stereochemistry is not yet represented.
+ * aromatic perception is performed.
+ *
+ * Tetrahedral and cis/trans stereochemistry are read from the coordinates and
+ * written. There is no way to express "unspecified", so a centre with a
+ * definite geometry always gets a definite descriptor. Ring cis/trans centres
+ * are not detected -- see atomEquivalenceClasses().
  */
 
 class AVOGADROIO_EXPORT SmilesWriter

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -7,6 +7,7 @@
 
 #include <avogadro/io/cjsonformat.h>
 #include <avogadro/io/fileformatmanager.h>
+#include <avogadro/io/smilesformat.h>
 
 #include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtgui/rwmolecule.h>
@@ -30,6 +31,7 @@ CopyPaste::CopyPaste(QObject* parent_)
     m_copyAction(new QAction(tr("Copy"), this)),
     // don't translate SMILES, InChI, or XYZ
     m_copySMILES(new QAction("SMILES", this)),
+    m_copyMappedSMILES(new QAction(tr("Atom Mapped SMILES"), this)),
     m_copyInChI(new QAction("InChI", this)),
     m_copyXYZ(new QAction("XYZ", this)),
     m_cutAction(new QAction(tr("Cut"), this)),
@@ -48,6 +50,9 @@ CopyPaste::CopyPaste(QObject* parent_)
 
   m_copySMILES->setProperty("menu priority", 540);
   connect(m_copySMILES, SIGNAL(triggered()), SLOT(copySMILES()));
+
+  m_copyMappedSMILES->setProperty("menu priority", 535);
+  connect(m_copyMappedSMILES, SIGNAL(triggered()), SLOT(copyMappedSMILES()));
 
   m_copyInChI->setProperty("menu priority", 530);
   connect(m_copyInChI, SIGNAL(triggered()), SLOT(copyInChI()));
@@ -74,17 +79,20 @@ CopyPaste::~CopyPaste()
 QList<QAction*> CopyPaste::actions() const
 {
   QList<QAction*> result;
-  return result << m_copyAction << m_copySMILES << m_copyInChI << m_copyXYZ
-                << m_cutAction << m_pasteAction << m_clearAction;
+  return result << m_copyAction << m_copySMILES << m_copyMappedSMILES
+                << m_copyInChI << m_copyXYZ << m_cutAction << m_pasteAction
+                << m_clearAction;
 }
 
 QStringList CopyPaste::menuPath(QAction* action) const
 {
-  if (action->text() != tr("SMILES") && action->text() != tr("InChI") &&
-      action->text() != tr("XYZ"))
-    return QStringList() << tr("&Edit");
-  else
+  // Compare the actions themselves rather than their text: the format names
+  // are deliberately untranslated, so a tr() comparison would not match.
+  if (action == m_copySMILES || action == m_copyMappedSMILES ||
+      action == m_copyInChI || action == m_copyXYZ)
     return QStringList() << tr("&Edit") << tr("Copy As");
+
+  return QStringList() << tr("&Edit");
 }
 
 void CopyPaste::setMolecule(QtGui::Molecule* mol)
@@ -105,6 +113,19 @@ void CopyPaste::copySMILES()
 
   copy(format);
   delete format;
+}
+
+void CopyPaste::copyMappedSMILES()
+{
+  // Not routed through FileFormatManager: the native SMILES format is not
+  // registered for the "smi" extension, which still resolves to Open Babel.
+  Io::SmilesFormat format;
+  format.setOptions("{\"atomMaps\": true}");
+
+  // The map classes number the atoms of whatever is written, one-based. With
+  // a selection active, copy() writes a re-indexed copy of the selected atoms,
+  // so the classes follow that fragment rather than the full molecule.
+  copy(&format);
 }
 
 void CopyPaste::copyInChI()
@@ -165,11 +186,10 @@ bool CopyPaste::copy(Io::FileFormat* format)
       qobject_cast<QWidget*>(this->parent()), tr("Error Clipping Molecule"),
       tr("Error generating clipboard data.") + "\n" +
         tr("Output format: %1\n%2", "file format")
-          .arg(QString::fromStdString(m_pastedFormat->name()))
-          .arg(QString::fromStdString(m_pastedFormat->description())) +
+          .arg(QString::fromStdString(format->name()))
+          .arg(QString::fromStdString(format->description())) +
         "\n\n" +
-        tr("Reader error:\n%1")
-          .arg(QString::fromStdString(m_pastedFormat->error())));
+        tr("Reader error:\n%1").arg(QString::fromStdString(format->error())));
     return false;
   }
 

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -199,7 +199,7 @@ bool CopyPaste::copy(Io::FileFormat* format)
           .arg(QString::fromStdString(format->name()))
           .arg(QString::fromStdString(format->description())) +
         "\n\n" +
-        tr("Reader error:\n%1").arg(QString::fromStdString(format->error())));
+        tr("Writer error:\n%1").arg(QString::fromStdString(format->error())));
     return false;
   }
 

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -48,16 +48,22 @@ CopyPaste::CopyPaste(QObject* parent_)
   m_copyAction->setProperty("menu priority", 550);
   connect(m_copyAction, SIGNAL(triggered()), SLOT(copyCJSON()));
 
+  const QString copyAs = tr("Copy As");
+
   m_copySMILES->setProperty("menu priority", 540);
+  m_copySMILES->setProperty("menu submenu", copyAs);
   connect(m_copySMILES, SIGNAL(triggered()), SLOT(copySMILES()));
 
   m_copyMappedSMILES->setProperty("menu priority", 535);
+  m_copyMappedSMILES->setProperty("menu submenu", copyAs);
   connect(m_copyMappedSMILES, SIGNAL(triggered()), SLOT(copyMappedSMILES()));
 
   m_copyInChI->setProperty("menu priority", 530);
+  m_copyInChI->setProperty("menu submenu", copyAs);
   connect(m_copyInChI, SIGNAL(triggered()), SLOT(copyInChI()));
 
   m_copyXYZ->setProperty("menu priority", 520);
+  m_copyXYZ->setProperty("menu submenu", copyAs);
   connect(m_copyXYZ, SIGNAL(triggered()), SLOT(copyXYZ()));
 
   m_pasteAction->setShortcut(QKeySequence::Paste);
@@ -86,11 +92,12 @@ QList<QAction*> CopyPaste::actions() const
 
 QStringList CopyPaste::menuPath(QAction* action) const
 {
-  // Compare the actions themselves rather than their text: the format names
-  // are deliberately untranslated, so a tr() comparison would not match.
-  if (action == m_copySMILES || action == m_copyMappedSMILES ||
-      action == m_copyInChI || action == m_copyXYZ)
-    return QStringList() << tr("&Edit") << tr("Copy As");
+  // Each action carries its own submenu, in the same spirit as the "menu
+  // priority" property set above. Matching on text would not work here: the
+  // format names are deliberately untranslated.
+  const QVariant submenu = action->property("menu submenu");
+  if (submenu.isValid())
+    return QStringList() << tr("&Edit") << submenu.toString();
 
   return QStringList() << tr("&Edit");
 }
@@ -119,8 +126,11 @@ void CopyPaste::copyMappedSMILES()
 {
   // Not routed through FileFormatManager: the native SMILES format is not
   // registered for the "smi" extension, which still resolves to Open Babel.
+  // TODO: once implicit hydrogen output lands, both SMILES actions should go
+  // through one implementation rather than two engines with different
+  // aromaticity and hydrogen conventions.
   Io::SmilesFormat format;
-  format.setOptions("{\"atomMaps\": true}");
+  format.setAtomMaps(true);
 
   // The map classes number the atoms of whatever is written, one-based. With
   // a selection active, copy() writes a re-indexed copy of the selected atoms,
@@ -175,7 +185,7 @@ bool CopyPaste::copy(Io::FileFormat* format)
       Core::Bond bond = m_molecule->bond(i);
       Index start = bond.atom1().index();
       Index end = bond.atom2().index();
-      if (m_molecule->atomSelected(start) && m_molecule->atomSelected(start)) {
+      if (m_molecule->atomSelected(start) && m_molecule->atomSelected(end)) {
         copy->addBond(atomIndex[start], atomIndex[end], bond.order());
       }
     }

--- a/avogadro/qtplugins/copypaste/copypaste.cpp
+++ b/avogadro/qtplugins/copypaste/copypaste.cpp
@@ -124,11 +124,9 @@ void CopyPaste::copySMILES()
 
 void CopyPaste::copyMappedSMILES()
 {
-  // Not routed through FileFormatManager: the native SMILES format is not
-  // registered for the "smi" extension, which still resolves to Open Babel.
-  // TODO: once implicit hydrogen output lands, both SMILES actions should go
-  // through one implementation rather than two engines with different
-  // aromaticity and hydrogen conventions.
+  // Named directly rather than looked up by extension, because atom mapping is
+  // a setting only this format has. Plain "Copy as SMILES" reaches the same
+  // writer through the manager, so the two agree on everything else.
   Io::SmilesFormat format;
   format.setAtomMaps(true);
 

--- a/avogadro/qtplugins/copypaste/copypaste.h
+++ b/avogadro/qtplugins/copypaste/copypaste.h
@@ -47,6 +47,7 @@ private slots:
     Io::FileFormat* format); // returns bool so cut can reuse implementation.
   bool copyCJSON();
   void copySMILES();
+  void copyMappedSMILES();
   void copyInChI();
   void copyXYZ();
   void cut();
@@ -62,6 +63,7 @@ private:
 
   QAction* m_copyAction;
   QAction* m_copySMILES;
+  QAction* m_copyMappedSMILES;
   QAction* m_copyInChI;
   QAction* m_copyXYZ;
   QAction* m_cutAction;

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Specify the name of each test (the Test will be appended where needed).
 set(tests
   AngleIterator
+  Aromaticity
   Array
   Atom
   AtomTyper

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
   GaussianSet
   Graph
   InternalCoordinates
+  Kekulize
   Mesh
   Molecule
   Mutex

--- a/tests/core/aromaticitytest.cpp
+++ b/tests/core/aromaticitytest.cpp
@@ -71,11 +71,11 @@ bool noneAromatic(const Molecule& mol)
   return true;
 }
 
-const unsigned char C = 6;
-const unsigned char N = 7;
-const unsigned char O = 8;
-const unsigned char S = 16;
-const unsigned char B = 5;
+constexpr unsigned char C = 6;
+constexpr unsigned char N = 7;
+constexpr unsigned char O = 8;
+constexpr unsigned char S = 16;
+constexpr unsigned char B = 5;
 
 } // namespace
 
@@ -155,12 +155,17 @@ TEST(AromaticityTest, antiaromaticAndSaturatedRingsAreNot)
     noneAromatic(ring({ { C, 0, 2 }, { C, 0, 1 }, { C, 0, 2 }, { C, 0, 1 } })));
 
   // Cyclohexane: no atom has a p orbital to lend.
-  EXPECT_TRUE(noneAromatic(ring({ { C, 0, 1 },
-                                  { C, 0, 1 },
-                                  { C, 0, 1 },
-                                  { C, 0, 1 },
-                                  { C, 0, 1 },
-                                  { C, 0, 1 } })));
+  Molecule cyclohexane = ring({ { C, 0, 1 },
+                                { C, 0, 1 },
+                                { C, 0, 1 },
+                                { C, 0, 1 },
+                                { C, 0, 1 },
+                                { C, 0, 1 } });
+  for (Index i = 0; i < 6; ++i) {
+    cyclohexane.addBond(i, cyclohexane.addAtom(1).index(), 1);
+    cyclohexane.addBond(i, cyclohexane.addAtom(1).index(), 1);
+  }
+  EXPECT_TRUE(noneAromatic(cyclohexane));
 
   // Cyclooctatetraene: eight electrons.
   EXPECT_TRUE(noneAromatic(ring({ { C, 0, 2 },
@@ -200,7 +205,7 @@ TEST(AromaticityTest, exocyclicDoubleBond)
   EXPECT_EQ(perceiver.piContributions()[0], 2) << "amide nitrogen";
   EXPECT_TRUE(perceiver.aromaticAtoms()[0]);
   EXPECT_TRUE(perceiver.aromaticAtoms()[1]);
-  EXPECT_FALSE(perceiver.aromaticAtoms()[6]) << "the oxygen is not in a ring";
+  EXPECT_FALSE(perceiver.aromaticAtoms()[7]) << "the oxygen is not in a ring";
 }
 
 TEST(AromaticityTest, fusedRings)

--- a/tests/core/aromaticitytest.cpp
+++ b/tests/core/aromaticitytest.cpp
@@ -1,0 +1,264 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/aromaticity.h>
+#include <avogadro/core/molecule.h>
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+using Avogadro::Index;
+using Avogadro::Core::AromaticityPerceiver;
+using Avogadro::Core::Molecule;
+using Avogadro::Core::NotAromaticCandidate;
+
+namespace {
+
+/**
+ * Build a single ring from a compact description: one entry per ring atom
+ * giving its atomic number, formal charge, and the order of the bond to the
+ * next atom round the ring.
+ */
+struct RingAtom
+{
+  unsigned char atomicNumber;
+  signed char charge;
+  unsigned char bondToNext;
+};
+
+Molecule ring(const std::vector<RingAtom>& atoms)
+{
+  Molecule mol;
+  for (const RingAtom& atom : atoms) {
+    Index index = mol.addAtom(atom.atomicNumber).index();
+    mol.setFormalCharge(index, atom.charge);
+  }
+  for (Index i = 0; i < atoms.size(); ++i)
+    mol.addBond(i, (i + 1) % atoms.size(), atoms[i].bondToNext);
+  return mol;
+}
+
+/**
+ * True when the first @a ringSize atoms all came out aromatic. Ring atoms are
+ * always added first, so any hydrogens or substituents added afterwards -- and
+ * which are not in the ring -- are correctly ignored.
+ */
+bool allAromatic(const Molecule& mol, Index ringSize)
+{
+  AromaticityPerceiver perceiver(&mol);
+  const std::vector<bool>& atoms = perceiver.aromaticAtoms();
+  if (atoms.size() < ringSize || ringSize == 0)
+    return false;
+  for (Index i = 0; i < ringSize; ++i) {
+    if (!atoms[i])
+      return false;
+  }
+  return true;
+}
+
+bool noneAromatic(const Molecule& mol)
+{
+  AromaticityPerceiver perceiver(&mol);
+  for (bool aromatic : perceiver.aromaticAtoms()) {
+    if (aromatic)
+      return false;
+  }
+  return true;
+}
+
+const unsigned char C = 6;
+const unsigned char N = 7;
+const unsigned char O = 8;
+const unsigned char S = 16;
+const unsigned char B = 5;
+
+} // namespace
+
+TEST(AromaticityTest, benzene)
+{
+  EXPECT_TRUE(allAromatic(ring({ { C, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 } }),
+                          6));
+}
+
+TEST(AromaticityTest, sixMemberedHeterocycles)
+{
+  // Pyridine: the nitrogen carries a ring double bond and gives one electron.
+  EXPECT_TRUE(allAromatic(ring({ { N, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 } }),
+                          6));
+}
+
+TEST(AromaticityTest, fiveMemberedHeterocycles)
+{
+  // Pyrrole, furan and thiophene all work the same way: the heteroatom has no
+  // ring double bond and donates its lone pair.
+  for (unsigned char heteroatom : { N, O, S }) {
+    Molecule mol = ring({ { heteroatom, 0, 1 },
+                          { C, 0, 2 },
+                          { C, 0, 1 },
+                          { C, 0, 2 },
+                          { C, 0, 1 } });
+    // Pyrrole's nitrogen needs its hydrogen to reach three connections.
+    if (heteroatom == N)
+      mol.addBond(0, mol.addAtom(1).index(), 1);
+    EXPECT_TRUE(allAromatic(mol, 5)) << "atomic number " << int(heteroatom);
+  }
+}
+
+TEST(AromaticityTest, imidazole)
+{
+  Molecule mol = ring({ { N, 0, 1 }, // pyrrole-type, donates two
+                        { C, 0, 2 }, //
+                        { N, 0, 1 }, // pyridine-type, donates one
+                        { C, 0, 2 }, //
+                        { C, 0, 1 } });
+  mol.addBond(0, mol.addAtom(1).index(), 1);
+  EXPECT_TRUE(allAromatic(mol, 5));
+}
+
+TEST(AromaticityTest, chargedRings)
+{
+  // Cyclopentadienyl anion: the carbanion donates its pair, giving six.
+  EXPECT_TRUE(allAromatic(
+    ring({ { C, -1, 1 }, { C, 0, 2 }, { C, 0, 1 }, { C, 0, 2 }, { C, 0, 1 } }),
+    5));
+
+  // Tropylium: the carbocation donates nothing, leaving six from the rest.
+  EXPECT_TRUE(allAromatic(ring({ { C, 1, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 },
+                                 { C, 0, 2 },
+                                 { C, 0, 1 } }),
+                          7));
+}
+
+TEST(AromaticityTest, antiaromaticAndSaturatedRingsAreNot)
+{
+  // Cyclobutadiene: four electrons is not 4n+2.
+  EXPECT_TRUE(
+    noneAromatic(ring({ { C, 0, 2 }, { C, 0, 1 }, { C, 0, 2 }, { C, 0, 1 } })));
+
+  // Cyclohexane: no atom has a p orbital to lend.
+  EXPECT_TRUE(noneAromatic(ring({ { C, 0, 1 },
+                                  { C, 0, 1 },
+                                  { C, 0, 1 },
+                                  { C, 0, 1 },
+                                  { C, 0, 1 },
+                                  { C, 0, 1 } })));
+
+  // Cyclooctatetraene: eight electrons.
+  EXPECT_TRUE(noneAromatic(ring({ { C, 0, 2 },
+                                  { C, 0, 1 },
+                                  { C, 0, 2 },
+                                  { C, 0, 1 },
+                                  { C, 0, 2 },
+                                  { C, 0, 1 },
+                                  { C, 0, 2 },
+                                  { C, 0, 1 } })));
+
+  // Borazine. Boron is not treated as a candidate, so the answer does not
+  // depend on how the B-N bonds were drawn.
+  EXPECT_TRUE(noneAromatic(ring({ { B, 0, 1 },
+                                  { N, 0, 1 },
+                                  { B, 0, 1 },
+                                  { N, 0, 1 },
+                                  { B, 0, 1 },
+                                  { N, 0, 1 } })));
+}
+
+TEST(AromaticityTest, exocyclicDoubleBond)
+{
+  // 2-pyridone: the carbonyl carbon donates nothing, and the amide nitrogen
+  // donates its pair, which still totals six.
+  Molecule mol = ring({ { N, 0, 1 },
+                        { C, 0, 1 },
+                        { C, 0, 2 },
+                        { C, 0, 1 },
+                        { C, 0, 2 },
+                        { C, 0, 1 } });
+  mol.addBond(0, mol.addAtom(1).index(), 1); // N-H
+  mol.addBond(1, mol.addAtom(O).index(), 2); // C=O, leaving the ring
+
+  AromaticityPerceiver perceiver(&mol);
+  EXPECT_EQ(perceiver.piContributions()[1], 0) << "carbonyl carbon";
+  EXPECT_EQ(perceiver.piContributions()[0], 2) << "amide nitrogen";
+  EXPECT_TRUE(perceiver.aromaticAtoms()[0]);
+  EXPECT_TRUE(perceiver.aromaticAtoms()[1]);
+  EXPECT_FALSE(perceiver.aromaticAtoms()[6]) << "the oxygen is not in a ring";
+}
+
+TEST(AromaticityTest, fusedRings)
+{
+  // Naphthalene, built as two six-membered rings sharing a bond.
+  Molecule mol;
+  for (int i = 0; i < 10; ++i)
+    mol.addAtom(C);
+  const int bonds[11][3] = { { 0, 1, 2 }, { 1, 2, 1 }, { 2, 3, 2 }, { 3, 4, 1 },
+                             { 4, 5, 2 }, { 5, 0, 1 }, { 4, 6, 1 }, { 6, 7, 2 },
+                             { 7, 8, 1 }, { 8, 9, 2 }, { 9, 3, 1 } };
+  for (const auto& bond : bonds)
+    mol.addBond(bond[0], bond[1], static_cast<unsigned char>(bond[2]));
+
+  EXPECT_TRUE(allAromatic(mol, 10));
+
+  AromaticityPerceiver perceiver(&mol);
+  ASSERT_EQ(perceiver.ringSystems().size(), 1u)
+    << "the two rings are fused, so they form one system";
+  EXPECT_EQ(perceiver.ringSystems()[0].size(), 10u);
+}
+
+TEST(AromaticityTest, azuleneNeedsTheWholeSystem)
+{
+  // Neither ring satisfies Huckel alone -- five and seven atoms -- but the
+  // fused system has ten pi electrons.
+  Molecule mol;
+  for (int i = 0; i < 10; ++i)
+    mol.addAtom(C);
+  const int bonds[11][3] = { { 0, 1, 2 }, { 1, 2, 1 }, { 2, 3, 2 }, { 3, 4, 1 },
+                             { 4, 0, 1 }, { 0, 5, 1 }, { 5, 6, 2 }, { 6, 7, 1 },
+                             { 7, 8, 2 }, { 8, 9, 1 }, { 9, 4, 2 } };
+  for (const auto& bond : bonds)
+    mol.addBond(bond[0], bond[1], static_cast<unsigned char>(bond[2]));
+
+  EXPECT_TRUE(allAromatic(mol, 10));
+}
+
+TEST(AromaticityTest, acyclicMoleculesHaveNoAromaticity)
+{
+  Molecule mol;
+  Index a = mol.addAtom(C).index();
+  Index b = mol.addAtom(C).index();
+  mol.addBond(a, b, 2);
+
+  AromaticityPerceiver perceiver(&mol);
+  EXPECT_TRUE(noneAromatic(mol));
+  EXPECT_EQ(perceiver.piContributions()[0], NotAromaticCandidate);
+  EXPECT_TRUE(perceiver.ringSystems().empty());
+}
+
+TEST(AromaticityTest, emptyMolecule)
+{
+  Molecule mol;
+  AromaticityPerceiver perceiver(&mol);
+  EXPECT_TRUE(perceiver.aromaticAtoms().empty());
+  EXPECT_TRUE(perceiver.ringSystems().empty());
+
+  AromaticityPerceiver detached;
+  EXPECT_TRUE(detached.aromaticAtoms().empty());
+}

--- a/tests/core/kekulizetest.cpp
+++ b/tests/core/kekulizetest.cpp
@@ -1,0 +1,559 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/aromaticity.h>
+#include <avogadro/core/kekulize.h>
+#include <avogadro/core/molecule.h>
+
+#include <vector>
+
+using Avogadro::Index;
+using Avogadro::MaxIndex;
+using Avogadro::Core::AromaticityPerceiver;
+using Avogadro::Core::kekulize;
+using Avogadro::Core::Molecule;
+
+namespace {
+
+constexpr unsigned char C = 6;
+constexpr unsigned char N = 7;
+constexpr unsigned char O = 8;
+constexpr unsigned char S = 16;
+
+/**
+ * Builds a molecule while keeping a bond-is-aromatic mask in lockstep: bonds
+ * are appended to a Molecule with sequential indices, so recording "aromatic"
+ * or not right next to every addBond() call is the simplest way to keep the
+ * two in sync.
+ */
+class Builder
+{
+public:
+  Index atom(unsigned char atomicNumber, signed char charge = 0)
+  {
+    const Index index = mol.addAtom(atomicNumber).index();
+    if (charge != 0)
+      mol.setFormalCharge(index, charge);
+    return index;
+  }
+
+  void aromaticBond(Index a, Index b)
+  {
+    mol.addBond(a, b, 1);
+    aromatic.push_back(true);
+  }
+
+  void plainBond(Index a, Index b, unsigned char order = 1)
+  {
+    mol.addBond(a, b, order);
+    aromatic.push_back(false);
+  }
+
+  /** A single hydrogen, attached to @a heavy with a non-aromatic bond. */
+  Index hydrogen(Index heavy)
+  {
+    const Index h = atom(1);
+    plainBond(heavy, h);
+    return h;
+  }
+
+  Molecule mol;
+  std::vector<bool> aromatic;
+};
+
+/** One entry per ring atom: which ring bonds are aromatic, added in order. */
+void ringBonds(Builder& b, const std::vector<Index>& ring)
+{
+  for (size_t i = 0; i < ring.size(); ++i)
+    b.aromaticBond(ring[i], ring[(i + 1) % ring.size()]);
+}
+
+int countOrder(const Builder& b, unsigned char order)
+{
+  int count = 0;
+  for (Index bond = 0; bond < b.mol.bondCount(); ++bond) {
+    if (b.aromatic[bond] && b.mol.bondOrders()[bond] == order)
+      ++count;
+  }
+  return count;
+}
+
+/**
+ * Kekulizes @a b.mol and, on success, checks the strongest available
+ * consistency test: AromaticityPerceiver, run on the result, must perceive
+ * exactly the bonds flagged aromatic going in -- neither more nor less. This
+ * is what catches an assignment that is valence-legal but chemically wrong.
+ */
+void expectKekulizedAndRoundTrips(Builder& b)
+{
+  Index failedAtom = MaxIndex;
+  ASSERT_TRUE(kekulize(b.mol, b.aromatic, &failedAtom))
+    << "failed at atom " << failedAtom;
+
+  AromaticityPerceiver perceiver(&b.mol);
+  const std::vector<bool>& perceived = perceiver.aromaticBonds();
+  ASSERT_EQ(perceived.size(), b.aromatic.size());
+  for (Index bond = 0; bond < b.aromatic.size(); ++bond)
+    EXPECT_EQ(perceived[bond], b.aromatic[bond]) << "bond " << bond;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// No-op.
+
+TEST(KekulizeTest, noAromaticBondsIsNoOp)
+{
+  // Plain ethane: every bond added through plainBond(), so the mask is all
+  // false and there is nothing for kekulize() to do.
+  Builder b;
+  const Index c1 = b.atom(C);
+  const Index c2 = b.atom(C);
+  b.plainBond(c1, c2);
+  for (int i = 0; i < 3; ++i)
+    b.hydrogen(c1);
+  for (int i = 0; i < 3; ++i)
+    b.hydrogen(c2);
+
+  EXPECT_TRUE(kekulize(b.mol, b.aromatic));
+  for (Index bond = 0; bond < b.mol.bondCount(); ++bond)
+    EXPECT_EQ(b.mol.bondOrders()[bond], 1) << "bond " << bond;
+}
+
+// ---------------------------------------------------------------------------
+// Six-membered rings.
+
+TEST(KekulizeTest, benzene)
+{
+  Builder b;
+  std::vector<Index> ring;
+  for (int i = 0; i < 6; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (Index atom : ring)
+    b.hydrogen(atom);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 3);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, pyridine)
+{
+  // Ring: N, then five CH.
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(N));
+  for (int i = 0; i < 5; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (size_t i = 1; i < ring.size(); ++i)
+    b.hydrogen(ring[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 3);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, naphthalene)
+{
+  // Two fused six-membered rings, sharing the bond between atoms 3 and 4
+  // (connectivity matches AromaticityTest.fusedRings).
+  Builder b;
+  std::vector<Index> atoms;
+  for (int i = 0; i < 10; ++i)
+    atoms.push_back(b.atom(C));
+  const int bonds[11][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 4 },
+                             { 4, 5 }, { 5, 0 }, { 4, 6 }, { 6, 7 },
+                             { 7, 8 }, { 8, 9 }, { 9, 3 } };
+  for (const auto& bond : bonds)
+    b.aromaticBond(atoms[bond[0]], atoms[bond[1]]);
+  const bool bridgehead[10] = { false, false, false, true,  true,
+                                false, false, false, false, false };
+  for (int i = 0; i < 10; ++i) {
+    if (!bridgehead[i])
+      b.hydrogen(atoms[i]);
+  }
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 5);
+  EXPECT_EQ(countOrder(b, 1), 6);
+  // The bridgehead bond specifically must come out single.
+  const Avogadro::Core::Bond bridge = b.mol.bond(atoms[3], atoms[4]);
+  ASSERT_TRUE(bridge.isValid());
+  EXPECT_EQ(bridge.order(), 1);
+}
+
+TEST(KekulizeTest, anthracene)
+{
+  // Naphthalene (as above), extended with a third ring fused to the second
+  // at the edge directly opposite the first fusion (a linear, catacondensed
+  // acene, not an angular one).
+  Builder b;
+  std::vector<Index> atoms;
+  for (int i = 0; i < 14; ++i)
+    atoms.push_back(b.atom(C));
+  const int bonds[16][2] = { { 0, 1 },   { 1, 2 },   { 2, 3 },   { 3, 4 },
+                             { 4, 5 },   { 5, 0 },   { 4, 6 },   { 6, 7 },
+                             { 7, 8 },   { 8, 9 },   { 9, 3 },   { 8, 10 },
+                             { 10, 11 }, { 11, 12 }, { 12, 13 }, { 13, 7 } };
+  for (const auto& bond : bonds)
+    b.aromaticBond(atoms[bond[0]], atoms[bond[1]]);
+  const bool fusion[14] = { false, false, false, true,  true,  false, false,
+                            true,  true,  false, false, false, false, false };
+  for (int i = 0; i < 14; ++i) {
+    if (!fusion[i])
+      b.hydrogen(atoms[i]);
+  }
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 7);
+  EXPECT_EQ(countOrder(b, 1), 9);
+}
+
+TEST(KekulizeTest, biphenylConnectingBondIsNotAromatic)
+{
+  // Two benzene rings joined by a single, non-aromatic bond: only the twelve
+  // ring bonds are aromatic.
+  Builder b;
+  std::vector<Index> ringA, ringB;
+  for (int i = 0; i < 6; ++i)
+    ringA.push_back(b.atom(C));
+  for (int i = 0; i < 6; ++i)
+    ringB.push_back(b.atom(C));
+  ringBonds(b, ringA);
+  ringBonds(b, ringB);
+  b.plainBond(ringA[0], ringB[0]); // The connecting bond: not aromatic.
+  for (int i = 1; i < 6; ++i)
+    b.hydrogen(ringA[i]);
+  for (int i = 1; i < 6; ++i)
+    b.hydrogen(ringB[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 6);
+  EXPECT_EQ(countOrder(b, 1), 6);
+  const Avogadro::Core::Bond connecting = b.mol.bond(ringA[0], ringB[0]);
+  ASSERT_TRUE(connecting.isValid());
+  EXPECT_EQ(connecting.order(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Five-membered rings.
+
+TEST(KekulizeTest, pyrrole)
+{
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(N));
+  for (int i = 0; i < 4; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (Index atom : ring)
+    b.hydrogen(atom); // N-H, then the four ring C-H.
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, furan)
+{
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(O));
+  for (int i = 0; i < 4; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (size_t i = 1; i < ring.size(); ++i)
+    b.hydrogen(ring[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, thiophene)
+{
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(S));
+  for (int i = 0; i < 4; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (size_t i = 1; i < ring.size(); ++i)
+    b.hydrogen(ring[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, imidazole)
+{
+  // N1(H) - C2 - N3 - C4 - C5 - back to N1.
+  Builder b;
+  const Index n1 = b.atom(N);
+  const Index c2 = b.atom(C);
+  const Index n3 = b.atom(N);
+  const Index c4 = b.atom(C);
+  const Index c5 = b.atom(C);
+  ringBonds(b, { n1, c2, n3, c4, c5 });
+  b.hydrogen(n1);
+  b.hydrogen(c2);
+  b.hydrogen(c4);
+  b.hydrogen(c5);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+  // The textbook Kekule structure: C2=N3 and C4=C5.
+  EXPECT_EQ(b.mol.bond(c2, n3).order(), 2);
+  EXPECT_EQ(b.mol.bond(c4, c5).order(), 2);
+  EXPECT_EQ(b.mol.bond(n1, c2).order(), 1);
+  EXPECT_EQ(b.mol.bond(n3, c4).order(), 1);
+  EXPECT_EQ(b.mol.bond(c5, n1).order(), 1);
+}
+
+TEST(KekulizeTest, pyrazole)
+{
+  // N1(H) - N2 - C3 - C4 - C5 - back to N1.
+  Builder b;
+  const Index n1 = b.atom(N);
+  const Index n2 = b.atom(N);
+  const Index c3 = b.atom(C);
+  const Index c4 = b.atom(C);
+  const Index c5 = b.atom(C);
+  ringBonds(b, { n1, n2, c3, c4, c5 });
+  b.hydrogen(n1);
+  b.hydrogen(c3);
+  b.hydrogen(c4);
+  b.hydrogen(c5);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+  EXPECT_EQ(b.mol.bond(n2, c3).order(), 2);
+  EXPECT_EQ(b.mol.bond(c4, c5).order(), 2);
+}
+
+TEST(KekulizeTest, nMethylpyrrole)
+{
+  // Like pyrrole, but the N carries a methyl instead of a hydrogen -- still
+  // three connections, so the classification is unchanged.
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(N));
+  for (int i = 0; i < 4; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  const Index methyl = b.atom(C);
+  b.plainBond(ring[0], methyl);
+  for (int i = 0; i < 3; ++i)
+    b.hydrogen(methyl);
+  for (size_t i = 1; i < ring.size(); ++i)
+    b.hydrogen(ring[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, nMethylpyridinium)
+{
+  // [n+](C) in a six-membered ring: the quaternary nitrogen now needs a
+  // double bond too, same as a ring carbon.
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(N, 1));
+  for (int i = 0; i < 5; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  const Index methyl = b.atom(C);
+  b.plainBond(ring[0], methyl);
+  for (int i = 0; i < 3; ++i)
+    b.hydrogen(methyl);
+  for (size_t i = 1; i < ring.size(); ++i)
+    b.hydrogen(ring[i]);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 3);
+  EXPECT_EQ(countOrder(b, 1), 3);
+}
+
+TEST(KekulizeTest, cyclopentadienylAnion)
+{
+  // One carbon carries the -1 charge (a localized resonance structure); it
+  // must not take a double bond, and its two ring bonds must come out single.
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(C, -1));
+  for (int i = 0; i < 4; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (Index atom : ring)
+    b.hydrogen(atom);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 3);
+  EXPECT_EQ(b.mol.bond(ring[0], ring[1]).order(), 1);
+  EXPECT_EQ(b.mol.bond(ring[4], ring[0]).order(), 1);
+}
+
+TEST(KekulizeTest, tropylium)
+{
+  // Seven-membered ring, one carbon carrying the +1 charge; it must not take
+  // a double bond.
+  Builder b;
+  std::vector<Index> ring;
+  ring.push_back(b.atom(C, 1));
+  for (int i = 0; i < 6; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (Index atom : ring)
+    b.hydrogen(atom);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 3);
+  EXPECT_EQ(countOrder(b, 1), 4);
+  EXPECT_EQ(b.mol.bond(ring[0], ring[1]).order(), 1);
+  EXPECT_EQ(b.mol.bond(ring[6], ring[0]).order(), 1);
+}
+
+TEST(KekulizeTest, pyridinoneExocyclicCarbonylTakesNoRingDouble)
+{
+  // 2-pyridone: N1(H) - C2(=O, exocyclic) - C3 - C4 - C5 - C6 - back to N1.
+  Builder b;
+  const Index n1 = b.atom(N);
+  const Index c2 = b.atom(C);
+  const Index c3 = b.atom(C);
+  const Index c4 = b.atom(C);
+  const Index c5 = b.atom(C);
+  const Index c6 = b.atom(C);
+  ringBonds(b, { n1, c2, c3, c4, c5, c6 });
+  b.hydrogen(n1);
+  const Index oxygen = b.atom(O);
+  b.plainBond(c2, oxygen, 2); // The exocyclic carbonyl, already order 2.
+  b.hydrogen(c3);
+  b.hydrogen(c4);
+  b.hydrogen(c5);
+  b.hydrogen(c6);
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 2);
+  EXPECT_EQ(countOrder(b, 1), 4);
+  // Neither of the carbonyl carbon's ring bonds may be the double one.
+  EXPECT_EQ(b.mol.bond(n1, c2).order(), 1);
+  EXPECT_EQ(b.mol.bond(c2, c3).order(), 1);
+  EXPECT_EQ(b.mol.bond(c2, oxygen).order(), 2) << "untouched: not aromatic";
+}
+
+// ---------------------------------------------------------------------------
+// A fused system whose two rings are not independently 4n+2.
+
+TEST(KekulizeTest, azulene)
+{
+  // Five-membered ring (0-1-2-3-4) fused to a seven-membered ring
+  // (0-5-6-7-8-9-4), sharing the bond 4-0 (matches
+  // AromaticityTest.azuleneNeedsTheWholeSystem's connectivity).
+  Builder b;
+  std::vector<Index> atoms;
+  for (int i = 0; i < 10; ++i)
+    atoms.push_back(b.atom(C));
+  const int bonds[11][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 4 },
+                             { 4, 0 }, { 0, 5 }, { 5, 6 }, { 6, 7 },
+                             { 7, 8 }, { 8, 9 }, { 9, 4 } };
+  for (const auto& bond : bonds)
+    b.aromaticBond(atoms[bond[0]], atoms[bond[1]]);
+  const bool bridgehead[10] = { true,  false, false, false, true,
+                                false, false, false, false, false };
+  for (int i = 0; i < 10; ++i) {
+    if (!bridgehead[i])
+      b.hydrogen(atoms[i]);
+  }
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 5);
+  EXPECT_EQ(countOrder(b, 1), 6);
+}
+
+// ---------------------------------------------------------------------------
+// A larger, peri-fused system: pyrene, four six-membered rings sharing two
+// central carbons that each belong to three of them. Its size and the
+// central carbons are what exercise the backtracking search rather than
+// forced moves alone.
+
+TEST(KekulizeTest, pyrene)
+{
+  // IUPAC numbering 1,2,3,3a,4,5,5a,6,7,8,8a,9,10,10a,10b,10c mapped to
+  // 0-15 in that order. Perimeter, then the five internal bonds that close
+  // the four rings around the central 10b-10c bond.
+  Builder b;
+  std::vector<Index> atoms;
+  for (int i = 0; i < 16; ++i)
+    atoms.push_back(b.atom(C));
+  const int perimeter[14][2] = { { 0, 1 },   { 1, 2 },  { 2, 3 },   { 3, 4 },
+                                 { 4, 5 },   { 5, 6 },  { 6, 7 },   { 7, 8 },
+                                 { 8, 9 },   { 9, 10 }, { 10, 11 }, { 11, 12 },
+                                 { 12, 13 }, { 13, 0 } };
+  for (const auto& bond : perimeter)
+    b.aromaticBond(atoms[bond[0]], atoms[bond[1]]);
+  const int internal[5][2] = {
+    { 13, 14 }, { 3, 14 }, { 6, 15 }, { 10, 15 }, { 14, 15 }
+  };
+  for (const auto& bond : internal)
+    b.aromaticBond(atoms[bond[0]], atoms[bond[1]]);
+  const bool fusion[16] = { false, false, false, true,  false, false,
+                            true,  false, false, false, true,  false,
+                            false, true,  true,  true };
+  for (int i = 0; i < 16; ++i) {
+    if (!fusion[i])
+      b.hydrogen(atoms[i]);
+  }
+
+  expectKekulizedAndRoundTrips(b);
+  EXPECT_EQ(countOrder(b, 2), 8);
+  EXPECT_EQ(countOrder(b, 1), 11);
+}
+
+// ---------------------------------------------------------------------------
+// Failure cases.
+
+TEST(KekulizeTest, oddCarbocycleHasNoPerfectMatching)
+{
+  // Three CH carbons, all needing a double bond: a triangle can match at
+  // most one pair, always leaving one atom uncovered.
+  Builder b;
+  std::vector<Index> ring;
+  for (int i = 0; i < 3; ++i)
+    ring.push_back(b.atom(C));
+  ringBonds(b, ring);
+  for (Index atom : ring)
+    b.hydrogen(atom);
+
+  Index failedAtom = MaxIndex;
+  EXPECT_FALSE(kekulize(b.mol, b.aromatic, &failedAtom));
+  EXPECT_LT(failedAtom, 3u) << "failedAtom should name one of the ring atoms";
+}
+
+TEST(KekulizeTest, atomWithNoCandidatePartnerFails)
+{
+  // atom0 (a CH carbon) has a single aromatic bond, to atom1; atom1 is a
+  // carbon whose other three bonds already fill its valence, so it does not
+  // need a double bond and atom0 is left with no candidate at all.
+  Builder b;
+  const Index atom0 = b.atom(C);
+  const Index atom1 = b.atom(C);
+  b.aromaticBond(atom0, atom1);
+  b.hydrogen(atom0);
+  for (int i = 0; i < 3; ++i)
+    b.hydrogen(atom1);
+
+  Index failedAtom = MaxIndex;
+  EXPECT_FALSE(kekulize(b.mol, b.aromatic, &failedAtom));
+  EXPECT_EQ(failedAtom, atom0);
+}

--- a/tests/core/kekulizetest.cpp
+++ b/tests/core/kekulizetest.cpp
@@ -523,6 +523,37 @@ TEST(KekulizeTest, pyrene)
 // ---------------------------------------------------------------------------
 // Failure cases.
 
+/**
+ * Run kekulize() expecting it to fail, and check it left every bond order
+ * exactly as it found it.
+ *
+ * kekulize() promises to write nothing unless the whole assignment succeeds,
+ * and that promise is what lets a caller report a clean error instead of
+ * handing back a half-assigned molecule. Asserting only the return value
+ * would leave it untested, so compare all the orders, not just the aromatic
+ * ones -- a bug that wrote through to a plain bond should show up too.
+ *
+ * @return The atom kekulize() blamed, for the caller to assert on.
+ */
+Index expectKekulizeFailsLeavingOrdersAlone(Builder& b)
+{
+  // Copied, not referenced: bondOrders() hands back a reference to the live
+  // array, which would track any write rather than record what was there.
+  const std::vector<unsigned char> before(b.mol.bondOrders().begin(),
+                                          b.mol.bondOrders().end());
+
+  Index failedAtom = MaxIndex;
+  EXPECT_FALSE(kekulize(b.mol, b.aromatic, &failedAtom));
+
+  const Avogadro::Core::Array<unsigned char>& after = b.mol.bondOrders();
+  EXPECT_EQ(after.size(), before.size());
+  for (Index bond = 0; bond < before.size() && bond < after.size(); ++bond) {
+    EXPECT_EQ(after[bond], before[bond])
+      << "bond " << bond << " was modified by a kekulize() that failed";
+  }
+  return failedAtom;
+}
+
 TEST(KekulizeTest, oddCarbocycleHasNoPerfectMatching)
 {
   // Three CH carbons, all needing a double bond: a triangle can match at
@@ -535,8 +566,7 @@ TEST(KekulizeTest, oddCarbocycleHasNoPerfectMatching)
   for (Index atom : ring)
     b.hydrogen(atom);
 
-  Index failedAtom = MaxIndex;
-  EXPECT_FALSE(kekulize(b.mol, b.aromatic, &failedAtom));
+  const Index failedAtom = expectKekulizeFailsLeavingOrdersAlone(b);
   EXPECT_LT(failedAtom, 3u) << "failedAtom should name one of the ring atoms";
 }
 
@@ -553,7 +583,6 @@ TEST(KekulizeTest, atomWithNoCandidatePartnerFails)
   for (int i = 0; i < 3; ++i)
     b.hydrogen(atom1);
 
-  Index failedAtom = MaxIndex;
-  EXPECT_FALSE(kekulize(b.mol, b.aromatic, &failedAtom));
+  const Index failedAtom = expectKekulizeFailsLeavingOrdersAlone(b);
   EXPECT_EQ(failedAtom, atom0);
 }

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -6,6 +6,7 @@ set(tests
   Lammps
   Mdl
   Pdb
+  Smiles
   Turbomole
   Vasp
   Xyz

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
   Mdl
   Pdb
   Smiles
+  SmilesParser
   Turbomole
   Vasp
   Xyz

--- a/tests/io/cmltest.cpp
+++ b/tests/io/cmltest.cpp
@@ -222,114 +222,92 @@ TEST(CmlTest, readString)
   EXPECT_EQ(moleculeFromString.bondCount(), static_cast<size_t>(7));
 }
 
+namespace {
+
+/** Benzene with its six ring bonds written using @a order, e.g. "A". */
+std::string benzeneCml(const std::string& order)
+{
+  std::string cml("<?xml version=\"1.0\"?>"
+                  "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
+                  "<atomArray>");
+  for (int i = 1; i <= 6; ++i)
+    cml += "<atom id=\"a" + std::to_string(i) + "\" elementType=\"C\"/>";
+  for (int i = 7; i <= 12; ++i)
+    cml += "<atom id=\"a" + std::to_string(i) + "\" elementType=\"H\"/>";
+  cml += "</atomArray><bondArray>";
+  // The ring, then one C-H per ring carbon.
+  for (int i = 1; i <= 6; ++i) {
+    const int next = (i == 6) ? 1 : i + 1;
+    cml += "<bond atomRefs2=\"a" + std::to_string(i) + " a" +
+           std::to_string(next) + "\" order=\"" + order + "\"/>";
+  }
+  for (int i = 1; i <= 6; ++i)
+    cml += "<bond atomRefs2=\"a" + std::to_string(i) + " a" +
+           std::to_string(i + 6) + "\" order=\"1\"/>";
+  cml += "</bondArray></molecule>";
+  return cml;
+}
+
+/**
+ * Assert that @a molecule is benzene whose aromatic ring came back kekulized:
+ * no bond left at the aromatic order, and the ring alternating three double
+ * with three single bonds.
+ *
+ * Ring bonds are looked up by their endpoints rather than by bond index, so
+ * this does not quietly depend on the order the reader added them in. The
+ * first six atoms are the ring, in order around it.
+ */
+void expectKekulizedBenzene(const Molecule& molecule)
+{
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
+  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
+
+  int doubleCount = 0;
+  int singleCount = 0;
+  for (size_t i = 0; i < molecule.bondCount(); ++i) {
+    const unsigned char order = molecule.bond(i).order();
+    EXPECT_LE(order, static_cast<unsigned char>(2))
+      << "bond " << i << " should be single or double after kekulization,"
+      << " rather than still carrying the aromatic order";
+    if (order == 2)
+      ++doubleCount;
+    else if (order == 1)
+      ++singleCount;
+  }
+  EXPECT_EQ(doubleCount, 3);
+  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
+
+  int ringDouble = 0;
+  for (Avogadro::Index i = 0; i < 6; ++i) {
+    const Bond ring = molecule.bond(i, (i + 1) % 6);
+    ASSERT_TRUE(ring.isValid()) << "ring bond " << i << " is missing";
+    if (ring.order() == 2)
+      ++ringDouble;
+  }
+  EXPECT_EQ(ringDouble, 3); // The ring bonds specifically must alternate.
+}
+
+} // namespace
+
 TEST(CmlTest, aromaticBondOrderAIsKekulized)
 {
   // Benzene, its six ring bonds written with the CML aromatic order "A".
   // Before kekulize() was wired in, "A" fell through to the single-bond
   // default; now it should come back as alternating single and double
   // bonds, not all single.
-  std::string cmlStr("<?xml version=\"1.0\"?>"
-                     "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
-                     "<atomArray>"
-                     "<atom id=\"a1\" elementType=\"C\"/>"
-                     "<atom id=\"a2\" elementType=\"C\"/>"
-                     "<atom id=\"a3\" elementType=\"C\"/>"
-                     "<atom id=\"a4\" elementType=\"C\"/>"
-                     "<atom id=\"a5\" elementType=\"C\"/>"
-                     "<atom id=\"a6\" elementType=\"C\"/>"
-                     "<atom id=\"a7\" elementType=\"H\"/>"
-                     "<atom id=\"a8\" elementType=\"H\"/>"
-                     "<atom id=\"a9\" elementType=\"H\"/>"
-                     "<atom id=\"a10\" elementType=\"H\"/>"
-                     "<atom id=\"a11\" elementType=\"H\"/>"
-                     "<atom id=\"a12\" elementType=\"H\"/>"
-                     "</atomArray>"
-                     "<bondArray>"
-                     "<bond atomRefs2=\"a1 a2\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a2 a3\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a3 a4\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a4 a5\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a5 a6\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a6 a1\" order=\"A\"/>"
-                     "<bond atomRefs2=\"a1 a7\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a2 a8\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a3 a9\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a4 a10\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a5 a11\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a6 a12\" order=\"1\"/>"
-                     "</bondArray>"
-                     "</molecule>");
-
   CmlFormat cml;
   Molecule molecule;
-  ASSERT_TRUE(cml.readString(cmlStr, molecule)) << cml.error();
-  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
-  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
-
-  int doubleCount = 0;
-  int singleCount = 0;
-  int ringDouble = 0;
-  for (size_t i = 0; i < molecule.bondCount(); ++i) {
-    const unsigned char order = molecule.bond(i).order();
-    EXPECT_LE(order, static_cast<unsigned char>(2))
-      << "bond " << i << " should not still be a single bond by default";
-    if (order == 2) {
-      ++doubleCount;
-      if (i < 6)
-        ++ringDouble;
-    } else if (order == 1) {
-      ++singleCount;
-    }
-  }
-  EXPECT_EQ(doubleCount, 3);
-  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
-  EXPECT_EQ(ringDouble, 3);  // The ring bonds specifically must alternate.
+  ASSERT_TRUE(cml.readString(benzeneCml("A"), molecule)) << cml.error();
+  expectKekulizedBenzene(molecule);
 }
 
 TEST(CmlTest, aromaticBondOrderAromaticSpellingIsKekulized)
 {
   // The same molecule, but with the multi-character spelling order
-  // ="aromatic", which the single-character comparison used to miss.
-  std::string cmlStr("<?xml version=\"1.0\"?>"
-                     "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
-                     "<atomArray>"
-                     "<atom id=\"a1\" elementType=\"C\"/>"
-                     "<atom id=\"a2\" elementType=\"C\"/>"
-                     "<atom id=\"a3\" elementType=\"C\"/>"
-                     "<atom id=\"a4\" elementType=\"C\"/>"
-                     "<atom id=\"a5\" elementType=\"C\"/>"
-                     "<atom id=\"a6\" elementType=\"C\"/>"
-                     "<atom id=\"a7\" elementType=\"H\"/>"
-                     "<atom id=\"a8\" elementType=\"H\"/>"
-                     "<atom id=\"a9\" elementType=\"H\"/>"
-                     "<atom id=\"a10\" elementType=\"H\"/>"
-                     "<atom id=\"a11\" elementType=\"H\"/>"
-                     "<atom id=\"a12\" elementType=\"H\"/>"
-                     "</atomArray>"
-                     "<bondArray>"
-                     "<bond atomRefs2=\"a1 a2\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a2 a3\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a3 a4\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a4 a5\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a5 a6\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a6 a1\" order=\"aromatic\"/>"
-                     "<bond atomRefs2=\"a1 a7\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a2 a8\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a3 a9\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a4 a10\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a5 a11\" order=\"1\"/>"
-                     "<bond atomRefs2=\"a6 a12\" order=\"1\"/>"
-                     "</bondArray>"
-                     "</molecule>");
-
+  // ="aromatic", which the single-character comparison used to miss. It has
+  // to reach exactly the same result as "A", so it gets the same assertions.
   CmlFormat cml;
   Molecule molecule;
-  ASSERT_TRUE(cml.readString(cmlStr, molecule)) << cml.error();
-
-  int doubleCount = 0;
-  for (size_t i = 0; i < molecule.bondCount(); ++i) {
-    if (molecule.bond(i).order() == 2)
-      ++doubleCount;
-  }
-  EXPECT_EQ(doubleCount, 3);
+  ASSERT_TRUE(cml.readString(benzeneCml("aromatic"), molecule)) << cml.error();
+  expectKekulizedBenzene(molecule);
 }

--- a/tests/io/cmltest.cpp
+++ b/tests/io/cmltest.cpp
@@ -221,3 +221,115 @@ TEST(CmlTest, readString)
   EXPECT_EQ(moleculeFromString.atomCount(), static_cast<size_t>(8));
   EXPECT_EQ(moleculeFromString.bondCount(), static_cast<size_t>(7));
 }
+
+TEST(CmlTest, aromaticBondOrderAIsKekulized)
+{
+  // Benzene, its six ring bonds written with the CML aromatic order "A".
+  // Before kekulize() was wired in, "A" fell through to the single-bond
+  // default; now it should come back as alternating single and double
+  // bonds, not all single.
+  std::string cmlStr("<?xml version=\"1.0\"?>"
+                     "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
+                     "<atomArray>"
+                     "<atom id=\"a1\" elementType=\"C\"/>"
+                     "<atom id=\"a2\" elementType=\"C\"/>"
+                     "<atom id=\"a3\" elementType=\"C\"/>"
+                     "<atom id=\"a4\" elementType=\"C\"/>"
+                     "<atom id=\"a5\" elementType=\"C\"/>"
+                     "<atom id=\"a6\" elementType=\"C\"/>"
+                     "<atom id=\"a7\" elementType=\"H\"/>"
+                     "<atom id=\"a8\" elementType=\"H\"/>"
+                     "<atom id=\"a9\" elementType=\"H\"/>"
+                     "<atom id=\"a10\" elementType=\"H\"/>"
+                     "<atom id=\"a11\" elementType=\"H\"/>"
+                     "<atom id=\"a12\" elementType=\"H\"/>"
+                     "</atomArray>"
+                     "<bondArray>"
+                     "<bond atomRefs2=\"a1 a2\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a2 a3\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a3 a4\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a4 a5\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a5 a6\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a6 a1\" order=\"A\"/>"
+                     "<bond atomRefs2=\"a1 a7\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a2 a8\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a3 a9\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a4 a10\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a5 a11\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a6 a12\" order=\"1\"/>"
+                     "</bondArray>"
+                     "</molecule>");
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(cmlStr, molecule)) << cml.error();
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
+  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
+
+  int doubleCount = 0;
+  int singleCount = 0;
+  int ringDouble = 0;
+  for (size_t i = 0; i < molecule.bondCount(); ++i) {
+    const unsigned char order = molecule.bond(i).order();
+    EXPECT_LE(order, static_cast<unsigned char>(2))
+      << "bond " << i << " should not still be a single bond by default";
+    if (order == 2) {
+      ++doubleCount;
+      if (i < 6)
+        ++ringDouble;
+    } else if (order == 1) {
+      ++singleCount;
+    }
+  }
+  EXPECT_EQ(doubleCount, 3);
+  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
+  EXPECT_EQ(ringDouble, 3);  // The ring bonds specifically must alternate.
+}
+
+TEST(CmlTest, aromaticBondOrderAromaticSpellingIsKekulized)
+{
+  // The same molecule, but with the multi-character spelling order
+  // ="aromatic", which the single-character comparison used to miss.
+  std::string cmlStr("<?xml version=\"1.0\"?>"
+                     "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
+                     "<atomArray>"
+                     "<atom id=\"a1\" elementType=\"C\"/>"
+                     "<atom id=\"a2\" elementType=\"C\"/>"
+                     "<atom id=\"a3\" elementType=\"C\"/>"
+                     "<atom id=\"a4\" elementType=\"C\"/>"
+                     "<atom id=\"a5\" elementType=\"C\"/>"
+                     "<atom id=\"a6\" elementType=\"C\"/>"
+                     "<atom id=\"a7\" elementType=\"H\"/>"
+                     "<atom id=\"a8\" elementType=\"H\"/>"
+                     "<atom id=\"a9\" elementType=\"H\"/>"
+                     "<atom id=\"a10\" elementType=\"H\"/>"
+                     "<atom id=\"a11\" elementType=\"H\"/>"
+                     "<atom id=\"a12\" elementType=\"H\"/>"
+                     "</atomArray>"
+                     "<bondArray>"
+                     "<bond atomRefs2=\"a1 a2\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a2 a3\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a3 a4\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a4 a5\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a5 a6\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a6 a1\" order=\"aromatic\"/>"
+                     "<bond atomRefs2=\"a1 a7\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a2 a8\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a3 a9\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a4 a10\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a5 a11\" order=\"1\"/>"
+                     "<bond atomRefs2=\"a6 a12\" order=\"1\"/>"
+                     "</bondArray>"
+                     "</molecule>");
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(cmlStr, molecule)) << cml.error();
+
+  int doubleCount = 0;
+  for (size_t i = 0; i < molecule.bondCount(); ++i) {
+    if (molecule.bond(i).order() == 2)
+      ++doubleCount;
+  }
+  EXPECT_EQ(doubleCount, 3);
+}

--- a/tests/io/mdltest.cpp
+++ b/tests/io/mdltest.cpp
@@ -260,6 +260,49 @@ TEST(MdlTest, readV3000Valence)
   EXPECT_EQ(normalC.hybridization(), Avogadro::Core::HybridizationUnknown);
 }
 
+namespace {
+
+/**
+ * Assert that @a molecule is benzene whose aromatic ring came back kekulized:
+ * no bond left at the aromatic order, and the ring alternating three double
+ * with three single bonds.
+ *
+ * Ring bonds are looked up by their endpoints rather than by bond index, so
+ * this does not quietly depend on the order the reader happened to add them
+ * in. The first six atoms are the ring, in order around it.
+ */
+void expectKekulizedBenzene(const Molecule& molecule)
+{
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
+  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
+
+  int doubleCount = 0;
+  int singleCount = 0;
+  for (size_t i = 0; i < molecule.bondCount(); ++i) {
+    const unsigned char order = molecule.bond(i).order();
+    EXPECT_LE(order, static_cast<unsigned char>(2))
+      << "bond " << i << " should be single or double after kekulization,"
+      << " rather than still carrying the aromatic order";
+    if (order == 2)
+      ++doubleCount;
+    else if (order == 1)
+      ++singleCount;
+  }
+  EXPECT_EQ(doubleCount, 3);
+  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
+
+  int ringDouble = 0;
+  for (Avogadro::Index i = 0; i < 6; ++i) {
+    const Bond ring = molecule.bond(i, (i + 1) % 6);
+    ASSERT_TRUE(ring.isValid()) << "ring bond " << i << " is missing";
+    if (ring.order() == 2)
+      ++ringDouble;
+  }
+  EXPECT_EQ(ringDouble, 3); // The ring bonds specifically must alternate.
+}
+
+} // namespace
+
 TEST(MdlTest, aromaticBondType4IsKekulized)
 {
   // Benzene, its six ring bonds written as MDL bond type 4 (aromatic).
@@ -300,28 +343,52 @@ TEST(MdlTest, aromaticBondType4IsKekulized)
   MdlFormat mdl;
   Molecule molecule;
   ASSERT_TRUE(mdl.readString(molfile, molecule)) << mdl.error();
-  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
-  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
+  expectKekulizedBenzene(molecule);
+}
 
-  int doubleCount = 0;
-  int singleCount = 0;
-  for (size_t i = 0; i < molecule.bondCount(); ++i) {
-    const unsigned char order = molecule.bond(i).order();
-    EXPECT_LE(order, static_cast<unsigned char>(2))
-      << "bond " << i << " should not still be a quadruple bond";
-    if (order == 2)
-      ++doubleCount;
-    else if (order == 1)
-      ++singleCount;
-  }
-  EXPECT_EQ(doubleCount, 3);
-  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
+TEST(MdlTest, aromaticBondType4IsKekulizedV3000)
+{
+  // The same benzene in V3000, whose bond block is parsed by a separate
+  // function that had the same bug: order 4 went straight to addBond().
+  const std::string molfile = "Benzene\n"
+                              "  Test3D\n"
+                              "\n"
+                              "  0  0  0     0  0            999 V3000\n"
+                              "M  V30 BEGIN CTAB\n"
+                              "M  V30 COUNTS 12 12 0 0 0\n"
+                              "M  V30 BEGIN ATOM\n"
+                              "M  V30 1 C 1.2 0.0 0.0 0\n"
+                              "M  V30 2 C 0.6 1.0 0.0 0\n"
+                              "M  V30 3 C -0.6 1.0 0.0 0\n"
+                              "M  V30 4 C -1.2 0.0 0.0 0\n"
+                              "M  V30 5 C -0.6 -1.0 0.0 0\n"
+                              "M  V30 6 C 0.6 -1.0 0.0 0\n"
+                              "M  V30 7 H 2.2 0.0 0.0 0\n"
+                              "M  V30 8 H 1.1 1.9 0.0 0\n"
+                              "M  V30 9 H -1.1 1.9 0.0 0\n"
+                              "M  V30 10 H -2.2 0.0 0.0 0\n"
+                              "M  V30 11 H -1.1 -1.9 0.0 0\n"
+                              "M  V30 12 H 1.1 -1.9 0.0 0\n"
+                              "M  V30 END ATOM\n"
+                              "M  V30 BEGIN BOND\n"
+                              "M  V30 1 4 1 2\n"
+                              "M  V30 2 4 2 3\n"
+                              "M  V30 3 4 3 4\n"
+                              "M  V30 4 4 4 5\n"
+                              "M  V30 5 4 5 6\n"
+                              "M  V30 6 4 6 1\n"
+                              "M  V30 7 1 1 7\n"
+                              "M  V30 8 1 2 8\n"
+                              "M  V30 9 1 3 9\n"
+                              "M  V30 10 1 4 10\n"
+                              "M  V30 11 1 5 11\n"
+                              "M  V30 12 1 6 12\n"
+                              "M  V30 END BOND\n"
+                              "M  V30 END CTAB\n"
+                              "M  END\n";
 
-  // Specifically, the ring bonds (0-5) must alternate rather than all match.
-  int ringDouble = 0;
-  for (size_t i = 0; i < 6; ++i) {
-    if (molecule.bond(i).order() == 2)
-      ++ringDouble;
-  }
-  EXPECT_EQ(ringDouble, 3);
+  MdlFormat mdl;
+  Molecule molecule;
+  ASSERT_TRUE(mdl.readString(molfile, molecule)) << mdl.error();
+  expectKekulizedBenzene(molecule);
 }

--- a/tests/io/mdltest.cpp
+++ b/tests/io/mdltest.cpp
@@ -259,3 +259,69 @@ TEST(MdlTest, readV3000Valence)
   EXPECT_EQ(normalC.atomicNumber(), static_cast<unsigned char>(6));
   EXPECT_EQ(normalC.hybridization(), Avogadro::Core::HybridizationUnknown);
 }
+
+TEST(MdlTest, aromaticBondType4IsKekulized)
+{
+  // Benzene, its six ring bonds written as MDL bond type 4 (aromatic).
+  // Before kekulize() was wired in, type 4 was passed straight to addBond()
+  // and became a quadruple bond; now it should come back as alternating
+  // single and double bonds, not all one order.
+  const std::string molfile =
+    "Benzene\n"
+    "  Test2D\n"
+    "\n"
+    " 12 12  0  0  0  0  0  0  0  0999 V2000\n"
+    "    1.2000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "    0.6000    1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -0.6000    1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -1.2000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -0.6000   -1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "    0.6000   -1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "    2.2000    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "    1.1000    1.9000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -1.1000    1.9000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -2.2000    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "   -1.1000   -1.9000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "    1.1000   -1.9000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "  1  2  4  0  0  0  0\n"
+    "  2  3  4  0  0  0  0\n"
+    "  3  4  4  0  0  0  0\n"
+    "  4  5  4  0  0  0  0\n"
+    "  5  6  4  0  0  0  0\n"
+    "  6  1  4  0  0  0  0\n"
+    "  1  7  1  0  0  0  0\n"
+    "  2  8  1  0  0  0  0\n"
+    "  3  9  1  0  0  0  0\n"
+    "  4 10  1  0  0  0  0\n"
+    "  5 11  1  0  0  0  0\n"
+    "  6 12  1  0  0  0  0\n"
+    "M  END\n";
+
+  MdlFormat mdl;
+  Molecule molecule;
+  ASSERT_TRUE(mdl.readString(molfile, molecule)) << mdl.error();
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(12));
+  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(12));
+
+  int doubleCount = 0;
+  int singleCount = 0;
+  for (size_t i = 0; i < molecule.bondCount(); ++i) {
+    const unsigned char order = molecule.bond(i).order();
+    EXPECT_LE(order, static_cast<unsigned char>(2))
+      << "bond " << i << " should not still be a quadruple bond";
+    if (order == 2)
+      ++doubleCount;
+    else if (order == 1)
+      ++singleCount;
+  }
+  EXPECT_EQ(doubleCount, 3);
+  EXPECT_EQ(singleCount, 9); // Three ring single bonds, plus six C-H.
+
+  // Specifically, the ring bonds (0-5) must alternate rather than all match.
+  int ringDouble = 0;
+  for (size_t i = 0; i < 6; ++i) {
+    if (molecule.bond(i).order() == 2)
+      ++ringDouble;
+  }
+  EXPECT_EQ(ringDouble, 3);
+}

--- a/tests/io/smilesparsertest.cpp
+++ b/tests/io/smilesparsertest.cpp
@@ -510,29 +510,213 @@ TEST(SmilesParserTest, errorAtomClassOverflow)
 }
 
 // ---------------------------------------------------------------------------
-// Aromatic input: rejected until a kekulizer exists.
+// Aromatic input: kekulized rather than rejected.
 
-TEST(SmilesParserTest, errorAromaticRingIsRejected)
+TEST(SmilesParserTest, aromaticBenzene)
 {
-  SmilesParser parser;
-  Molecule mol;
-  EXPECT_FALSE(parser.parse("c1ccccc1", mol));
-  EXPECT_EQ(parser.errorPosition(), 0u);
-  EXPECT_EQ(parser.error(),
-            "Aromatic SMILES requires kekulization, which is not yet "
-            "implemented.");
+  Molecule mol = parseOk("c1ccccc1");
+  EXPECT_EQ(mol.atomCount(), 12u);
+  EXPECT_EQ(countElement(mol, 6), 6);
+  EXPECT_EQ(countElement(mol, 1), 6);
+  EXPECT_EQ(countBondOrder(mol, 2), 3);
+  EXPECT_EQ(countBondOrder(mol, 1), 9);
 }
 
-TEST(SmilesParserTest, errorAromaticBracketAtomIsRejected)
+TEST(SmilesParserTest, aromaticPyridine)
 {
-  expectError("[nH]1cccc1", 0);
+  Molecule mol = parseOk("c1ccncc1");
+  EXPECT_EQ(mol.atomCount(), 11u);
+  EXPECT_EQ(countElement(mol, 6), 5);
+  EXPECT_EQ(countElement(mol, 7), 1);
+  EXPECT_EQ(countElement(mol, 1), 5);
+  EXPECT_EQ(countBondOrder(mol, 2), 3);
+  EXPECT_EQ(countBondOrder(mol, 1), 8);
 }
 
-TEST(SmilesParserTest, errorAromaticBondIsRejected)
+TEST(SmilesParserTest, aromaticPyrroleBracketNitrogen)
 {
-  // Neither atom is written lower case; only the explicit ':' bond is
-  // aromatic here.
-  expectError("C:C", 1);
+  // The [nH] states its hydrogen explicitly, which is what lets kekulize()
+  // classify the nitrogen correctly (it must not take a ring double bond).
+  Molecule mol = parseOk("[nH]1cccc1");
+  EXPECT_EQ(mol.atomCount(), 10u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 7), 1);
+  EXPECT_EQ(countElement(mol, 1), 5); // Four ring CH, plus the N-H.
+  EXPECT_EQ(countBondOrder(mol, 2), 2);
+  EXPECT_EQ(countBondOrder(mol, 1), 8);
+}
+
+TEST(SmilesParserTest, aromaticFuran)
+{
+  Molecule mol = parseOk("c1ccoc1");
+  EXPECT_EQ(mol.atomCount(), 9u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 8), 1);
+  EXPECT_EQ(countElement(mol, 1), 4);
+  EXPECT_EQ(countBondOrder(mol, 2), 2);
+  EXPECT_EQ(countBondOrder(mol, 1), 7);
+}
+
+TEST(SmilesParserTest, aromaticThiophene)
+{
+  Molecule mol = parseOk("c1ccsc1");
+  EXPECT_EQ(mol.atomCount(), 9u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 16), 1);
+  EXPECT_EQ(countElement(mol, 1), 4);
+  EXPECT_EQ(countBondOrder(mol, 2), 2);
+  EXPECT_EQ(countBondOrder(mol, 1), 7);
+}
+
+TEST(SmilesParserTest, aromaticImidazole)
+{
+  Molecule mol = parseOk("c1c[nH]cn1");
+  EXPECT_EQ(mol.atomCount(), 9u);
+  EXPECT_EQ(countElement(mol, 6), 3);
+  EXPECT_EQ(countElement(mol, 7), 2);
+  EXPECT_EQ(countElement(mol, 1), 4); // Three ring CH, plus the N-H.
+  EXPECT_EQ(countBondOrder(mol, 2), 2);
+  EXPECT_EQ(countBondOrder(mol, 1), 7);
+}
+
+TEST(SmilesParserTest, aromaticNaphthaleneFusedRings)
+{
+  Molecule mol = parseOk("c1ccc2ccccc2c1");
+  EXPECT_EQ(mol.atomCount(), 18u);
+  EXPECT_EQ(countElement(mol, 6), 10);
+  EXPECT_EQ(countElement(mol, 1), 8); // The two bridgeheads carry no H.
+  EXPECT_EQ(countBondOrder(mol, 2), 5);
+  EXPECT_EQ(countBondOrder(mol, 1), 14);
+}
+
+TEST(SmilesParserTest, aromaticBiphenylConnectingBondIsNotAromatic)
+{
+  // The explicit '-' is load bearing: between two lower case atoms, writing
+  // no bond symbol at all would mean an aromatic bond instead, joining the
+  // two rings into a single (unkekulizable) twelve-membered system.
+  Molecule mol = parseOk("c1ccc(cc1)-c1ccccc1");
+  EXPECT_EQ(mol.atomCount(), 22u);
+  EXPECT_EQ(countElement(mol, 6), 12);
+  EXPECT_EQ(countElement(mol, 1), 10);
+  EXPECT_EQ(countBondOrder(mol, 2), 6);
+  // Eleven ring single bonds (five per ring, plus the connecting bond) and
+  // ten C-H bonds.
+  EXPECT_EQ(countBondOrder(mol, 1), 17);
+}
+
+TEST(SmilesParserTest, aromaticCaffeine)
+{
+  // 1,3,7-trimethylxanthine: a fused imidazole and pyrimidinedione, with two
+  // exocyclic C=O bonds written explicitly inside the aromatic ring.
+  Molecule mol = parseOk("Cn1cnc2c1c(=O)n(C)c(=O)n2C");
+  EXPECT_EQ(mol.atomCount(), 24u);
+  EXPECT_EQ(countElement(mol, 6), 8);
+  EXPECT_EQ(countElement(mol, 7), 4);
+  EXPECT_EQ(countElement(mol, 8), 2);
+  EXPECT_EQ(countElement(mol, 1), 10);
+}
+
+TEST(SmilesParserTest, errorUnkekulizableAromaticRing)
+{
+  // Three aromatic carbons: a triangle has no perfect matching, so no
+  // arrangement of alternating bonds can satisfy every atom.
+  expectError("c1cc1", 0);
+}
+
+// ---------------------------------------------------------------------------
+// Aromatic round trip: parse, write back out with the writer's default
+// (setAromatic(true)), and reparse.
+//
+// Individual bonds cannot be compared. A ring with more than one valid Kekule
+// structure -- benzene, for instance -- can legitimately come back with a
+// different one, because perceiving it as aromatic in order to write it
+// discards which alternation the original happened to hold.
+//
+// Two things do survive that, and are worth far more than an atom count. The
+// number of double bonds is fixed by kekulize()'s classification rather than
+// by the search, so the bond order multiset is invariant. So is each atom's
+// total bond order, which is its valence -- and atom maps correlate the two
+// molecules exactly, since asking for maps does not turn aromatic output off.
+
+namespace {
+
+/** Total bond order at each atom, which is the atom's valence. */
+std::vector<unsigned int> valences(const Molecule& mol)
+{
+  std::vector<unsigned int> sums(mol.atomCount(), 0);
+  for (Index b = 0; b < mol.bondCount(); ++b) {
+    const unsigned char order = mol.bondOrders()[b];
+    sums[mol.bondPairs()[b].first] += order;
+    sums[mol.bondPairs()[b].second] += order;
+  }
+  return sums;
+}
+
+void expectAromaticRoundTrip(const std::string& smiles)
+{
+  Molecule original = parseOk(smiles);
+
+  SmilesWriter writer; // setAromatic(true) is the default.
+  writer.setAtomMaps(true);
+  std::string written;
+  ASSERT_TRUE(writer.write(original, written))
+    << smiles << ": " << writer.error();
+
+  SmilesParser reparser;
+  Molecule reparsed;
+  ASSERT_TRUE(reparser.parse(written, reparsed))
+    << smiles << " -> " << written << ": " << reparser.error();
+
+  ASSERT_EQ(reparsed.atomCount(), original.atomCount()) << smiles;
+  EXPECT_EQ(reparsed.bondCount(), original.bondCount()) << smiles;
+  for (unsigned char element : { 1, 6, 7, 8, 16 }) {
+    EXPECT_EQ(countElement(reparsed, element), countElement(original, element))
+      << smiles << ", element " << int(element);
+  }
+  for (unsigned char order : { 1, 2, 3 }) {
+    EXPECT_EQ(countBondOrder(reparsed, order), countBondOrder(original, order))
+      << smiles << ", bond order " << int(order);
+  }
+
+  const std::vector<unsigned int> before = valences(original);
+  const std::vector<unsigned int> after = valences(reparsed);
+  const std::vector<size_t>& maps = reparser.atomMaps();
+  ASSERT_EQ(maps.size(), reparsed.atomCount()) << smiles;
+  for (Index i = 0; i < reparsed.atomCount(); ++i) {
+    ASSERT_GT(maps[i], 0u) << smiles;
+    const Index originalIndex = static_cast<Index>(maps[i] - 1);
+    ASSERT_LT(originalIndex, original.atomCount()) << smiles;
+    EXPECT_EQ(reparsed.atomicNumber(i), original.atomicNumber(originalIndex))
+      << smiles << ": atom " << i;
+    EXPECT_EQ(after[i], before[originalIndex]) << smiles << ": atom " << i;
+  }
+}
+
+} // namespace
+
+TEST(SmilesParserTest, aromaticRoundTripBenzene)
+{
+  expectAromaticRoundTrip("c1ccccc1");
+}
+
+TEST(SmilesParserTest, aromaticRoundTripPyrrole)
+{
+  expectAromaticRoundTrip("[nH]1cccc1");
+}
+
+TEST(SmilesParserTest, aromaticRoundTripNaphthalene)
+{
+  expectAromaticRoundTrip("c1ccc2ccccc2c1");
+}
+
+TEST(SmilesParserTest, aromaticRoundTripBiphenyl)
+{
+  expectAromaticRoundTrip("c1ccc(cc1)-c1ccccc1");
+}
+
+TEST(SmilesParserTest, aromaticRoundTripCaffeine)
+{
+  expectAromaticRoundTrip("Cn1cnc2c1c(=O)n(C)c(=O)n2C");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/io/smilesparsertest.cpp
+++ b/tests/io/smilesparsertest.cpp
@@ -1,0 +1,690 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/molecule.h>
+
+#include <avogadro/io/smilesparser.h>
+#include <avogadro/io/smileswriter.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using Avogadro::Index;
+using Avogadro::Core::Molecule;
+using Avogadro::Io::SmilesParser;
+using Avogadro::Io::SmilesWriter;
+
+namespace {
+
+/** Attach @a count hydrogens to @a heavy with single bonds. */
+void addHydrogens(Molecule& mol, Index heavy, int count)
+{
+  for (int i = 0; i < count; ++i)
+    mol.addBond(heavy, mol.addAtom(1).index(), 1);
+}
+
+/** Parse @a smiles, asserting success, and return the resulting molecule. */
+Molecule parseOk(const std::string& smiles)
+{
+  SmilesParser parser;
+  Molecule mol;
+  EXPECT_TRUE(parser.parse(smiles, mol))
+    << smiles << ": " << parser.error() << " at " << parser.errorPosition();
+  return mol;
+}
+
+/** Parse @a smiles, asserting it fails at @a expectedPosition. */
+void expectError(const std::string& smiles, size_t expectedPosition)
+{
+  SmilesParser parser;
+  Molecule mol;
+  EXPECT_FALSE(parser.parse(smiles, mol)) << smiles;
+  EXPECT_FALSE(parser.error().empty()) << smiles;
+  EXPECT_EQ(parser.errorPosition(), expectedPosition)
+    << smiles << ": " << parser.error();
+  EXPECT_EQ(mol.atomCount(), 0u) << smiles;
+}
+
+int countElement(const Molecule& mol, unsigned char atomicNumber)
+{
+  int count = 0;
+  for (Index i = 0; i < mol.atomCount(); ++i) {
+    if (mol.atomicNumber(i) == atomicNumber)
+      ++count;
+  }
+  return count;
+}
+
+int countBondOrder(const Molecule& mol, unsigned char order)
+{
+  int count = 0;
+  for (Index i = 0; i < mol.bondCount(); ++i) {
+    if (mol.bondOrders()[i] == order)
+      ++count;
+  }
+  return count;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Bare atoms and implied hydrogen counts.
+
+TEST(SmilesParserTest, bareCarbon)
+{
+  Molecule mol = parseOk("C");
+  EXPECT_EQ(mol.atomCount(), 5u);
+  EXPECT_EQ(mol.bondCount(), 4u);
+  EXPECT_EQ(countElement(mol, 6), 1);
+  EXPECT_EQ(countElement(mol, 1), 4);
+}
+
+TEST(SmilesParserTest, bareEthane)
+{
+  Molecule mol = parseOk("CC");
+  EXPECT_EQ(mol.atomCount(), 8u);
+  EXPECT_EQ(mol.bondCount(), 7u);
+  EXPECT_EQ(countElement(mol, 6), 2);
+  EXPECT_EQ(countElement(mol, 1), 6);
+}
+
+TEST(SmilesParserTest, bareEthylene)
+{
+  Molecule mol = parseOk("C=C");
+  EXPECT_EQ(mol.atomCount(), 6u);
+  EXPECT_EQ(mol.bondCount(), 5u);
+  EXPECT_EQ(countBondOrder(mol, 2), 1);
+  EXPECT_EQ(countBondOrder(mol, 1), 4);
+}
+
+TEST(SmilesParserTest, bareHydrogenCyanide)
+{
+  Molecule mol = parseOk("C#N");
+  EXPECT_EQ(mol.atomCount(), 3u);
+  EXPECT_EQ(mol.bondCount(), 2u);
+  EXPECT_EQ(countElement(mol, 6), 1);
+  EXPECT_EQ(countElement(mol, 7), 1);
+  EXPECT_EQ(countElement(mol, 1), 1);
+  EXPECT_EQ(countBondOrder(mol, 3), 1);
+  EXPECT_EQ(countBondOrder(mol, 1), 1);
+}
+
+TEST(SmilesParserTest, bareWater)
+{
+  Molecule mol = parseOk("O");
+  EXPECT_EQ(mol.atomCount(), 3u);
+  EXPECT_EQ(mol.bondCount(), 2u);
+  EXPECT_EQ(countElement(mol, 8), 1);
+  EXPECT_EQ(countElement(mol, 1), 2);
+}
+
+TEST(SmilesParserTest, bareAmmonia)
+{
+  Molecule mol = parseOk("N");
+  EXPECT_EQ(mol.atomCount(), 4u);
+  EXPECT_EQ(mol.bondCount(), 3u);
+}
+
+TEST(SmilesParserTest, bareHydrogenSulfide)
+{
+  Molecule mol = parseOk("S");
+  EXPECT_EQ(mol.atomCount(), 3u);
+  EXPECT_EQ(mol.bondCount(), 2u);
+}
+
+TEST(SmilesParserTest, bareHydrogenChloride)
+{
+  Molecule mol = parseOk("Cl");
+  EXPECT_EQ(mol.atomCount(), 2u);
+  EXPECT_EQ(mol.bondCount(), 1u);
+  EXPECT_EQ(countElement(mol, 17), 1);
+  EXPECT_EQ(countElement(mol, 1), 1);
+}
+
+TEST(SmilesParserTest, bracketHydrogenMolecule)
+{
+  Molecule mol = parseOk("[H][H]");
+  EXPECT_EQ(mol.atomCount(), 2u);
+  EXPECT_EQ(mol.bondCount(), 1u);
+  EXPECT_EQ(countElement(mol, 1), 2);
+  EXPECT_EQ(countBondOrder(mol, 1), 1);
+}
+
+// ---------------------------------------------------------------------------
+// The valence model's multi-valence cases.
+
+TEST(SmilesParserTest, nitrogenValences)
+{
+  Molecule ammonia = parseOk("N");
+  EXPECT_EQ(ammonia.atomCount(), 4u); // NH3
+
+  Molecule dioxide = parseOk("N(=O)=O");
+  EXPECT_EQ(dioxide.atomCount(), 4u); // one N, two O, one H
+  EXPECT_EQ(dioxide.bondCount(), 3u);
+  EXPECT_EQ(countElement(dioxide, 7), 1);
+  EXPECT_EQ(countElement(dioxide, 8), 2);
+  EXPECT_EQ(countElement(dioxide, 1), 1);
+  EXPECT_EQ(countBondOrder(dioxide, 2), 2);
+  EXPECT_EQ(countBondOrder(dioxide, 1), 1);
+}
+
+TEST(SmilesParserTest, sulfurValences)
+{
+  Molecule sulfide = parseOk("S");
+  EXPECT_EQ(sulfide.atomCount(), 3u); // H2S
+
+  Molecule dioxide = parseOk("S(=O)(=O)");
+  EXPECT_EQ(dioxide.atomCount(), 3u); // S reaches valence 4, no H
+  EXPECT_EQ(dioxide.bondCount(), 2u);
+  EXPECT_EQ(countBondOrder(dioxide, 2), 2);
+  EXPECT_EQ(countBondOrder(dioxide, 1), 0);
+}
+
+TEST(SmilesParserTest, phosphorusValence)
+{
+  Molecule phosphine = parseOk("P");
+  EXPECT_EQ(phosphine.atomCount(), 4u); // PH3
+  EXPECT_EQ(phosphine.bondCount(), 3u);
+}
+
+// ---------------------------------------------------------------------------
+// Bracket atoms.
+
+TEST(SmilesParserTest, bracketMethane)
+{
+  Molecule mol = parseOk("[CH4]");
+  EXPECT_EQ(mol.atomCount(), 5u);
+  EXPECT_EQ(countElement(mol, 6), 1);
+  EXPECT_EQ(countElement(mol, 1), 4);
+}
+
+TEST(SmilesParserTest, bracketAmmonium)
+{
+  Molecule mol = parseOk("[NH4+]");
+  EXPECT_EQ(mol.atomCount(), 5u);
+  EXPECT_EQ(mol.formalCharge(0), 1);
+}
+
+TEST(SmilesParserTest, bracketIronDigitCharge)
+{
+  Molecule mol = parseOk("[Fe+2]");
+  EXPECT_EQ(mol.atomCount(), 1u);
+  EXPECT_EQ(mol.atomicNumber(0), 26);
+  EXPECT_EQ(mol.formalCharge(0), 2);
+}
+
+TEST(SmilesParserTest, bracketIronRepeatedSignCharge)
+{
+  Molecule mol = parseOk("[Fe++]");
+  EXPECT_EQ(mol.atomCount(), 1u);
+  EXPECT_EQ(mol.atomicNumber(0), 26);
+  EXPECT_EQ(mol.formalCharge(0), 2);
+}
+
+TEST(SmilesParserTest, bracketOxideAnion)
+{
+  Molecule mol = parseOk("[O-]");
+  EXPECT_EQ(mol.atomCount(), 1u);
+  EXPECT_EQ(mol.formalCharge(0), -1);
+}
+
+TEST(SmilesParserTest, bracketIsotope)
+{
+  Molecule mol = parseOk("[13CH4]");
+  EXPECT_EQ(mol.atomCount(), 5u);
+  EXPECT_EQ(mol.atomicNumber(0), 6);
+  EXPECT_EQ(mol.isotope(0), 13);
+  EXPECT_EQ(countElement(mol, 1), 4);
+}
+
+TEST(SmilesParserTest, bracketChiralityDiscarded)
+{
+  SmilesParser parser;
+  Molecule mol;
+  ASSERT_TRUE(parser.parse("[C@H](N)(O)C", mol)) << parser.error();
+  EXPECT_EQ(mol.atomCount(), 11u);
+  EXPECT_EQ(mol.bondCount(), 10u);
+  ASSERT_EQ(parser.warnings().size(), 1u);
+}
+
+TEST(SmilesParserTest, bracketWildcard)
+{
+  Molecule mol = parseOk("[*]");
+  EXPECT_EQ(mol.atomCount(), 1u);
+  EXPECT_EQ(mol.atomicNumber(0), 0);
+  EXPECT_EQ(mol.bondCount(), 0u);
+}
+
+TEST(SmilesParserTest, atomMapClasses)
+{
+  SmilesParser single;
+  Molecule mol;
+  ASSERT_TRUE(single.parse("[C:5]", mol)) << single.error();
+  EXPECT_EQ(mol.atomCount(), 1u);
+  ASSERT_EQ(single.atomMaps().size(), 1u);
+  EXPECT_EQ(single.atomMaps()[0], 5u);
+
+  SmilesParser withHydrogens;
+  Molecule methyl;
+  ASSERT_TRUE(withHydrogens.parse("[CH3:12]", methyl)) << withHydrogens.error();
+  EXPECT_EQ(methyl.atomCount(), 4u);
+  ASSERT_EQ(withHydrogens.atomMaps().size(), 4u);
+  EXPECT_EQ(withHydrogens.atomMaps()[0], 12u);
+  EXPECT_EQ(withHydrogens.atomMaps()[1], 0u);
+  EXPECT_EQ(withHydrogens.atomMaps()[2], 0u);
+  EXPECT_EQ(withHydrogens.atomMaps()[3], 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Branches, including nested and consecutive.
+
+TEST(SmilesParserTest, consecutiveBranches)
+{
+  // Isobutane.
+  Molecule mol = parseOk("CC(C)C");
+  EXPECT_EQ(mol.atomCount(), 14u);
+  EXPECT_EQ(mol.bondCount(), 13u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 1), 10);
+}
+
+TEST(SmilesParserTest, doubleBranch)
+{
+  // Neopentane.
+  Molecule mol = parseOk("CC(C)(C)C");
+  EXPECT_EQ(mol.atomCount(), 17u);
+  EXPECT_EQ(mol.bondCount(), 16u);
+  EXPECT_EQ(countElement(mol, 6), 5);
+  EXPECT_EQ(countElement(mol, 1), 12);
+}
+
+TEST(SmilesParserTest, nestedBranch)
+{
+  // n-Butane, written with a branch nested inside another.
+  Molecule mol = parseOk("C(C(C))C");
+  EXPECT_EQ(mol.atomCount(), 14u);
+  EXPECT_EQ(mol.bondCount(), 13u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 1), 10);
+}
+
+// ---------------------------------------------------------------------------
+// Ring closures.
+
+TEST(SmilesParserTest, ringClosureDigit)
+{
+  // Cyclohexane.
+  Molecule mol = parseOk("C1CCCCC1");
+  EXPECT_EQ(mol.atomCount(), 18u);
+  EXPECT_EQ(mol.bondCount(), 18u);
+  EXPECT_EQ(countElement(mol, 6), 6);
+  EXPECT_EQ(countElement(mol, 1), 12);
+}
+
+TEST(SmilesParserTest, ringClosurePercent)
+{
+  // The same cyclohexane, with a two digit ring number.
+  Molecule mol = parseOk("C%10CCCCC%10");
+  EXPECT_EQ(mol.atomCount(), 18u);
+  EXPECT_EQ(mol.bondCount(), 18u);
+}
+
+TEST(SmilesParserTest, ringNumberReusedAfterClosing)
+{
+  // Bicyclopropyl: two cyclopropane rings, joined by a single bond, both
+  // written with ring number 1.
+  Molecule mol = parseOk("C1CC1C1CC1");
+  EXPECT_EQ(mol.atomCount(), 16u);
+  EXPECT_EQ(mol.bondCount(), 17u);
+  EXPECT_EQ(countElement(mol, 6), 6);
+  EXPECT_EQ(countElement(mol, 1), 10);
+}
+
+TEST(SmilesParserTest, ringClosureBondOrderOnOneEnd)
+{
+  // Cyclohexene.
+  Molecule mol = parseOk("C=1CCCCC1");
+  EXPECT_EQ(mol.atomCount(), 16u);
+  EXPECT_EQ(mol.bondCount(), 16u);
+  EXPECT_EQ(countBondOrder(mol, 2), 1);
+}
+
+TEST(SmilesParserTest, ringClosureBondOrderOnBothEnds)
+{
+  // The two ends agree, so this is the same cyclohexene as above.
+  Molecule mol = parseOk("C=1CCCCC=1");
+  EXPECT_EQ(mol.atomCount(), 16u);
+  EXPECT_EQ(mol.bondCount(), 16u);
+  EXPECT_EQ(countBondOrder(mol, 2), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Dot disconnection.
+
+TEST(SmilesParserTest, dotDisconnection)
+{
+  Molecule mol = parseOk("[Na+].[Cl-]");
+  EXPECT_EQ(mol.atomCount(), 2u);
+  EXPECT_EQ(mol.bondCount(), 0u);
+  EXPECT_EQ(mol.atomicNumber(0), 11);
+  EXPECT_EQ(mol.formalCharge(0), 1);
+  EXPECT_EQ(mol.atomicNumber(1), 17);
+  EXPECT_EQ(mol.formalCharge(1), -1);
+}
+
+TEST(SmilesParserTest, dotInsideABranch)
+{
+  // The branch's tail ("N") is disconnected from what came before the dot,
+  // but the branch still closes back onto the atom that opened it.
+  Molecule mol = parseOk("C(CC.N)C");
+  EXPECT_EQ(mol.atomCount(), 18u);
+  EXPECT_EQ(mol.bondCount(), 16u);
+  EXPECT_EQ(countElement(mol, 6), 4);
+  EXPECT_EQ(countElement(mol, 7), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Title handling.
+
+TEST(SmilesParserTest, title)
+{
+  SmilesParser parser;
+  Molecule mol;
+  ASSERT_TRUE(parser.parse("CC ethane", mol)) << parser.error();
+  EXPECT_EQ(mol.atomCount(), 8u); // The title does not affect the graph.
+  ASSERT_TRUE(mol.hasData("name"));
+  EXPECT_EQ(mol.data("name").toString(), "ethane");
+}
+
+TEST(SmilesParserTest, noTitleMeansNoNameData)
+{
+  Molecule mol = parseOk("CC");
+  EXPECT_FALSE(mol.hasData("name"));
+}
+
+// ---------------------------------------------------------------------------
+// Empty input.
+
+TEST(SmilesParserTest, emptyString)
+{
+  SmilesParser parser;
+  Molecule mol;
+  EXPECT_TRUE(parser.parse("", mol)) << parser.error();
+  EXPECT_EQ(mol.atomCount(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Errors. Each of these picks an offset deliberately, so a bug that reports
+// the wrong position -- as opposed to merely failing -- is still caught.
+
+TEST(SmilesParserTest, errorUnexpectedCharacter)
+{
+  expectError("CX", 1);
+}
+
+TEST(SmilesParserTest, errorUnterminatedBracket)
+{
+  expectError("[C", 0);
+}
+
+TEST(SmilesParserTest, errorEmptyBracket)
+{
+  expectError("[]", 0);
+}
+
+TEST(SmilesParserTest, errorUnknownElementInBracket)
+{
+  expectError("[Zz]", 1);
+}
+
+TEST(SmilesParserTest, errorBondNotFollowedByAtom)
+{
+  expectError("C-", 1);
+}
+
+TEST(SmilesParserTest, errorUnmatchedCloseParen)
+{
+  expectError(")C", 0);
+}
+
+TEST(SmilesParserTest, errorUnclosedOpenParen)
+{
+  expectError("C(C", 1);
+}
+
+TEST(SmilesParserTest, errorBranchWithNoPrecedingAtom)
+{
+  expectError("(C)", 0);
+}
+
+TEST(SmilesParserTest, errorBondWithNoPrecedingAtom)
+{
+  expectError("-C", 0);
+}
+
+TEST(SmilesParserTest, errorPercentNotTwoDigits)
+{
+  expectError("C%1", 1);
+}
+
+TEST(SmilesParserTest, errorRingClosureConflictingBondOrder)
+{
+  expectError("C=1CCCCC#1", 8);
+}
+
+TEST(SmilesParserTest, errorRingClosureToItself)
+{
+  expectError("C11", 2);
+}
+
+TEST(SmilesParserTest, errorRingClosureDuplicatesExistingBond)
+{
+  // Ring 2 closes the atom0-atom2 bond; ring 1 then tries to close the same
+  // pair again.
+  expectError("C12CC21", 6);
+}
+
+TEST(SmilesParserTest, errorRingClosureStillOpenAtEndOfInput)
+{
+  expectError("C1CC", 1);
+}
+
+TEST(SmilesParserTest, errorIsotopeOverflow)
+{
+  expectError("[999999C]", 1);
+}
+
+TEST(SmilesParserTest, errorChargeOverflow)
+{
+  expectError("[Fe+999]", 3);
+}
+
+TEST(SmilesParserTest, errorAtomClassOverflow)
+{
+  expectError("[C:9999999999]", 2);
+}
+
+// ---------------------------------------------------------------------------
+// Aromatic input: rejected until a kekulizer exists.
+
+TEST(SmilesParserTest, errorAromaticRingIsRejected)
+{
+  SmilesParser parser;
+  Molecule mol;
+  EXPECT_FALSE(parser.parse("c1ccccc1", mol));
+  EXPECT_EQ(parser.errorPosition(), 0u);
+  EXPECT_EQ(parser.error(),
+            "Aromatic SMILES requires kekulization, which is not yet "
+            "implemented.");
+}
+
+TEST(SmilesParserTest, errorAromaticBracketAtomIsRejected)
+{
+  expectError("[nH]1cccc1", 0);
+}
+
+TEST(SmilesParserTest, errorAromaticBondIsRejected)
+{
+  // Neither atom is written lower case; only the explicit ':' bond is
+  // aromatic here.
+  expectError("C:C", 1);
+}
+
+// ---------------------------------------------------------------------------
+// Round trip: write a parsed-in molecule back out with explicit hydrogens,
+// atom maps and no aromatic perception, reparse it, and check that the two
+// molecules agree atom for atom.
+
+namespace {
+
+void expectRoundTrip(Molecule& original)
+{
+  SmilesWriter writer;
+  writer.setAtomMaps(true); // Implies explicit hydrogens.
+  writer.setAromatic(false);
+  std::string smiles;
+  ASSERT_TRUE(writer.write(original, smiles)) << writer.error();
+
+  SmilesParser parser;
+  Molecule reparsed;
+  ASSERT_TRUE(parser.parse(smiles, reparsed))
+    << smiles << ": " << parser.error();
+
+  ASSERT_EQ(reparsed.atomCount(), original.atomCount()) << smiles;
+  const std::vector<size_t>& maps = parser.atomMaps();
+  ASSERT_EQ(maps.size(), reparsed.atomCount());
+
+  // Atom maps correlate the two molecules' atoms: SmilesWriter wrote class
+  // N+1 for original atom N, so subtracting one recovers the original index.
+  for (Index i = 0; i < reparsed.atomCount(); ++i) {
+    ASSERT_GT(maps[i], 0u) << smiles;
+    const Index originalIndex = static_cast<Index>(maps[i] - 1);
+    ASSERT_LT(originalIndex, original.atomCount()) << smiles;
+    EXPECT_EQ(reparsed.atomicNumber(i), original.atomicNumber(originalIndex))
+      << smiles << ": atom " << i;
+    EXPECT_EQ(reparsed.formalCharge(i), original.formalCharge(originalIndex))
+      << smiles << ": atom " << i;
+    EXPECT_EQ(reparsed.isotope(i), original.isotope(originalIndex))
+      << smiles << ": atom " << i;
+  }
+
+  ASSERT_EQ(reparsed.bondCount(), original.bondCount()) << smiles;
+  for (Index b = 0; b < reparsed.bondCount(); ++b) {
+    const std::pair<Index, Index> pair = reparsed.bondPair(b);
+    const Index origA = static_cast<Index>(maps[pair.first] - 1);
+    const Index origB = static_cast<Index>(maps[pair.second] - 1);
+    const Avogadro::Core::Bond origBond = original.bond(origA, origB);
+    ASSERT_TRUE(origBond.isValid()) << smiles;
+    EXPECT_EQ(reparsed.bondOrders()[b], origBond.order()) << smiles;
+  }
+}
+
+Molecule ethanolMolecule()
+{
+  Molecule mol;
+  const Index c1 = mol.addAtom(6).index();
+  const Index c2 = mol.addAtom(6).index();
+  const Index oxygen = mol.addAtom(8).index();
+  mol.addBond(c1, c2, 1);
+  mol.addBond(c2, oxygen, 1);
+  addHydrogens(mol, c1, 3);
+  addHydrogens(mol, c2, 2);
+  addHydrogens(mol, oxygen, 1);
+  return mol;
+}
+
+Molecule cyclohexaneMolecule()
+{
+  Molecule mol;
+  Index ring[6];
+  for (int i = 0; i < 6; ++i)
+    ring[i] = mol.addAtom(6).index();
+  for (int i = 0; i < 6; ++i)
+    mol.addBond(ring[i], ring[(i + 1) % 6], 1);
+  for (int i = 0; i < 6; ++i)
+    addHydrogens(mol, ring[i], 2);
+  return mol;
+}
+
+Molecule kekuleNaphthaleneMolecule()
+{
+  Molecule mol;
+  Index ring[10];
+  for (int i = 0; i < 10; ++i)
+    ring[i] = mol.addAtom(6).index();
+  // Alternating bond orders around the perimeter, plus the single bond
+  // shared by the two fused rings (4a-8a in naphthalene's own numbering).
+  for (int i = 0; i < 10; ++i) {
+    const unsigned char order = (i % 2 == 0) ? 1 : 2;
+    mol.addBond(ring[i], ring[(i + 1) % 10], order);
+  }
+  mol.addBond(ring[4], ring[9], 1);
+
+  const bool bridgehead[10] = { false, false, false, false, true,
+                                false, false, false, false, true };
+  for (int i = 0; i < 10; ++i) {
+    if (!bridgehead[i])
+      addHydrogens(mol, ring[i], 1);
+  }
+  return mol;
+}
+
+Molecule saltMolecule()
+{
+  Molecule mol;
+  const Index sodium = mol.addAtom(11).index();
+  mol.setFormalCharge(sodium, 1);
+  const Index chlorine = mol.addAtom(17).index();
+  mol.setFormalCharge(chlorine, -1);
+  return mol;
+}
+
+Molecule isotopeLabelledMolecule()
+{
+  // 13C-labelled methane, with one of its hydrogens replaced by deuterium.
+  Molecule mol;
+  const Index carbon = mol.addAtom(6).index();
+  mol.setIsotope(carbon, 13);
+  addHydrogens(mol, carbon, 3);
+  const Index deuterium = mol.addAtom(1).index();
+  mol.setIsotope(deuterium, 2);
+  mol.addBond(carbon, deuterium, 1);
+  return mol;
+}
+
+} // namespace
+
+TEST(SmilesParserTest, roundTripEthanol)
+{
+  Molecule mol = ethanolMolecule();
+  expectRoundTrip(mol);
+}
+
+TEST(SmilesParserTest, roundTripCyclohexane)
+{
+  Molecule mol = cyclohexaneMolecule();
+  expectRoundTrip(mol);
+}
+
+TEST(SmilesParserTest, roundTripKekuleNaphthalene)
+{
+  Molecule mol = kekuleNaphthaleneMolecule();
+  expectRoundTrip(mol);
+}
+
+TEST(SmilesParserTest, roundTripChargedSalt)
+{
+  Molecule mol = saltMolecule();
+  expectRoundTrip(mol);
+}
+
+TEST(SmilesParserTest, roundTripIsotopeLabelled)
+{
+  Molecule mol = isotopeLabelledMolecule();
+  expectRoundTrip(mol);
+}

--- a/tests/io/smilesparsertest.cpp
+++ b/tests/io/smilesparsertest.cpp
@@ -614,6 +614,15 @@ TEST(SmilesParserTest, aromaticCaffeine)
   EXPECT_EQ(countElement(mol, 7), 4);
   EXPECT_EQ(countElement(mol, 8), 2);
   EXPECT_EQ(countElement(mol, 1), 10);
+
+  // Four double bonds: the two exocyclic C=O written in the string, plus two
+  // the kekulizer assigns. Only four of the nine aromatic atoms have room for
+  // a double bond -- the two carbonyl carbons are already full, and all three
+  // nitrogens bearing a methyl are pyrrole-type -- so the ring system carries
+  // two, not the three a bare purine would.
+  EXPECT_EQ(mol.bondCount(), 25u);
+  EXPECT_EQ(countBondOrder(mol, 2), 4);
+  EXPECT_EQ(countBondOrder(mol, 1), 21);
 }
 
 TEST(SmilesParserTest, errorUnkekulizableAromaticRing)

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -760,6 +760,11 @@ Molecule aromaticRing(const std::vector<unsigned char>& elements,
                       const std::vector<unsigned char>& orders)
 {
   Molecule mol;
+  EXPECT_EQ(hydrogens.size(), elements.size());
+  EXPECT_EQ(orders.size(), elements.size());
+  if (hydrogens.size() != elements.size() || orders.size() != elements.size())
+    return mol;
+
   for (unsigned char element : elements)
     mol.addAtom(element);
   for (Index i = 0; i < elements.size(); ++i)
@@ -861,11 +866,34 @@ TEST(SmilesTest, formatOptions)
     EXPECT_EQ(output, mode.second) << mode.first;
   }
 
+  // The aromatic option, which is on unless a caller turns it off.
+  Molecule benzene =
+    aromaticRing({ 6, 6, 6, 6, 6, 6 }, { true, true, true, true, true, true },
+                 { 2, 1, 2, 1, 2, 1 });
+  for (const std::pair<const char*, const char*>& setting :
+       { std::make_pair("{}", "c1ccccc1\n"),
+         std::make_pair("{\"aromatic\": true}", "c1ccccc1\n"),
+         std::make_pair("{\"aromatic\": false}", "C1=CC=CC=C1\n") }) {
+    SmilesFormat format3;
+    format3.setOptions(setting.first);
+    std::string output;
+    EXPECT_TRUE(format3.writeString(output, benzene)) << format3.error();
+    EXPECT_EQ(output, setting.second) << setting.first;
+  }
+
+  // Malformed JSON is not an error: it parses to a discarded value and the
+  // typed settings stand. What matters is that nothing throws.
+  SmilesFormat malformed;
+  malformed.setOptions("{ this is not json ");
+  std::string fromMalformed;
+  EXPECT_TRUE(malformed.writeString(fromMalformed, mol)) << malformed.error();
+  EXPECT_EQ(fromMalformed, "C\n");
+
   // An option that is present but unusable is an error, not a silent default:
   // a wrong type, and a value this format does not know.
   const char* rejected[] = { "{\"hydrogens\": \"aromatic\"}",
-                             "{\"hydrogens\": true}",
-                             "{\"atomMaps\": \"yes\"}" };
+                             "{\"hydrogens\": true}", "{\"atomMaps\": \"yes\"}",
+                             "{\"aromatic\": \"yes\"}" };
   for (const char* options : rejected) {
     SmilesFormat bad;
     bad.setOptions(options);

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -747,6 +747,83 @@ TEST(SmilesTest, unspecifiedMarkersFollowTheirBonds)
   EXPECT_TRUE(markedDoubleBond);
 }
 
+namespace {
+
+/** A ring of @a elements, alternating double and single bonds, plus one
+ *  hydrogen on every atom that is given one in @a hydrogens. */
+Molecule aromaticRing(const std::vector<unsigned char>& elements,
+                      const std::vector<bool>& hydrogens,
+                      const std::vector<unsigned char>& orders)
+{
+  Molecule mol;
+  for (unsigned char element : elements)
+    mol.addAtom(element);
+  for (Index i = 0; i < elements.size(); ++i)
+    mol.addBond(i, (i + 1) % elements.size(), orders[i]);
+  for (Index i = 0; i < elements.size(); ++i) {
+    if (hydrogens[i])
+      mol.addBond(i, mol.addAtom(1).index(), 1);
+  }
+  return mol;
+}
+
+} // namespace
+
+TEST(SmilesTest, aromaticOutput)
+{
+  // Benzene, in the form everyone writes it.
+  Molecule benzene =
+    aromaticRing({ 6, 6, 6, 6, 6, 6 }, { true, true, true, true, true, true },
+                 { 2, 1, 2, 1, 2, 1 });
+  EXPECT_EQ(writeImplicit(benzene), "c1ccccc1");
+
+  // Pyridine: the nitrogen needs no hydrogen and stays bare.
+  Molecule pyridine =
+    aromaticRing({ 7, 6, 6, 6, 6, 6 }, { false, true, true, true, true, true },
+                 { 2, 1, 2, 1, 2, 1 });
+  EXPECT_EQ(writeImplicit(pyridine), "n1ccccc1");
+}
+
+TEST(SmilesTest, aromaticHeteroatomsSpellOutTheirHydrogens)
+{
+  // Pyrrole. A reader cannot kekulize the ring without knowing whether the
+  // nitrogen carries a hydrogen, so it has to be written explicitly.
+  Molecule pyrrole = aromaticRing(
+    { 7, 6, 6, 6, 6 }, { true, true, true, true, true }, { 1, 2, 1, 2, 1 });
+  EXPECT_EQ(writeImplicit(pyrrole), "[nH]1cccc1");
+
+  // Furan's oxygen has none, so it needs no bracket.
+  Molecule furan = aromaticRing(
+    { 8, 6, 6, 6, 6 }, { false, true, true, true, true }, { 1, 2, 1, 2, 1 });
+  EXPECT_EQ(writeImplicit(furan), "o1cccc1");
+}
+
+TEST(SmilesTest, kekuleOutputOnRequest)
+{
+  Molecule benzene =
+    aromaticRing({ 6, 6, 6, 6, 6, 6 }, { true, true, true, true, true, true },
+                 { 2, 1, 2, 1, 2, 1 });
+
+  SmilesWriter writer;
+  writer.setAromatic(false);
+  std::string smiles;
+  EXPECT_TRUE(writer.write(benzene, smiles)) << writer.error();
+  EXPECT_EQ(smiles, "C1=CC=CC=C1");
+}
+
+TEST(SmilesTest, nonAromaticRingsKeepTheirBondOrders)
+{
+  // Cyclohexane has no aromaticity to find, so nothing changes.
+  Molecule mol = aromaticRing({ 6, 6, 6, 6, 6, 6 },
+                              { false, false, false, false, false, false },
+                              { 1, 1, 1, 1, 1, 1 });
+  for (Index i = 0; i < 6; ++i) {
+    mol.addBond(i, mol.addAtom(1).index(), 1);
+    mol.addBond(i, mol.addAtom(1).index(), 1);
+  }
+  EXPECT_EQ(writeImplicit(mol), "C1CCCCC1");
+}
+
 TEST(SmilesTest, formatIsWriteOnly)
 {
   SmilesFormat format;

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 
 using Avogadro::Index;
 using Avogadro::Vector3;
@@ -32,7 +33,7 @@ using Avogadro::Io::SmilesWriter;
 
 namespace {
 
-/** Write in the only mode implemented so far: mapped, explicit hydrogens. */
+/** Write with atom maps, which implies explicit hydrogens. */
 std::string writeMapped(const Molecule& mol)
 {
   SmilesWriter writer;
@@ -291,6 +292,8 @@ TEST(SmilesTest, atomMapsImplyExplicitHydrogens)
   EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]");
 }
 
+namespace {
+
 /** Write in the default (implicit hydrogen) mode. */
 std::string writeImplicit(const Molecule& mol)
 {
@@ -316,6 +319,8 @@ Molecule hydride(unsigned char atomicNumber, int count)
   addHydrogens(mol, mol.addAtom(atomicNumber).index(), count);
   return mol;
 }
+
+} // namespace
 
 TEST(SmilesTest, implicitOrganicSubset)
 {
@@ -630,6 +635,12 @@ Molecule difluoroethene(bool trans)
   return mol;
 }
 
+bool hasDirectionalBond(const std::string& smiles)
+{
+  return smiles.find('/') != std::string::npos ||
+         smiles.find('\\') != std::string::npos;
+}
+
 } // namespace
 
 TEST(SmilesTest, cisTransMarkers)
@@ -654,8 +665,7 @@ TEST(SmilesTest, noCisTransWithoutTwoDistinctEnds)
   mol.addBond(c2, mol.addAtom(1, Vector3(2.0, -1.03, 0.0)).index(), 1);
 
   const std::string smiles = writeImplicit(mol);
-  EXPECT_EQ(smiles.find('/'), std::string::npos) << smiles;
-  EXPECT_EQ(smiles.find('\\'), std::string::npos) << smiles;
+  EXPECT_FALSE(hasDirectionalBond(smiles)) << smiles;
 }
 
 TEST(SmilesTest, noCisTransWithoutCoordinates)
@@ -692,12 +702,6 @@ std::string buteneMol(const char* doubleBondStereo)
                      "  1  2  1  0\n"
                      "  2  3  2  ") +
          doubleBondStereo + "\n  3  4  1  0\nM  END\n";
-}
-
-bool hasDirectionalBond(const std::string& smiles)
-{
-  return smiles.find('/') != std::string::npos ||
-         smiles.find('\\') != std::string::npos;
 }
 
 } // namespace
@@ -749,8 +753,8 @@ TEST(SmilesTest, unspecifiedMarkersFollowTheirBonds)
 
 namespace {
 
-/** A ring of @a elements, alternating double and single bonds, plus one
- *  hydrogen on every atom that is given one in @a hydrogens. */
+/** A ring of @a elements bonded in @a orders, plus one hydrogen on every atom
+ *  flagged in @a hydrogens. */
 Molecule aromaticRing(const std::vector<unsigned char>& elements,
                       const std::vector<bool>& hydrogens,
                       const std::vector<unsigned char>& orders)
@@ -842,6 +846,33 @@ TEST(SmilesTest, formatOptions)
   std::string smiles;
   EXPECT_TRUE(format.writeString(smiles, mol)) << format.error();
   EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]\n");
+
+  // Each hydrogen mode, through the option rather than the typed setter.
+  const std::pair<const char*, const char*> modes[] = {
+    { "implicit", "C\n" },
+    { "bracket", "[CH4]\n" },
+    { "explicit", "[C]([H])([H])([H])[H]\n" }
+  };
+  for (const auto& mode : modes) {
+    SmilesFormat format2;
+    format2.setOptions(std::string("{\"hydrogens\": \"") + mode.first + "\"}");
+    std::string output;
+    EXPECT_TRUE(format2.writeString(output, mol)) << format2.error();
+    EXPECT_EQ(output, mode.second) << mode.first;
+  }
+
+  // An option that is present but unusable is an error, not a silent default:
+  // a wrong type, and a value this format does not know.
+  const char* rejected[] = { "{\"hydrogens\": \"aromatic\"}",
+                             "{\"hydrogens\": true}",
+                             "{\"atomMaps\": \"yes\"}" };
+  for (const char* options : rejected) {
+    SmilesFormat bad;
+    bad.setOptions(options);
+    std::string output;
+    EXPECT_FALSE(bad.writeString(output, mol)) << options;
+    EXPECT_FALSE(bad.error().empty()) << options;
+  }
 
   SmilesFormat defaults;
   std::string implicit;

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <avogadro/core/molecule.h>
+#include <avogadro/core/vector.h>
 
 #include <avogadro/io/cmlformat.h>
 #include <avogadro/io/smilesformat.h>
@@ -18,6 +19,7 @@
 #include <string>
 
 using Avogadro::Index;
+using Avogadro::Vector3;
 using Avogadro::Core::Molecule;
 using Avogadro::Io::CmlFormat;
 using Avogadro::Io::SmilesFormat;
@@ -284,21 +286,288 @@ TEST(SmilesTest, atomMapsImplyExplicitHydrogens)
   EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]");
 }
 
-TEST(SmilesTest, unimplementedModesFailCleanly)
+/** Write in the default (implicit hydrogen) mode. */
+std::string writeImplicit(const Molecule& mol)
+{
+  SmilesWriter writer;
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
+  return smiles;
+}
+
+std::string writeBracket(const Molecule& mol)
+{
+  SmilesWriter writer;
+  writer.setHydrogenMode(SmilesWriter::HydrogenMode::Bracket);
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
+  return smiles;
+}
+
+/** Build a heavy atom carrying @a count hydrogens. */
+Molecule hydride(unsigned char atomicNumber, int count)
 {
   Molecule mol;
-  mol.addAtom(6);
+  addHydrogens(mol, mol.addAtom(atomicNumber).index(), count);
+  return mol;
+}
 
-  for (SmilesWriter::HydrogenMode mode :
-       { SmilesWriter::HydrogenMode::Implicit,
-         SmilesWriter::HydrogenMode::Bracket }) {
-    SmilesWriter writer;
-    writer.setHydrogenMode(mode);
-    std::string smiles;
-    EXPECT_FALSE(writer.write(mol, smiles));
-    EXPECT_FALSE(writer.error().empty());
-    EXPECT_EQ(smiles, "");
+TEST(SmilesTest, implicitOrganicSubset)
+{
+  // One bare atom per organic subset element, at its lowest normal valence.
+  EXPECT_EQ(writeImplicit(hydride(6, 4)), "C");   // methane
+  EXPECT_EQ(writeImplicit(hydride(7, 3)), "N");   // ammonia
+  EXPECT_EQ(writeImplicit(hydride(8, 2)), "O");   // water
+  EXPECT_EQ(writeImplicit(hydride(5, 3)), "B");   // borane
+  EXPECT_EQ(writeImplicit(hydride(15, 3)), "P");  // phosphine
+  EXPECT_EQ(writeImplicit(hydride(16, 2)), "S");  // hydrogen sulfide
+  EXPECT_EQ(writeImplicit(hydride(9, 1)), "F");   // hydrogen fluoride
+  EXPECT_EQ(writeImplicit(hydride(17, 1)), "Cl"); // hydrogen chloride
+}
+
+TEST(SmilesTest, implicitHigherValences)
+{
+  // Nitrogen's second normal valence: a bond order sum of 4 implies one H.
+  Molecule imine;
+  Index nitrogen = imine.addAtom(7).index();
+  Index first = imine.addAtom(6).index();
+  Index second = imine.addAtom(6).index();
+  imine.addBond(nitrogen, first, 2);
+  imine.addBond(nitrogen, second, 2);
+  addHydrogens(imine, nitrogen, 1);
+  addHydrogens(imine, first, 2);
+  addHydrogens(imine, second, 2);
+
+  EXPECT_EQ(writeImplicit(imine), "N(=C)=C");
+
+  // Dimethyl sulfone: sulfur reaches its third normal valence, so it needs no
+  // hydrogens, while the methyl carbons reach their first and take three each.
+  Molecule sulfone;
+  Index sulfur = sulfone.addAtom(16).index();
+  sulfone.addBond(sulfur, sulfone.addAtom(8).index(), 2);
+  sulfone.addBond(sulfur, sulfone.addAtom(8).index(), 2);
+  for (int i = 0; i < 2; ++i) {
+    Index methyl = sulfone.addAtom(6).index();
+    sulfone.addBond(sulfur, methyl, 1);
+    addHydrogens(sulfone, methyl, 3);
   }
+
+  EXPECT_EQ(writeImplicit(sulfone), "S(=O)(=O)(C)C");
+}
+
+TEST(SmilesTest, implicitFallsBackToBrackets)
+{
+  // A methyl radical has one hydrogen fewer than carbon's valence implies, so
+  // writing it bare would silently turn it into methane.
+  EXPECT_EQ(writeImplicit(hydride(6, 3)), "[CH3]");
+
+  // Charge, isotope and non-subset elements each force a bracket.
+  Molecule ammonium = hydride(7, 4);
+  ammonium.setFormalCharge(0, 1);
+  EXPECT_EQ(writeImplicit(ammonium), "[NH4+]");
+
+  Molecule heavyWater = hydride(8, 2);
+  heavyWater.setIsotope(1, 2);
+  heavyWater.setIsotope(2, 2);
+  EXPECT_EQ(writeImplicit(heavyWater), "O([2H])[2H]");
+
+  Molecule iron;
+  iron.addAtom(26);
+  EXPECT_EQ(writeImplicit(iron), "[Fe]");
+
+  // Wildcards are always bracketed: bare '*' has no implied hydrogen rule.
+  Molecule dummy;
+  dummy.addAtom(0);
+  EXPECT_EQ(writeImplicit(dummy), "[*]");
+}
+
+TEST(SmilesTest, hydrogensThatCannotBeSuppressed)
+{
+  // Molecular hydrogen: neither atom has a heavy neighbour to fold into.
+  Molecule h2;
+  h2.addBond(h2.addAtom(1).index(), h2.addAtom(1).index(), 1);
+  EXPECT_EQ(writeImplicit(h2), "[H][H]");
+
+  // A lone hydrogen atom, and a hydride ion.
+  Molecule atomic;
+  atomic.addAtom(1);
+  EXPECT_EQ(writeImplicit(atomic), "[H]");
+
+  Molecule anion;
+  anion.addAtom(1);
+  anion.setFormalCharge(0, -1);
+  EXPECT_EQ(writeImplicit(anion), "[H-]");
+
+  // A bridging hydrogen has two bonds, so it stays an atom of its own while
+  // the terminal hydrogens on the same borons are folded away.
+  Molecule bridged;
+  Index left = bridged.addAtom(5).index();
+  Index right = bridged.addAtom(5).index();
+  Index bridge = bridged.addAtom(1).index();
+  bridged.addBond(left, bridge, 1);
+  bridged.addBond(right, bridge, 1);
+  addHydrogens(bridged, left, 2);
+  addHydrogens(bridged, right, 2);
+  EXPECT_EQ(writeImplicit(bridged), "B[H]B");
+}
+
+TEST(SmilesTest, bracketMode)
+{
+  EXPECT_EQ(writeBracket(hydride(6, 4)), "[CH4]");
+  EXPECT_EQ(writeBracket(hydride(8, 2)), "[OH2]");
+
+  // Bracket mode still folds hydrogens away; it just never goes bare.
+  Molecule ethanol;
+  Index c1 = ethanol.addAtom(6).index();
+  Index c2 = ethanol.addAtom(6).index();
+  Index oxygen = ethanol.addAtom(8).index();
+  ethanol.addBond(c1, c2, 1);
+  ethanol.addBond(c2, oxygen, 1);
+  addHydrogens(ethanol, c1, 3);
+  addHydrogens(ethanol, c2, 2);
+  addHydrogens(ethanol, oxygen, 1);
+
+  EXPECT_EQ(writeBracket(ethanol), "[CH3][CH2][OH]");
+  EXPECT_EQ(writeImplicit(ethanol), "CCO");
+}
+
+namespace {
+
+/**
+ * A tetrahedral centre with four substituents at alternating cube corners.
+ * Listing them in the order @a first .. @a fourth reproduces the neighbour
+ * order the writer will use, since the centre is atom zero and the bonds are
+ * added in that order.
+ *
+ * @param mirror Reflect the coordinates, giving the opposite enantiomer with
+ * an otherwise identical molecule and an identical neighbour order.
+ */
+Molecule tetrahedralCenter(unsigned char first, unsigned char second,
+                           unsigned char third, unsigned char fourth,
+                           bool mirror = false)
+{
+  Molecule mol;
+  Index center = mol.addAtom(6, Vector3(0.0, 0.0, 0.0)).index();
+  const Vector3 corners[4] = { Vector3(1.0, 1.0, 1.0), Vector3(1.0, -1.0, -1.0),
+                               Vector3(-1.0, 1.0, -1.0),
+                               Vector3(-1.0, -1.0, 1.0) };
+  const unsigned char elements[4] = { first, second, third, fourth };
+  const double flip = mirror ? -1.0 : 1.0;
+  for (int i = 0; i < 4; ++i) {
+    const Vector3 corner(flip * corners[i].x(), corners[i].y(), corners[i].z());
+    mol.addBond(center, mol.addAtom(elements[i], corner).index(), 1);
+  }
+  return mol;
+}
+
+} // namespace
+
+TEST(SmilesTest, tetrahedralChirality)
+{
+  // F, Cl, Br, I at the four corners in written order.
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(9, 17, 35, 53)),
+            "[C@](F)(Cl)(Br)I");
+
+  // The mirror image is the same graph written the same way, so only the
+  // chirality symbol may differ.
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(9, 17, 35, 53, true)),
+            "[C@@](F)(Cl)(Br)I");
+}
+
+TEST(SmilesTest, chiralityWithASuppressedHydrogen)
+{
+  // A folded hydrogen still occupies a slot in the neighbour ordering -- here
+  // the first, since the centre has no atom it was reached from.
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(1, 9, 17, 35)), "[C@H](F)(Cl)Br");
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(1, 9, 17, 35, true)),
+            "[C@@H](F)(Cl)Br");
+}
+
+TEST(SmilesTest, noChiralityWithoutFourDistinctSubstituents)
+{
+  // Two identical substituents: nothing stereogenic, so no "@" at all.
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(9, 9, 17, 35)), "C(F)(F)(Cl)Br");
+
+  // Two hydrogens fold away and are indistinguishable.
+  EXPECT_EQ(writeImplicit(tetrahedralCenter(1, 1, 17, 35)), "C(Cl)Br");
+}
+
+TEST(SmilesTest, noChiralityWithoutCoordinates)
+{
+  // Built without positions, so there is no handedness to read.
+  Molecule mol;
+  Index center = mol.addAtom(6).index();
+  for (unsigned char element : { 9, 17, 35, 53 })
+    mol.addBond(center, mol.addAtom(element).index(), 1);
+
+  EXPECT_EQ(writeImplicit(mol), "C(F)(Cl)(Br)I");
+}
+
+namespace {
+
+/**
+ * Planar 1,2-difluoroethene. @a trans puts the two fluorines on opposite sides
+ * of the double bond; otherwise they sit on the same side.
+ */
+Molecule difluoroethene(bool trans)
+{
+  Molecule mol;
+  const double side = trans ? -1.0 : 1.0;
+  Index c1 = mol.addAtom(6, Vector3(0.0, 0.0, 0.0)).index();
+  Index f1 = mol.addAtom(9, Vector3(-0.67, 1.03, 0.0)).index();
+  Index h1 = mol.addAtom(1, Vector3(-0.67, -1.03, 0.0)).index();
+  Index c2 = mol.addAtom(6, Vector3(1.33, 0.0, 0.0)).index();
+  Index f2 = mol.addAtom(9, Vector3(2.0, side * 1.03, 0.0)).index();
+  Index h2 = mol.addAtom(1, Vector3(2.0, side * -1.03, 0.0)).index();
+
+  mol.addBond(c1, f1, 1);
+  mol.addBond(c1, h1, 1);
+  mol.addBond(c1, c2, 2);
+  mol.addBond(c2, f2, 1);
+  mol.addBond(c2, h2, 1);
+  return mol;
+}
+
+} // namespace
+
+TEST(SmilesTest, cisTransMarkers)
+{
+  // The markers sit on the single bonds either side of the double bond, and
+  // opposite senses mean the substituents are on opposite sides.
+  EXPECT_EQ(writeImplicit(difluoroethene(true)), "C(/F)=C\\F");
+  EXPECT_EQ(writeImplicit(difluoroethene(false)), "C(/F)=C/F");
+}
+
+TEST(SmilesTest, noCisTransWithoutTwoDistinctEnds)
+{
+  // 1,1-difluoroethene: one end carries two fluorines, so there is no
+  // cis/trans relationship to describe.
+  Molecule mol;
+  Index c1 = mol.addAtom(6, Vector3(0.0, 0.0, 0.0)).index();
+  Index c2 = mol.addAtom(6, Vector3(1.33, 0.0, 0.0)).index();
+  mol.addBond(c1, c2, 2);
+  mol.addBond(c1, mol.addAtom(9, Vector3(-0.67, 1.03, 0.0)).index(), 1);
+  mol.addBond(c1, mol.addAtom(9, Vector3(-0.67, -1.03, 0.0)).index(), 1);
+  mol.addBond(c2, mol.addAtom(1, Vector3(2.0, 1.03, 0.0)).index(), 1);
+  mol.addBond(c2, mol.addAtom(1, Vector3(2.0, -1.03, 0.0)).index(), 1);
+
+  const std::string smiles = writeImplicit(mol);
+  EXPECT_EQ(smiles.find('/'), std::string::npos) << smiles;
+  EXPECT_EQ(smiles.find('\\'), std::string::npos) << smiles;
+}
+
+TEST(SmilesTest, noCisTransWithoutCoordinates)
+{
+  Molecule mol;
+  Index c1 = mol.addAtom(6).index();
+  Index c2 = mol.addAtom(6).index();
+  mol.addBond(c1, mol.addAtom(9).index(), 1);
+  mol.addBond(c1, mol.addAtom(1).index(), 1);
+  mol.addBond(c1, c2, 2);
+  mol.addBond(c2, mol.addAtom(9).index(), 1);
+  mol.addBond(c2, mol.addAtom(1).index(), 1);
+
+  EXPECT_EQ(writeImplicit(mol), "C(F)=CF");
 }
 
 TEST(SmilesTest, formatIsWriteOnly)
@@ -321,8 +590,9 @@ TEST(SmilesTest, formatOptions)
   EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]\n");
 
   SmilesFormat defaults;
-  std::string unimplemented;
-  EXPECT_FALSE(defaults.writeString(unimplemented, mol));
+  std::string implicit;
+  EXPECT_TRUE(defaults.writeString(implicit, mol)) << defaults.error();
+  EXPECT_EQ(implicit, "C\n");
 }
 
 TEST(SmilesTest, structuralInvariantsOnRealMolecule)

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -14,6 +14,7 @@
 #include <avogadro/io/smilesformat.h>
 #include <avogadro/io/smileswriter.h>
 
+#include <cmath>
 #include <map>
 #include <set>
 #include <string>
@@ -490,6 +491,103 @@ TEST(SmilesTest, noChiralityWithoutFourDistinctSubstituents)
 
   // Two hydrogens fold away and are indistinguishable.
   EXPECT_EQ(writeImplicit(tetrahedralCenter(1, 1, 17, 35)), "C(Cl)Br");
+}
+
+namespace {
+
+/**
+ * A puckered six-membered carbon ring, with the substituent on @a first and
+ * @a second placed above or below the mean plane according to @a firstUp and
+ * @a secondUp. Every other ring position carries two hydrogens.
+ */
+Molecule substitutedCyclohexane(unsigned char firstElement, Index first,
+                                bool firstUp, unsigned char secondElement,
+                                Index second, bool secondUp)
+{
+  Molecule mol;
+  Index ring[6];
+  for (Index i = 0; i < 6; ++i) {
+    const double angle = 2.0 * M_PI * static_cast<double>(i) / 6.0;
+    // Alternating pucker, so the ring is not planar and the substituents have
+    // a real side to be on.
+    const double z = (i % 2 == 0) ? 0.25 : -0.25;
+    ring[i] =
+      mol.addAtom(6, Vector3(1.5 * cos(angle), 1.5 * sin(angle), z)).index();
+  }
+  for (Index i = 0; i < 6; ++i)
+    mol.addBond(ring[i], ring[(i + 1) % 6], 1);
+
+  for (Index i = 0; i < 6; ++i) {
+    const double angle = 2.0 * M_PI * static_cast<double>(i) / 6.0;
+    const bool substituted = (i == first) || (i == second);
+    const unsigned char element =
+      (i == first) ? firstElement : (i == second ? secondElement : 1);
+    const bool up = (i == first) ? firstUp : secondUp;
+
+    if (substituted) {
+      mol.addBond(
+        ring[i],
+        mol
+          .addAtom(element,
+                   Vector3(2.4 * cos(angle), 2.4 * sin(angle), up ? 1.0 : -1.0))
+          .index(),
+        1);
+      mol.addBond(ring[i],
+                  mol
+                    .addAtom(1, Vector3(1.7 * cos(angle), 1.7 * sin(angle),
+                                        up ? -1.0 : 1.0))
+                    .index(),
+                  1);
+    } else {
+      mol.addBond(
+        ring[i],
+        mol.addAtom(1, Vector3(2.4 * cos(angle), 2.4 * sin(angle), 1.0))
+          .index(),
+        1);
+      mol.addBond(
+        ring[i],
+        mol.addAtom(1, Vector3(1.7 * cos(angle), 1.7 * sin(angle), -1.0))
+          .index(),
+        1);
+    }
+  }
+  return mol;
+}
+
+bool hasChirality(const std::string& smiles)
+{
+  return smiles.find('@') != std::string::npos;
+}
+
+} // namespace
+
+TEST(SmilesTest, ringDependentStereocenters)
+{
+  // 4-methylcyclohexanol. Neither centre has four constitutionally different
+  // substituents -- the two ways round the ring are equivalent -- but the two
+  // together describe cis or trans, so both have to be written.
+  const std::string cis =
+    writeImplicit(substitutedCyclohexane(8, 0, true, 6, 3, true));
+  const std::string trans =
+    writeImplicit(substitutedCyclohexane(8, 0, true, 6, 3, false));
+
+  EXPECT_TRUE(hasChirality(cis)) << cis;
+  EXPECT_TRUE(hasChirality(trans)) << trans;
+  EXPECT_NE(cis, trans);
+}
+
+TEST(SmilesTest, noRingStereocenterWithoutAPartner)
+{
+  // Cyclohexanol has one such centre and no partner, so there is nothing for
+  // it to be cis or trans to and it is achiral.
+  Molecule mol = substitutedCyclohexane(8, 0, true, 1, 3, true);
+  const std::string smiles = writeImplicit(mol);
+  EXPECT_FALSE(hasChirality(smiles)) << smiles;
+
+  // Methylcyclohexane, likewise.
+  Molecule methyl = substitutedCyclohexane(6, 0, true, 1, 3, true);
+  const std::string methylSmiles = writeImplicit(methyl);
+  EXPECT_FALSE(hasChirality(methylSmiles)) << methylSmiles;
 }
 
 TEST(SmilesTest, noChiralityWithoutCoordinates)

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -9,7 +9,7 @@
 
 #include <avogadro/core/molecule.h>
 
-#include <avogadro/io/mdlformat.h>
+#include <avogadro/io/cmlformat.h>
 #include <avogadro/io/smilesformat.h>
 #include <avogadro/io/smileswriter.h>
 
@@ -19,23 +19,17 @@
 
 using Avogadro::Index;
 using Avogadro::Core::Molecule;
-using Avogadro::Io::MdlFormat;
+using Avogadro::Io::CmlFormat;
 using Avogadro::Io::SmilesFormat;
 using Avogadro::Io::SmilesWriter;
 
 namespace {
 
-/** A writer in the only mode implemented so far. */
-SmilesWriter mappedWriter()
+/** Write in the only mode implemented so far: mapped, explicit hydrogens. */
+std::string writeMapped(const Molecule& mol)
 {
   SmilesWriter writer;
   writer.setAtomMaps(true);
-  return writer;
-}
-
-std::string writeMapped(const Molecule& mol)
-{
-  SmilesWriter writer = mappedWriter();
   std::string smiles;
   EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
   return smiles;
@@ -269,10 +263,7 @@ TEST(SmilesTest, atomsWithoutAnElementSymbol)
 TEST(SmilesTest, emptyMolecule)
 {
   Molecule mol;
-  SmilesWriter writer = mappedWriter();
-  std::string smiles;
-  EXPECT_TRUE(writer.write(mol, smiles));
-  EXPECT_EQ(smiles, "");
+  EXPECT_EQ(writeMapped(mol), "");
 }
 
 TEST(SmilesTest, atomMapsImplyExplicitHydrogens)
@@ -336,10 +327,13 @@ TEST(SmilesTest, formatOptions)
 
 TEST(SmilesTest, structuralInvariantsOnRealMolecule)
 {
-  MdlFormat mdl;
+  // Caffeine rather than something acyclic: its fused rings are what give the
+  // ring closure invariant anything to check.
+  CmlFormat cml;
   Molecule mol;
   ASSERT_TRUE(
-    mdl.readFile(std::string(AVOGADRO_DATA) + "/data/sdf/ethane.mol", mol));
+    cml.readFile(std::string(AVOGADRO_DATA) + "/data/cml/caffeine.cml", mol));
+  ASSERT_GT(mol.bondCount(), mol.atomCount() - 1); // i.e. it has rings
 
   const std::string smiles = writeMapped(mol);
   EXPECT_TRUE(parenthesesBalanced(smiles)) << smiles;

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -13,12 +13,14 @@
 #include <avogadro/core/stereo.h>
 
 #include <avogadro/io/cmlformat.h>
+#include <avogadro/io/fileformatmanager.h>
 #include <avogadro/io/mdlformat.h>
 #include <avogadro/io/smilesformat.h>
 #include <avogadro/io/smileswriter.h>
 
 #include <cmath>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -30,6 +32,7 @@ using Avogadro::Io::CmlFormat;
 using Avogadro::Io::MdlFormat;
 using Avogadro::Io::SmilesFormat;
 using Avogadro::Io::SmilesWriter;
+namespace Io = Avogadro::Io;
 
 namespace {
 
@@ -838,6 +841,43 @@ TEST(SmilesTest, formatIsWriteOnly)
   SmilesFormat format;
   EXPECT_EQ(format.supportedOperations() & Avogadro::Io::FileFormat::Read, 0);
   EXPECT_NE(format.supportedOperations() & Avogadro::Io::FileFormat::Write, 0);
+}
+
+TEST(SmilesTest, registeredForWritingOnly)
+{
+  Io::FileFormatManager& manager = Io::FileFormatManager::instance();
+
+  // Asking for "smi" without a filter, as the copy and export paths do, has
+  // to reach the native writer.
+  std::unique_ptr<Io::FileFormat> anyUse(
+    manager.newFormatFromFileExtension("smi"));
+  ASSERT_NE(anyUse, nullptr);
+  EXPECT_EQ(anyUse->identifier(), "Avogadro: SMILES");
+
+  std::unique_ptr<Io::FileFormat> forWriting(manager.newFormatFromFileExtension(
+    "smi", Io::FileFormat::Write | Io::FileFormat::String));
+  ASSERT_NE(forWriting, nullptr);
+  EXPECT_EQ(forWriting->identifier(), "Avogadro: SMILES");
+
+  // Reading is deliberately not offered, so a SMILES reader -- Open Babel, in
+  // an application build -- is still the one that answers. Nothing registers
+  // one here, so there is no reader at all.
+  std::unique_ptr<Io::FileFormat> forReading(manager.newFormatFromFileExtension(
+    "smi", Io::FileFormat::Read | Io::FileFormat::String));
+  EXPECT_EQ(forReading, nullptr);
+}
+
+TEST(SmilesTest, writingThroughTheManager)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+
+  // What "Copy as SMILES" and a SMILES export both end up calling.
+  std::string smiles;
+  EXPECT_TRUE(
+    Io::FileFormatManager::instance().writeString(mol, smiles, "smi"));
+  EXPECT_EQ(smiles, "C\n");
 }
 
 TEST(SmilesTest, formatOptions)

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -10,7 +10,10 @@
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/vector.h>
 
+#include <avogadro/core/stereo.h>
+
 #include <avogadro/io/cmlformat.h>
+#include <avogadro/io/mdlformat.h>
 #include <avogadro/io/smilesformat.h>
 #include <avogadro/io/smileswriter.h>
 
@@ -23,6 +26,7 @@ using Avogadro::Index;
 using Avogadro::Vector3;
 using Avogadro::Core::Molecule;
 using Avogadro::Io::CmlFormat;
+using Avogadro::Io::MdlFormat;
 using Avogadro::Io::SmilesFormat;
 using Avogadro::Io::SmilesWriter;
 
@@ -666,6 +670,81 @@ TEST(SmilesTest, noCisTransWithoutCoordinates)
   mol.addBond(c2, mol.addAtom(1).index(), 1);
 
   EXPECT_EQ(writeImplicit(mol), "C(F)=CF");
+}
+
+namespace {
+
+/** trans-2-butene in two dimensions, with the given MDL bond stereo flag. */
+std::string buteneMol(const char* doubleBondStereo)
+{
+  return std::string("2-butene\n"
+                     "  Avogadro\n"
+                     "\n"
+                     "  4  3  0  0  0  0  0  0  0  0999 V2000\n"
+                     "    0.5000    0.8700    0.0000 C   0  0  0  0  0  0  0  "
+                     "0  0  0  0  0\n"
+                     "    1.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  "
+                     "0  0  0  0  0\n"
+                     "    2.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  "
+                     "0  0  0  0  0\n"
+                     "    2.5000   -0.8700    0.0000 C   0  0  0  0  0  0  0  "
+                     "0  0  0  0  0\n"
+                     "  1  2  1  0\n"
+                     "  2  3  2  ") +
+         doubleBondStereo + "\n  3  4  1  0\nM  END\n";
+}
+
+bool hasDirectionalBond(const std::string& smiles)
+{
+  return smiles.find('/') != std::string::npos ||
+         smiles.find('\\') != std::string::npos;
+}
+
+} // namespace
+
+TEST(SmilesTest, unspecifiedDoubleBondStereoIsNotInvented)
+{
+  // With the stereo column clear, the coordinates are the author's statement
+  // about configuration and get written out.
+  MdlFormat mdl;
+  Molecule defined;
+  ASSERT_TRUE(mdl.readString(buteneMol("0"), defined)) << mdl.error();
+  EXPECT_FALSE(Avogadro::Core::bondStereoUnspecified(defined, 1));
+
+  const std::string definedSmiles = writeImplicit(defined);
+  EXPECT_TRUE(hasDirectionalBond(definedSmiles)) << definedSmiles;
+
+  // Flag 3 is "cis or trans, either": the atoms still have coordinates, but
+  // the author declined to claim a configuration, so none may be written.
+  MdlFormat eitherMdl;
+  Molecule either;
+  ASSERT_TRUE(eitherMdl.readString(buteneMol("3"), either))
+    << eitherMdl.error();
+  EXPECT_TRUE(Avogadro::Core::bondStereoUnspecified(either, 1));
+
+  const std::string eitherSmiles = writeImplicit(either);
+  EXPECT_FALSE(hasDirectionalBond(eitherSmiles)) << eitherSmiles;
+}
+
+TEST(SmilesTest, unspecifiedMarkersFollowTheirBonds)
+{
+  // The markers live in the property map, so they have to survive editing.
+  MdlFormat mdl;
+  Molecule mol;
+  ASSERT_TRUE(mdl.readString(buteneMol("3"), mol)) << mdl.error();
+  ASSERT_TRUE(Avogadro::Core::bondStereoUnspecified(mol, 1));
+
+  // Removing a bond renumbers the rest -- Graph and PropertyMap both swap the
+  // last entry into the freed slot -- so the marker has to move with its bond
+  // rather than stay at index 1.
+  mol.removeBond(static_cast<Index>(0));
+
+  bool markedDoubleBond = false;
+  for (Index bond = 0; bond < mol.bondCount(); ++bond) {
+    if (mol.bondOrders()[bond] == 2)
+      markedDoubleBond = Avogadro::Core::bondStereoUnspecified(mol, bond);
+  }
+  EXPECT_TRUE(markedDoubleBond);
 }
 
 TEST(SmilesTest, formatIsWriteOnly)

--- a/tests/io/smilestest.cpp
+++ b/tests/io/smilestest.cpp
@@ -1,0 +1,348 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "iotests.h"
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/molecule.h>
+
+#include <avogadro/io/mdlformat.h>
+#include <avogadro/io/smilesformat.h>
+#include <avogadro/io/smileswriter.h>
+
+#include <map>
+#include <set>
+#include <string>
+
+using Avogadro::Index;
+using Avogadro::Core::Molecule;
+using Avogadro::Io::MdlFormat;
+using Avogadro::Io::SmilesFormat;
+using Avogadro::Io::SmilesWriter;
+
+namespace {
+
+/** A writer in the only mode implemented so far. */
+SmilesWriter mappedWriter()
+{
+  SmilesWriter writer;
+  writer.setAtomMaps(true);
+  return writer;
+}
+
+std::string writeMapped(const Molecule& mol)
+{
+  SmilesWriter writer = mappedWriter();
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
+  return smiles;
+}
+
+/** Attach @a count hydrogens to @a heavy with single bonds. */
+void addHydrogens(Molecule& mol, Index heavy, int count)
+{
+  for (int i = 0; i < count; ++i)
+    mol.addBond(heavy, mol.addAtom(1).index(), 1);
+}
+
+/** Parentheses balance, and never close more than were opened. */
+bool parenthesesBalanced(const std::string& smiles)
+{
+  int depth = 0;
+  for (char c : smiles) {
+    if (c == '(') {
+      ++depth;
+    } else if (c == ')') {
+      if (--depth < 0)
+        return false;
+    }
+  }
+  return depth == 0;
+}
+
+/** Every ring bond number in the string occurs an even number of times. */
+bool ringNumbersPaired(const std::string& smiles)
+{
+  std::map<int, int> counts;
+  for (size_t i = 0; i < smiles.size(); ++i) {
+    // Skip bracket contents, where digits are isotopes, charges and maps.
+    if (smiles[i] == '[') {
+      while (i < smiles.size() && smiles[i] != ']')
+        ++i;
+      continue;
+    }
+    if (smiles[i] == '%' && i + 2 < smiles.size()) {
+      counts[(smiles[i + 1] - '0') * 10 + (smiles[i + 2] - '0')] += 1;
+      i += 2;
+    } else if (smiles[i] >= '0' && smiles[i] <= '9') {
+      counts[smiles[i] - '0'] += 1;
+    }
+  }
+  for (const auto& entry : counts) {
+    if (entry.second % 2 != 0)
+      return false;
+  }
+  return true;
+}
+
+/** Each atom map class 1..atomCount appears exactly once. */
+bool everyAtomMapped(const std::string& smiles, Index atomCount)
+{
+  std::set<int> seen;
+  for (size_t i = 0; i < smiles.size(); ++i) {
+    if (smiles[i] != ':')
+      continue;
+    int value = 0;
+    size_t j = i + 1;
+    for (; j < smiles.size() && smiles[j] >= '0' && smiles[j] <= '9'; ++j)
+      value = value * 10 + (smiles[j] - '0');
+    if (j == i + 1)
+      return false; // A colon with no digits after it.
+    seen.insert(value);
+    i = j - 1;
+  }
+  if (seen.size() != atomCount)
+    return false;
+  return *seen.begin() == 1 && *seen.rbegin() == static_cast<int>(atomCount);
+}
+
+} // namespace
+
+TEST(SmilesTest, methane)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+
+  EXPECT_EQ(writeMapped(mol), "[C:1]([H:2])([H:3])([H:4])[H:5]");
+}
+
+TEST(SmilesTest, methaneWithoutMaps)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+
+  SmilesWriter writer;
+  writer.setHydrogenMode(SmilesWriter::HydrogenMode::Explicit);
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
+  EXPECT_EQ(smiles, "[C]([H])([H])([H])[H]");
+}
+
+TEST(SmilesTest, water)
+{
+  Molecule mol;
+  Index oxygen = mol.addAtom(8).index();
+  addHydrogens(mol, oxygen, 2);
+
+  EXPECT_EQ(writeMapped(mol), "[O:1]([H:2])[H:3]");
+}
+
+TEST(SmilesTest, formalCharge)
+{
+  Molecule mol;
+  Index nitrogen = mol.addAtom(7).index();
+  mol.setFormalCharge(nitrogen, 1);
+  addHydrogens(mol, nitrogen, 4);
+
+  EXPECT_EQ(writeMapped(mol), "[N+:1]([H:2])([H:3])([H:4])[H:5]");
+}
+
+TEST(SmilesTest, multipleCharge)
+{
+  Molecule mol;
+  Index magnesium = mol.addAtom(12).index();
+  mol.setFormalCharge(magnesium, 2);
+
+  EXPECT_EQ(writeMapped(mol), "[Mg+2:1]");
+
+  Molecule anion;
+  Index sulfur = anion.addAtom(16).index();
+  anion.setFormalCharge(sulfur, -2);
+
+  EXPECT_EQ(writeMapped(anion), "[S-2:1]");
+}
+
+TEST(SmilesTest, isotope)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+  mol.setIsotope(carbon, 13);
+  mol.setIsotope(1, 2);
+
+  EXPECT_EQ(writeMapped(mol), "[13C:1]([2H:2])([H:3])([H:4])[H:5]");
+}
+
+TEST(SmilesTest, bondOrders)
+{
+  Molecule mol;
+  Index first = mol.addAtom(6).index();
+  Index second = mol.addAtom(6).index();
+  mol.addBond(first, second, 2);
+  addHydrogens(mol, first, 2);
+  addHydrogens(mol, second, 2);
+
+  EXPECT_EQ(writeMapped(mol), "[C:1](=[C:2]([H:5])[H:6])([H:3])[H:4]");
+
+  Molecule triple;
+  Index a = triple.addAtom(6).index();
+  Index b = triple.addAtom(6).index();
+  triple.addBond(a, b, 3);
+
+  EXPECT_EQ(writeMapped(triple), "[C:1]#[C:2]");
+}
+
+TEST(SmilesTest, ringClosure)
+{
+  Molecule mol;
+  Index a = mol.addAtom(6).index();
+  Index b = mol.addAtom(6).index();
+  Index c = mol.addAtom(6).index();
+  mol.addBond(a, b, 1);
+  mol.addBond(b, c, 1);
+  mol.addBond(c, a, 1);
+
+  EXPECT_EQ(writeMapped(mol), "[C:1]1[C:2][C:3]1");
+}
+
+TEST(SmilesTest, ringClosureBondOrder)
+{
+  // The closing bond carries the double bond, so the symbol has to travel to
+  // the ring number rather than sitting between two atoms.
+  Molecule mol;
+  Index a = mol.addAtom(6).index();
+  Index b = mol.addAtom(6).index();
+  Index c = mol.addAtom(6).index();
+  Index d = mol.addAtom(6).index();
+  mol.addBond(a, b, 1);
+  mol.addBond(b, c, 1);
+  mol.addBond(c, d, 1);
+  mol.addBond(d, a, 2);
+
+  EXPECT_EQ(writeMapped(mol), "[C:1]=1[C:2][C:3][C:4]1");
+}
+
+TEST(SmilesTest, ringNumbersAreReused)
+{
+  // Two rings that do not overlap in the traversal should both use number 1.
+  Molecule mol;
+  for (int ring = 0; ring < 2; ++ring) {
+    Index base = mol.atomCount();
+    mol.addAtom(6);
+    mol.addAtom(6);
+    mol.addAtom(6);
+    mol.addBond(base, base + 1, 1);
+    mol.addBond(base + 1, base + 2, 1);
+    mol.addBond(base + 2, base, 1);
+  }
+
+  EXPECT_EQ(writeMapped(mol), "[C:1]1[C:2][C:3]1.[C:4]1[C:5][C:6]1");
+}
+
+TEST(SmilesTest, disconnectedComponents)
+{
+  Molecule mol;
+  mol.addAtom(11);
+  mol.addAtom(17);
+
+  EXPECT_EQ(writeMapped(mol), "[Na:1].[Cl:2]");
+}
+
+TEST(SmilesTest, atomsWithoutAnElementSymbol)
+{
+  // Dummy atoms, custom elements and InvalidElement all have to become the
+  // wildcard: Elements::symbol() answers "Xx" for them, which is not valid
+  // SMILES, and dropping them would leave a gap in the atom mapping.
+  Molecule mol;
+  mol.addAtom(0);
+  mol.addAtom(Avogadro::InvalidElement);
+  mol.addAtom(Avogadro::CustomElementMin);
+
+  EXPECT_EQ(writeMapped(mol), "[*:1].[*:2].[*:3]");
+}
+
+TEST(SmilesTest, emptyMolecule)
+{
+  Molecule mol;
+  SmilesWriter writer = mappedWriter();
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles));
+  EXPECT_EQ(smiles, "");
+}
+
+TEST(SmilesTest, atomMapsImplyExplicitHydrogens)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+
+  SmilesWriter writer;
+  writer.setHydrogenMode(SmilesWriter::HydrogenMode::Bracket);
+  writer.setAtomMaps(true);
+
+  EXPECT_EQ(writer.effectiveHydrogenMode(),
+            SmilesWriter::HydrogenMode::Explicit);
+
+  std::string smiles;
+  EXPECT_TRUE(writer.write(mol, smiles)) << writer.error();
+  EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]");
+}
+
+TEST(SmilesTest, unimplementedModesFailCleanly)
+{
+  Molecule mol;
+  mol.addAtom(6);
+
+  for (SmilesWriter::HydrogenMode mode :
+       { SmilesWriter::HydrogenMode::Implicit,
+         SmilesWriter::HydrogenMode::Bracket }) {
+    SmilesWriter writer;
+    writer.setHydrogenMode(mode);
+    std::string smiles;
+    EXPECT_FALSE(writer.write(mol, smiles));
+    EXPECT_FALSE(writer.error().empty());
+    EXPECT_EQ(smiles, "");
+  }
+}
+
+TEST(SmilesTest, formatIsWriteOnly)
+{
+  SmilesFormat format;
+  EXPECT_EQ(format.supportedOperations() & Avogadro::Io::FileFormat::Read, 0);
+  EXPECT_NE(format.supportedOperations() & Avogadro::Io::FileFormat::Write, 0);
+}
+
+TEST(SmilesTest, formatOptions)
+{
+  Molecule mol;
+  Index carbon = mol.addAtom(6).index();
+  addHydrogens(mol, carbon, 4);
+
+  SmilesFormat format;
+  format.setOptions("{\"atomMaps\": true}");
+  std::string smiles;
+  EXPECT_TRUE(format.writeString(smiles, mol)) << format.error();
+  EXPECT_EQ(smiles, "[C:1]([H:2])([H:3])([H:4])[H:5]\n");
+
+  SmilesFormat defaults;
+  std::string unimplemented;
+  EXPECT_FALSE(defaults.writeString(unimplemented, mol));
+}
+
+TEST(SmilesTest, structuralInvariantsOnRealMolecule)
+{
+  MdlFormat mdl;
+  Molecule mol;
+  ASSERT_TRUE(
+    mdl.readFile(std::string(AVOGADRO_DATA) + "/data/sdf/ethane.mol", mol));
+
+  const std::string smiles = writeMapped(mol);
+  EXPECT_TRUE(parenthesesBalanced(smiles)) << smiles;
+  EXPECT_TRUE(ringNumbersPaired(smiles)) << smiles;
+  EXPECT_TRUE(everyAtomMapped(smiles, mol.atomCount())) << smiles;
+}


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMILES import and export, supporting hydrogens, charges, isotopes, stereochemistry, rings, disconnected components, and atom mapping.
  * Added configurable hydrogen and aromatic output options.
  * Added “Copy As → Atom-Mapped SMILES.”
  * Added aromaticity perception, aromatic bond normalization, and unspecified stereochemistry support.
  * Added improved CML and MDL aromatic-bond handling.

* **Bug Fixes**
  * Improved selection handling, isotope preservation, and format-specific error reporting.

* **Tests**
  * Expanded coverage for SMILES, aromaticity, kekulization, CML, MDL, and molecule data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->