### PR TITLE
Fix bug with OB-3.2.x data directory not found

### DIFF
--- a/avogadro/qtgui/utilities.cpp
+++ b/avogadro/qtgui/utilities.cpp
@@ -6,11 +6,46 @@
 #include "utilities.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDir>
 #include <QtCore/QFileInfo>
 #include <QtCore/QProcessEnvironment>
 #include <QtCore/QStringList>
+#include <QtCore/QVersionNumber>
 
 namespace Avogadro::QtGui::Utilities {
+
+namespace {
+
+// Open Babel installs its data and plugins into a versioned directory, e.g.
+// "share/openbabel/3.2.0". An install tree that has been reused across Open
+// Babel updates can hold several of these, so take the highest version rather
+// than giving up. Returns an empty string if there are no versioned
+// directories under @a base.
+QString highestVersionedDirectory(const QString& base)
+{
+  QDir dir(base);
+  QStringList filters;
+  filters << "3.*"
+          << "2.*";
+
+  QString newest;
+  QVersionNumber newestVersion;
+  for (const QString& candidate : dir.entryList(filters, QDir::Dirs)) {
+    // Compare numerically, so that 3.10.0 sorts above 3.2.0.
+    QVersionNumber version = QVersionNumber::fromString(candidate);
+    if (newest.isEmpty() || newestVersion < version) {
+      newest = candidate;
+      newestVersion = version;
+    }
+  }
+
+  if (newest.isEmpty())
+    return QString();
+
+  return QDir::cleanPath(dir.absoluteFilePath(newest));
+}
+
+} // namespace
 
 QString libraryDirectory()
 {
@@ -20,6 +55,30 @@ QString libraryDirectory()
 QString dataDirectory()
 {
   return QString(AvogadroLibs_DATA_DIR);
+}
+
+QString openBabelDataDirectory()
+{
+#ifdef Q_OS_WIN32
+  return QDir::cleanPath(QCoreApplication::applicationDirPath() + "/data");
+#else
+  return highestVersionedDirectory(QCoreApplication::applicationDirPath() +
+                                   "/../share/openbabel");
+#endif
+}
+
+QString openBabelLibraryDirectory()
+{
+#ifdef Q_OS_WIN32
+  // The plugins are linked into the Open Babel library on Windows.
+  return QString();
+#else
+  QString base = QCoreApplication::applicationDirPath() + "/../lib/openbabel";
+  // Some configurations install the plugins unversioned, directly into the
+  // base directory.
+  QString versioned = highestVersionedDirectory(base);
+  return versioned.isEmpty() ? QDir::cleanPath(base) : versioned;
+#endif
 }
 
 QString findExecutablePath(QString program)

--- a/avogadro/qtgui/utilities.cpp
+++ b/avogadro/qtgui/utilities.cpp
@@ -12,6 +12,8 @@
 #include <QtCore/QStringList>
 #include <QtCore/QVersionNumber>
 
+#include <algorithm>
+
 namespace Avogadro::QtGui::Utilities {
 
 namespace {
@@ -23,7 +25,7 @@ namespace {
 // directories under @a base.
 QString highestVersionedDirectory(const QString& base)
 {
-  QDir dir(base);
+  const QDir dir(base);
   QStringList filters;
   filters << "3.*"
           << "2.*";
@@ -31,8 +33,16 @@ QString highestVersionedDirectory(const QString& base)
   QString newest;
   QVersionNumber newestVersion;
   for (const QString& candidate : dir.entryList(filters, QDir::Dirs)) {
+    // Only accept names that are entirely a version number, so that leftovers
+    // such as "3.1.1-backup" are skipped rather than parsed as "3.1.1".
+    const bool versionOnly =
+      std::all_of(candidate.cbegin(), candidate.cend(),
+                  [](QChar c) { return c.isDigit() || c == QLatin1Char('.'); });
+    if (!versionOnly)
+      continue;
+
     // Compare numerically, so that 3.10.0 sorts above 3.2.0.
-    QVersionNumber version = QVersionNumber::fromString(candidate);
+    const QVersionNumber version = QVersionNumber::fromString(candidate);
     if (newest.isEmpty() || newestVersion < version) {
       newest = candidate;
       newestVersion = version;
@@ -60,7 +70,11 @@ QString dataDirectory()
 QString openBabelDataDirectory()
 {
 #ifdef Q_OS_WIN32
-  return QDir::cleanPath(QCoreApplication::applicationDirPath() + "/data");
+  const QString dataDir =
+    QDir::cleanPath(QCoreApplication::applicationDirPath() + "/data");
+  // Callers treat an empty string as "not found", so don't hand back a path
+  // that isn't there.
+  return QDir(dataDir).exists() ? dataDir : QString();
 #else
   return highestVersionedDirectory(QCoreApplication::applicationDirPath() +
                                    "/../share/openbabel");
@@ -73,11 +87,16 @@ QString openBabelLibraryDirectory()
   // The plugins are linked into the Open Babel library on Windows.
   return QString();
 #else
-  QString base = QCoreApplication::applicationDirPath() + "/../lib/openbabel";
+  const QString base =
+    QCoreApplication::applicationDirPath() + "/../lib/openbabel";
+  const QString versioned = highestVersionedDirectory(base);
+  if (!versioned.isEmpty())
+    return versioned;
+
   // Some configurations install the plugins unversioned, directly into the
-  // base directory.
-  QString versioned = highestVersionedDirectory(base);
-  return versioned.isEmpty() ? QDir::cleanPath(base) : versioned;
+  // base directory. Only fall back to it if it actually exists.
+  const QDir baseDir(base);
+  return baseDir.exists() ? QDir::cleanPath(base) : QString();
 #endif
 }
 

--- a/avogadro/qtgui/utilities.h
+++ b/avogadro/qtgui/utilities.h
@@ -16,6 +16,12 @@ namespace Utilities {
 
 AVOGADROQTGUI_EXPORT QString libraryDirectory();
 AVOGADROQTGUI_EXPORT QString dataDirectory();
+//! \return the Open Babel data directory shipped alongside the application
+//! (suitable for BABEL_DATADIR), or an empty string if it cannot be found
+AVOGADROQTGUI_EXPORT QString openBabelDataDirectory();
+//! \return the Open Babel plugin directory shipped alongside the application
+//! (suitable for BABEL_LIBDIR), or an empty string if it cannot be found
+AVOGADROQTGUI_EXPORT QString openBabelLibraryDirectory();
 //! \return a fully-qualified path for a program or an empty string if not found
 AVOGADROQTGUI_EXPORT QString findExecutablePath(QString program);
 //! \return a list of all fully-qualified paths for programs that are found

--- a/avogadro/qtplugins/forcefield/obenergy.cpp
+++ b/avogadro/qtplugins/forcefield/obenergy.cpp
@@ -50,7 +50,7 @@ OBEnergy::OBEnergy(const std::string& method)
   // make sure we set the Open Babel variables for data files, leaving any
   // setting from the environment alone
   if (qgetenv("BABEL_DATADIR").isEmpty()) {
-    QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+    const QString dataDir = QtGui::Utilities::openBabelDataDirectory();
     if (!dataDir.isEmpty())
       qputenv("BABEL_DATADIR", dataDir.toLocal8Bit());
     else
@@ -58,7 +58,7 @@ OBEnergy::OBEnergy(const std::string& method)
   }
 
   if (qgetenv("BABEL_LIBDIR").isEmpty()) {
-    QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+    const QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
     if (!pluginDir.isEmpty())
       qputenv("BABEL_LIBDIR", pluginDir.toLocal8Bit());
   }

--- a/avogadro/qtplugins/forcefield/obenergy.cpp
+++ b/avogadro/qtplugins/forcefield/obenergy.cpp
@@ -7,6 +7,7 @@
 #include "obenergy.h"
 
 #include <avogadro/core/molecule.h>
+#include <avogadro/qtgui/utilities.h>
 
 #include <openbabel/babelconfig.h>
 
@@ -46,46 +47,21 @@ OBEnergy::OBEnergy(const std::string& method)
 {
   d = new Private;
 
-  // make sure we set the Open Babel variables for data files
-#ifdef _WIN32
-  QByteArray dataDir =
-    QString(QCoreApplication::applicationDirPath() + "/data").toLocal8Bit();
-  qputenv("BABEL_DATADIR", dataDir);
-#else
-  // check if BABEL_DATADIR is set in the environment
-  QStringList filters;
-  filters << "3.*"
-          << "2.*";
+  // make sure we set the Open Babel variables for data files, leaving any
+  // setting from the environment alone
   if (qgetenv("BABEL_DATADIR").isEmpty()) {
-    QDir dir(QCoreApplication::applicationDirPath() + "/../share/openbabel");
-    QStringList dirs = dir.entryList(filters);
-    if (dirs.size() == 1) {
-      // versioned data directory
-      QString dataDir = QCoreApplication::applicationDirPath() +
-                        "/../share/openbabel/" + dirs[0];
+    QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+    if (!dataDir.isEmpty())
       qputenv("BABEL_DATADIR", dataDir.toLocal8Bit());
-    } else {
+    else
       qDebug() << "Error, Open Babel data directory not found.";
-    }
   }
 
-  // Check if BABEL_LIBDIR is set
   if (qgetenv("BABEL_LIBDIR").isEmpty()) {
-    QDir dir(QCoreApplication::applicationDirPath() + "/../lib/openbabel");
-    QStringList dirs = dir.entryList(filters);
-    if (dirs.size() == 0) {
-      QString libDir =
-        QCoreApplication::applicationDirPath() + "/../lib/openbabel/";
-      qputenv("BABEL_LIBDIR", libDir.toLocal8Bit());
-    } else if (dirs.size() == 1) {
-      QString libDir =
-        QCoreApplication::applicationDirPath() + "/../lib/openbabel/" + dirs[0];
-      qputenv("BABEL_LIBDIR", libDir.toLocal8Bit());
-    } else {
-      qDebug() << "Error, Open Babel plugins directory not found.";
-    }
+    QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+    if (!pluginDir.isEmpty())
+      qputenv("BABEL_LIBDIR", pluginDir.toLocal8Bit());
   }
-#endif
   // Ensure the plugins are loaded
   OBPlugin::LoadAllPlugins();
 

--- a/avogadro/qtplugins/forcefield/obmmenergy.cpp
+++ b/avogadro/qtplugins/forcefield/obmmenergy.cpp
@@ -9,6 +9,8 @@
 
 #include <avogadro/io/cmlformat.h>
 
+#include <avogadro/qtgui/utilities.h>
+
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QScopedPointer>
@@ -142,31 +144,17 @@ void OBMMEnergy::setupProcess()
         QFileInfo(baseDir.absolutePath() + '/' + m_executable).exists()) {
       m_executable = baseDir.absolutePath() + '/' + m_executable;
       QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-#if defined(_WIN32)
-      env.insert("BABEL_DATADIR",
-                 QCoreApplication::applicationDirPath() + "/data");
-#else
-      QDir dir(QCoreApplication::applicationDirPath() + "/../share/openbabel");
-      QStringList filters;
-      filters << "3.*";
-      QStringList dirs = dir.entryList(filters);
-      if (dirs.size() == 1) {
-        env.insert("BABEL_DATADIR", QCoreApplication::applicationDirPath() +
-                                      "/../share/openbabel/" + dirs[0]);
-      } else {
+
+      QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+      if (!dataDir.isEmpty())
+        env.insert("BABEL_DATADIR", dataDir);
+      else
         qDebug() << "Error, Open Babel data directory not found.";
-      }
-      dir.setPath(QCoreApplication::applicationDirPath() + "/../lib/openbabel");
-      dirs = dir.entryList(filters);
-      if (dirs.size() == 1) {
-        env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
-                                     "/../lib/openbabel/" + dirs[0]);
-      } else {
-        env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
-                                     "/../lib/openbabel/");
-        qDebug() << "Error, Open Babel plugins directory not found.";
-      }
-#endif
+
+      QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+      if (!pluginDir.isEmpty())
+        env.insert("BABEL_LIBDIR", pluginDir);
+
       m_process->setProcessEnvironment(env);
     }
   }

--- a/avogadro/qtplugins/forcefield/obmmenergy.cpp
+++ b/avogadro/qtplugins/forcefield/obmmenergy.cpp
@@ -145,15 +145,20 @@ void OBMMEnergy::setupProcess()
       m_executable = baseDir.absolutePath() + '/' + m_executable;
       QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 
-      QString dataDir = QtGui::Utilities::openBabelDataDirectory();
-      if (!dataDir.isEmpty())
-        env.insert("BABEL_DATADIR", dataDir);
-      else
-        qDebug() << "Error, Open Babel data directory not found.";
+      // Leave any setting from the environment alone.
+      if (env.value("BABEL_DATADIR").isEmpty()) {
+        const QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+        if (!dataDir.isEmpty())
+          env.insert("BABEL_DATADIR", dataDir);
+        else
+          qDebug() << "Error, Open Babel data directory not found.";
+      }
 
-      QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
-      if (!pluginDir.isEmpty())
-        env.insert("BABEL_LIBDIR", pluginDir);
+      if (env.value("BABEL_LIBDIR").isEmpty()) {
+        const QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+        if (!pluginDir.isEmpty())
+          env.insert("BABEL_LIBDIR", pluginDir);
+      }
 
       m_process->setProcessEnvironment(env);
     }

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -5,6 +5,8 @@
 
 #include "obprocess.h"
 
+#include <avogadro/qtgui/utilities.h>
+
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
@@ -36,33 +38,17 @@ OBProcess::OBProcess(QObject* parent_)
         QFileInfo(baseDir.absolutePath() + '/' + m_obabelExecutable).exists()) {
       m_obabelExecutable = baseDir.absolutePath() + '/' + m_obabelExecutable;
       QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-#if defined(_WIN32)
-      env.insert("BABEL_DATADIR",
-                 QCoreApplication::applicationDirPath() + "/data");
-#else
-      QDir dir(QCoreApplication::applicationDirPath() + "/../share/openbabel");
-      QStringList filters;
-      filters << "3.*"
-              << "2.*";
-      QStringList dirs = dir.entryList(filters);
-      if (dirs.size() == 1) {
-        env.insert("BABEL_DATADIR", QCoreApplication::applicationDirPath() +
-                                      "/../share/openbabel/" + dirs[0]);
-      } else {
+
+      QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+      if (!dataDir.isEmpty())
+        env.insert("BABEL_DATADIR", dataDir);
+      else
         qDebug() << "Error, Open Babel data directory not found.";
-      }
-      dir.setPath(QCoreApplication::applicationDirPath() + "/../lib/openbabel");
-      dirs = dir.entryList(filters);
-      if (dirs.size() == 0) {
-        env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
-                                     "/../lib/openbabel/");
-      } else if (dirs.size() == 1) {
-        env.insert("BABEL_LIBDIR", QCoreApplication::applicationDirPath() +
-                                     "/../lib/openbabel/" + dirs[0]);
-      } else {
-        qDebug() << "Error, Open Babel plugins directory not found.";
-      }
-#endif
+
+      QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+      if (!pluginDir.isEmpty())
+        env.insert("BABEL_LIBDIR", pluginDir);
+
       m_process->setProcessEnvironment(env);
     }
   }

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -39,15 +39,20 @@ OBProcess::OBProcess(QObject* parent_)
       m_obabelExecutable = baseDir.absolutePath() + '/' + m_obabelExecutable;
       QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 
-      QString dataDir = QtGui::Utilities::openBabelDataDirectory();
-      if (!dataDir.isEmpty())
-        env.insert("BABEL_DATADIR", dataDir);
-      else
-        qDebug() << "Error, Open Babel data directory not found.";
+      // Leave any setting from the environment alone.
+      if (env.value("BABEL_DATADIR").isEmpty()) {
+        const QString dataDir = QtGui::Utilities::openBabelDataDirectory();
+        if (!dataDir.isEmpty())
+          env.insert("BABEL_DATADIR", dataDir);
+        else
+          qDebug() << "Error, Open Babel data directory not found.";
+      }
 
-      QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
-      if (!pluginDir.isEmpty())
-        env.insert("BABEL_LIBDIR", pluginDir);
+      if (env.value("BABEL_LIBDIR").isEmpty()) {
+        const QString pluginDir = QtGui::Utilities::openBabelLibraryDirectory();
+        if (!pluginDir.isEmpty())
+          env.insert("BABEL_LIBDIR", pluginDir);
+      }
 
       m_process->setProcessEnvironment(env);
     }


### PR DESCRIPTION
If more than one data directory was in an install, the code would ignore all of the (e.g. 3.1.1 and 3.2.0)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Open Babel data and plugin directories across Windows and Unix-based systems.
  * Automatically selects the highest compatible Open Babel version when multiple versions are installed.
  * Preserves existing Open Babel environment settings while providing reliable fallbacks.
  * Reports a clear error when required Open Babel data files cannot be located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->