### PR TITLE
Fix handling of several atom properties under edits

### DIFF
--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -663,7 +663,9 @@ Molecule::AtomType Molecule::addAtom(unsigned char number)
     m_elements.set(element_count - 1); // custom element
 
   m_layers.addAtomToActiveLayer(atomCount() - 1);
-  m_partialCharges.clear();
+  // The calculated results are per-atom, so a new atom invalidates them just
+  // as a removed atom does (see removeAtom()).
+  clearCalculatedResults();
   m_atomProperties.addEntry();
   return AtomType(this, static_cast<Index>(atomCount() - 1));
 }
@@ -948,7 +950,10 @@ Molecule::BondType Molecule::addBond(Index atom1, Index atom2,
   } else {
     m_bondOrders[index] = order;
   }
-  // any existing charges are invalidated
+  // Any existing charges are invalidated, but deliberately *not*
+  // clearCalculatedResults(): perceiveBondsSimple() adds bonds one at a time,
+  // and the player tool re-perceives connectivity on every animation frame
+  // when dynamic bonding is on (see clearBonds()).
   m_partialCharges.clear();
   return BondType(this, index);
 }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -676,6 +676,116 @@ Molecule::AtomType Molecule::addAtom(unsigned char number, Vector3 position3d)
   return addAtom(number); // Use virtual dispatch
 }
 
+namespace {
+
+// Every member touched below is indexed by atom, kept in step with
+// m_atomicNumbers and m_graph. Molecule::swapAtom(), Molecule::removeAtom(),
+// and Molecule::clearAtoms() must each handle every atom-indexed member: a
+// member that is added to the class but missed in one of the three is a
+// real bug (e.g. a label silently ending up on the wrong atom after a
+// removal). The helpers below let each member cost one line per function,
+// so the three function bodies can be written as parallel lists and a
+// member missing from one of them is visible by inspection. When a new
+// atom-indexed member is added to Molecule, add it to all three.
+//
+// "Handle" is not always "reindex". swapAtom() reindexes everything, since
+// swapping two indices relabels the same structure. removeAtom() changes the
+// structure, so anything computed *from* the structure -- forces, velocities,
+// normal modes, partial charges -- is dropped there instead; see the comment
+// in removeAtom(). Deciding which of the two a new member is, is the part
+// that needs thought.
+
+// Plain Array<T>, one entry per atom.
+template <typename T>
+void swapAtomEntry(Array<T>& values, Index a, Index b, Index max)
+{
+  using std::swap;
+  if (values.size() > max)
+    swap(values[a], values[b]);
+}
+
+template <typename T>
+void removeAtomEntry(Array<T>& values, Index index, Index atomCount)
+{
+  if (values.size() == atomCount)
+    values.swapAndPop(index);
+}
+
+// Nested Array<Array<T>>: the outer index is a conformer/trajectory frame
+// or a normal mode, the inner index is one entry per atom. Frames may
+// legitimately be empty or a different length than atomCount() (e.g. not
+// yet populated), so each frame is guarded individually rather than
+// assuming they all match.
+template <typename T>
+void swapAtomEntryFrames(Array<Array<T>>& frames, Index a, Index b, Index max)
+{
+  using std::swap;
+  for (auto& frame : frames) {
+    if (frame.size() > max)
+      swap(frame[a], frame[b]);
+  }
+}
+
+template <typename T>
+void removeAtomEntryFrames(Array<Array<T>>& frames, Index index,
+                           Index atomCount)
+{
+  for (auto& frame : frames) {
+    if (frame.size() == atomCount)
+      frame.swapAndPop(index);
+  }
+}
+
+// std::vector<bool>, one entry per atom. std::swap() on the vector<bool>
+// proxy reference is a well-known trap, so swap the two values explicitly.
+void swapAtomEntry(std::vector<bool>& values, Index a, Index b, Index max)
+{
+  if (values.size() > max) {
+    bool temp = values[a];
+    values[a] = values[b];
+    values[b] = temp;
+  }
+}
+
+// Eigen::VectorXd storing 3 entries (x, y, z) per atom, as used by
+// m_frozenAtomMask.
+void swapAtomMaskEntry(Eigen::VectorXd& values, Index a, Index b, Index max)
+{
+  auto ea = static_cast<Eigen::Index>(a);
+  auto eb = static_cast<Eigen::Index>(b);
+  if (values.rows() >= static_cast<Eigen::Index>(3 * (max + 1))) {
+    for (Eigen::Index i = 0; i < 3; ++i)
+      std::swap(values[3 * ea + i], values[3 * eb + i]);
+  }
+}
+
+void removeAtomMaskEntry(Eigen::VectorXd& values, Index index, Index atomCount)
+{
+  if (values.rows() == static_cast<Eigen::Index>(3 * atomCount)) {
+    auto eIndex = static_cast<Eigen::Index>(index);
+    Eigen::Index last = values.rows() - 3;
+    for (Eigen::Index i = 0; i < 3; ++i)
+      values[3 * eIndex + i] = values[last + i];
+    values.conservativeResize(values.rows() - 3);
+  }
+}
+
+// std::map<std::string, MatrixX>: one per-atom charge column per model.
+// removeAtom() deliberately clears this map instead of reindexing it, since
+// removing an atom invalidates any cached partial charges anyway.
+void swapAtomEntry(std::map<std::string, MatrixX>& models, Index a, Index b,
+                   Index max)
+{
+  using std::swap;
+  for (auto& model : models) {
+    if (static_cast<Index>(model.second.size()) > max)
+      swap(model.second(static_cast<Eigen::Index>(a), 0),
+           model.second(static_cast<Eigen::Index>(b), 0));
+  }
+}
+
+} // namespace
+
 void Molecule::swapBond(Index a, Index b)
 {
   // Allow Argument Dependent Lookup for swap
@@ -685,23 +795,31 @@ void Molecule::swapBond(Index a, Index b)
   swap(m_bondOrders[a], m_bondOrders[b]);
   m_bondProperties.swapEntries(a, b, bondCount());
 }
+
 void Molecule::swapAtom(Index a, Index b)
 {
+  Index max = a > b ? a : b;
+
+  // Atom-indexed members -- see the comment above the helpers in the
+  // anonymous namespace at the top of this file. Keep this list parallel
+  // with removeAtom() and clearAtoms().
+  swapAtomEntry(m_positions2d, a, b, max);
+  swapAtomEntry(m_positions3d, a, b, max);
+  swapAtomEntry(m_atomLabels, a, b, max);
+  swapAtomEntry(m_hybridizations, a, b, max);
+  swapAtomEntry(m_formalCharges, a, b, max);
+  swapAtomEntry(m_isotopes, a, b, max);
+  swapAtomEntry(m_forceVectors, a, b, max);
+  swapAtomEntry(m_colors, a, b, max);
+  swapAtomEntry(m_selectedAtoms, a, b, max);
+  swapAtomEntryFrames(m_coordinates3d, a, b, max);
+  swapAtomEntryFrames(m_velocities, a, b, max);
+  swapAtomEntryFrames(m_vibrationLx, a, b, max);
+  swapAtomMaskEntry(m_frozenAtomMask, a, b, max);
+  swapAtomEntry(m_partialCharges, a, b, max);
+
   // Allow Argument Dependent Lookup for swap
   using std::swap;
-
-  Index max = a > b ? a : b;
-  if (m_positions2d.size() > max)
-    swap(m_positions2d[a], m_positions2d[b]);
-  if (m_positions3d.size() > max)
-    swap(m_positions3d[a], m_positions3d[b]);
-  if (m_hybridizations.size() > max)
-    swap(m_hybridizations[a], m_hybridizations[b]);
-  if (m_formalCharges.size() > max)
-    swap(m_formalCharges[a], m_formalCharges[b]);
-  if (m_colors.size() > max)
-    swap(m_colors[a], m_colors[b]);
-
   swap(m_atomicNumbers[a], m_atomicNumbers[b]);
   m_graph.swapVertexIndices(a, b);
   m_layers.swapLayer(a, b);
@@ -712,16 +830,20 @@ bool Molecule::removeAtom(Index index)
 {
   if (index >= atomCount())
     return false;
-  if (m_positions2d.size() == atomCount())
-    m_positions2d.swapAndPop(index);
-  if (m_positions3d.size() == atomCount())
-    m_positions3d.swapAndPop(index);
-  if (m_hybridizations.size() == atomCount())
-    m_hybridizations.swapAndPop(index);
-  if (m_formalCharges.size() == atomCount())
-    m_formalCharges.swapAndPop(index);
-  if (m_colors.size() == atomCount())
-    m_colors.swapAndPop(index);
+
+  // Atom-indexed members -- see the comment above the helpers in the
+  // anonymous namespace at the top of this file. Keep this list parallel
+  // with swapAtom() and clearAtoms(). These must all run before
+  // m_atomicNumbers (and therefore atomCount()) is updated below.
+  removeAtomEntry(m_positions2d, index, atomCount());
+  removeAtomEntry(m_positions3d, index, atomCount());
+  removeAtomEntry(m_atomLabels, index, atomCount());
+  removeAtomEntry(m_hybridizations, index, atomCount());
+  removeAtomEntry(m_formalCharges, index, atomCount());
+  removeAtomEntry(m_isotopes, index, atomCount());
+  removeAtomEntry(m_colors, index, atomCount());
+  removeAtomEntryFrames(m_coordinates3d, index, atomCount());
+  removeAtomMaskEntry(m_frozenAtomMask, index, atomCount());
 
   if (m_selectedAtoms.size() == atomCount()) {
     // swap and pop on std::vector<bool>
@@ -731,7 +853,14 @@ bool Molecule::removeAtom(Index index)
     m_selectedAtoms.pop_back();
   }
 
-  m_partialCharges.clear();
+  // Losing an atom makes this a different molecule, so anything calculated
+  // from the old one goes rather than being reindexed. Contrast the members
+  // above, which are either the structure itself or user state about it
+  // (labels, colours, selection, frozen atoms) and do follow their atoms.
+  //
+  // swapAtom() reindexes instead, and is right to: swapping two indices
+  // relabels the same structure rather than changing it.
+  clearCalculatedResults();
   m_atomProperties.removeEntry(index, atomCount());
   removeBonds(index);
 
@@ -766,27 +895,35 @@ bool Molecule::removeAtom(const AtomType& atom_)
 
 void Molecule::clearAtoms()
 {
+  // Atom-indexed members -- see the comment above the helpers in the
+  // anonymous namespace at the top of this file. Keep this list parallel
+  // with swapAtom() and removeAtom().
   m_positions2d.clear();
   m_positions3d.clear();
   m_atomLabels.clear();
   m_hybridizations.clear();
   m_formalCharges.clear();
+  m_isotopes.clear();
+  m_forceVectors.clear();
   m_colors.clear();
+  m_selectedAtoms.clear();
+  m_coordinates3d.clear();
+  m_frozenAtomMask.resize(0);
+
+  // With no atoms left there is nothing for any calculated result to be about.
+  clearCalculatedResults();
+
   m_atomicNumbers.clear();
   m_bondOrders.clear();
   m_bondLabels.clear();
   m_residueLabels.clear();
   m_graph.clear();
-  m_partialCharges.clear();
   m_atomProperties.clear();
   m_bondProperties.clear();
   m_residues.clear();
   m_residueProperties.clear();
-  m_coordinates3d.clear();
   m_conformerProperties.clear();
-  m_velocities.clear();
   m_timesteps.clear();
-  m_selectedAtoms.clear();
   m_layers.clear();
   m_elements.reset();
 }
@@ -836,6 +973,18 @@ size_t calcNlogN(size_t n)
   return n * aproxLog;
 }
 
+void Molecule::clearCalculatedResults()
+{
+  m_partialCharges.clear();
+  m_forceVectors.clear();
+  m_velocities.clear();
+  m_vibrationLx.clear();
+  m_vibrationFrequencies.clear();
+  m_vibrationIRIntensities.clear();
+  m_vibrationRamanIntensities.clear();
+  m_spectra.clear();
+}
+
 bool Molecule::removeBond(Index index)
 {
   if (index >= bondCount())
@@ -843,7 +992,9 @@ bool Molecule::removeBond(Index index)
   m_bondProperties.removeEntry(index, bondCount());
   m_graph.removeEdge(index);
   m_bondOrders.swapAndPop(index);
-  m_partialCharges.clear();
+  // Connectivity is part of what was calculated from, so a bond going away
+  // invalidates the results just as an atom going away does.
+  clearCalculatedResults();
   return true;
 }
 
@@ -868,6 +1019,13 @@ void Molecule::clearBonds()
   m_bondProperties.clear();
   m_graph.removeEdges();
   m_graph.setSize(atomCount());
+
+  // Deliberately *not* clearCalculatedResults(), unlike removeBond(). This is
+  // used as "re-perceive connectivity" rather than as a structural edit: the
+  // player tool calls it with perceiveBondsSimple() on every animation frame
+  // when dynamic bonding is on, so dropping the vibrations here would destroy
+  // the normal modes being animated. Partial charges are cleared because they
+  // depend directly on bond orders and are cheap to recompute.
   m_partialCharges.clear();
 }
 

--- a/avogadro/core/molecule.h
+++ b/avogadro/core/molecule.h
@@ -970,6 +970,18 @@ public:
   // channge the Atom index position
   void swapAtom(Index a, Index b);
 
+  /**
+   * Drop everything that was calculated from the structure -- partial
+   * charges, forces, velocities, normal modes and spectra. Call this from
+   * any edit that changes which atoms or bonds exist: those results describe
+   * the molecule as it was, and after such an edit it is not that molecule.
+   *
+   * Reindexing them instead would keep the arrays the right length while the
+   * numbers went on describing something that no longer exists, which is the
+   * worse failure because nothing looks wrong.
+   */
+  void clearCalculatedResults();
+
   std::list<Index> getAtomsAtLayer(size_t layer);
 
   Layer& layer();

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -495,6 +495,337 @@ TEST_F(MoleculeTest, formulaCompositionIsotopes)
   EXPECT_EQ(comp["C"], 1);
 }
 
+TEST_F(MoleculeTest, isotopesFollowTheirAtoms)
+{
+  // The isotope array is allocated lazily, by the first setIsotope() call, so
+  // it is the one per-atom array that is easy to leave out of the bookkeeping
+  // every other one gets.
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+  molecule.setIsotope(2, 13);
+  molecule.setIsotope(3, 14);
+
+  // removeAtom() swaps the last atom into the hole, so atom 3's isotope has
+  // to travel with it.
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_EQ(molecule.isotope(0), 0);
+  EXPECT_EQ(molecule.isotope(1), 14);
+  EXPECT_EQ(molecule.isotope(2), 13);
+
+  // And clearing must not leave the old isotopes behind for whatever atoms
+  // are added next.
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_EQ(molecule.isotope(0), 0);
+}
+
+TEST_F(MoleculeTest, atomLabelsFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+  molecule.setAtomLabel(0, "zero");
+  molecule.setAtomLabel(1, "one");
+  molecule.setAtomLabel(2, "two");
+  molecule.setAtomLabel(3, "three");
+
+  // removeAtom() swaps the last atom into the hole, so atom 3's label has
+  // to travel with it.
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_EQ(molecule.atomLabel(0), "zero");
+  EXPECT_EQ(molecule.atomLabel(1), "three");
+  EXPECT_EQ(molecule.atomLabel(2), "two");
+
+  molecule.swapAtom(0, 2);
+  EXPECT_EQ(molecule.atomLabel(0), "two");
+  EXPECT_EQ(molecule.atomLabel(2), "zero");
+
+  // And clearing must not leave the old labels behind for whatever atoms
+  // are added next.
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_EQ(molecule.atomLabel(0), "");
+}
+
+TEST_F(MoleculeTest, forceVectorsFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+  molecule.setForceVector(0, Vector3(1, 0, 0));
+  molecule.setForceVector(1, Vector3(2, 0, 0));
+  molecule.setForceVector(2, Vector3(3, 0, 0));
+  molecule.setForceVector(3, Vector3(4, 0, 0));
+
+  // A swap relabels the same structure, so the forces still describe it.
+  molecule.swapAtom(0, 2);
+  EXPECT_EQ(molecule.forceVector(0), Vector3(3, 0, 0));
+  EXPECT_EQ(molecule.forceVector(2), Vector3(1, 0, 0));
+
+  // Removing an atom does not: these forces were computed for a geometry
+  // that no longer exists, so they are dropped rather than reindexed.
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_TRUE(molecule.forceVectors().empty());
+
+  // Vector3() is an uninitialized Eigen fixed-size vector, not a zero
+  // vector, so forceVector() past the end of a shorter-than-atomCount array
+  // is not comparable to a specific value; what matters is that the array
+  // itself was actually cleared rather than left with the old atoms' data.
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_TRUE(molecule.forceVectors().empty());
+}
+
+TEST_F(MoleculeTest, selectedAtomsFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+  molecule.setAtomSelected(0, false);
+  molecule.setAtomSelected(1, false);
+  molecule.setAtomSelected(2, false);
+  molecule.setAtomSelected(3, true);
+
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_FALSE(molecule.atomSelected(0));
+  EXPECT_TRUE(molecule.atomSelected(1)); // former atom 3
+  EXPECT_FALSE(molecule.atomSelected(2));
+
+  // swapAtom() was the one place this was missing: the selection is a
+  // std::vector<bool>, and std::swap() on its proxy references is unsafe.
+  molecule.swapAtom(0, 1);
+  EXPECT_TRUE(molecule.atomSelected(0));
+  EXPECT_FALSE(molecule.atomSelected(1));
+
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_FALSE(molecule.atomSelected(0));
+}
+
+TEST_F(MoleculeTest, frozenAtomMaskFollowsAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+
+  // give each atom a distinct per-axis pattern so a misassignment of the
+  // 3-entries-per-atom mask cannot pass by coincidence
+  molecule.setFrozenAtomAxis(0, 0, true); // atom0: x only
+  molecule.setFrozenAtomAxis(1, 1, true); // atom1: y only
+  molecule.setFrozenAtomAxis(2, 0, true);
+  molecule.setFrozenAtomAxis(2, 1, true); // atom2: x and y
+  molecule.setFrozenAtom(3, true);        // atom3: x, y and z
+
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_TRUE(molecule.frozenAtomAxis(0, 0));
+  EXPECT_FALSE(molecule.frozenAtomAxis(0, 1));
+  EXPECT_TRUE(molecule.frozenAtom(1)); // former atom 3
+  EXPECT_TRUE(molecule.frozenAtomAxis(2, 0));
+  EXPECT_TRUE(molecule.frozenAtomAxis(2, 1));
+  EXPECT_FALSE(molecule.frozenAtomAxis(2, 2));
+
+  molecule.swapAtom(0, 2);
+  EXPECT_TRUE(molecule.frozenAtomAxis(0, 0));
+  EXPECT_TRUE(molecule.frozenAtomAxis(0, 1));
+  EXPECT_TRUE(molecule.frozenAtomAxis(2, 0));
+  EXPECT_FALSE(molecule.frozenAtomAxis(2, 1));
+
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_FALSE(molecule.frozenAtom(0));
+}
+
+TEST_F(MoleculeTest, coordinates3dFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+
+  Array<Vector3> frame0;
+  frame0.push_back(Vector3(0, 0, 0));
+  frame0.push_back(Vector3(1, 0, 0));
+  frame0.push_back(Vector3(2, 0, 0));
+  frame0.push_back(Vector3(3, 0, 0));
+  molecule.setCoordinate3d(frame0, 0);
+
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  Array<Vector3> after = molecule.coordinate3d(0);
+  ASSERT_EQ(after.size(), static_cast<size_t>(3));
+  EXPECT_EQ(after[0], Vector3(0, 0, 0));
+  EXPECT_EQ(after[1], Vector3(3, 0, 0)); // former atom 3
+  EXPECT_EQ(after[2], Vector3(2, 0, 0));
+
+  molecule.swapAtom(0, 2);
+  after = molecule.coordinate3d(0);
+  EXPECT_EQ(after[0], Vector3(2, 0, 0));
+  EXPECT_EQ(after[2], Vector3(0, 0, 0));
+
+  // clearAtoms() already drops every stored frame outright.
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_EQ(molecule.coordinate3dCount(), static_cast<size_t>(0));
+}
+
+TEST_F(MoleculeTest, velocitiesFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+
+  Array<Vector3> vel0;
+  vel0.push_back(Vector3(0, 1, 0));
+  vel0.push_back(Vector3(1, 1, 0));
+  vel0.push_back(Vector3(2, 1, 0));
+  vel0.push_back(Vector3(3, 1, 0));
+  molecule.setVelocities(vel0, 0);
+
+  // A swap relabels the same structure, so the velocities still describe it.
+  molecule.swapAtom(0, 2);
+  Array<Vector3> after = molecule.velocities(0);
+  ASSERT_EQ(after.size(), static_cast<size_t>(4));
+  EXPECT_EQ(after[0], Vector3(2, 1, 0));
+  EXPECT_EQ(after[2], Vector3(0, 1, 0));
+
+  // Removing an atom does not: these velocities belong to a geometry that no
+  // longer exists, so they are dropped rather than reindexed.
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_TRUE(molecule.velocities(0).empty());
+
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_TRUE(molecule.velocities(0).empty());
+}
+
+TEST_F(MoleculeTest, vibrationLxFollowsAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+
+  Array<Array<Vector3>> modes(1);
+  modes[0].push_back(Vector3(0, 0, 1));
+  modes[0].push_back(Vector3(1, 0, 1));
+  modes[0].push_back(Vector3(2, 0, 1));
+  modes[0].push_back(Vector3(3, 0, 1));
+  molecule.setVibrationLx(modes);
+
+  // A swap relabels the same structure, so the modes still describe it.
+  molecule.swapAtom(0, 2);
+  Array<Vector3> mode0 = molecule.vibrationLx(0);
+  ASSERT_EQ(mode0.size(), static_cast<size_t>(4));
+  EXPECT_EQ(mode0[0], Vector3(2, 0, 1));
+  EXPECT_EQ(mode0[2], Vector3(0, 0, 1));
+
+  // Removing an atom makes the modes meaningless -- they were calculated for
+  // a different molecular structure -- so they are dropped, along with the
+  // frequencies and intensities that go with them, rather than reindexed.
+  molecule.setVibrationFrequencies(Array<double>(1, 1600.0));
+  molecule.setVibrationIRIntensities(Array<double>(1, 12.0));
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_EQ(molecule.atomCount(), 3);
+  EXPECT_TRUE(molecule.vibrationLx(0).empty());
+  EXPECT_TRUE(molecule.vibrationFrequencies().empty());
+  EXPECT_TRUE(molecule.vibrationIRIntensities().empty());
+
+  // And with no atoms left there is nothing for modes to describe either.
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_TRUE(molecule.vibrationLx(0).empty());
+}
+
+TEST_F(MoleculeTest, partialChargesFollowTheirAtoms)
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+
+  MatrixX charges(4, 1);
+  charges << 1.0, 2.0, 3.0, 4.0;
+  molecule.setPartialCharges("test", charges);
+
+  // swapAtom() must reindex every charge model along with the atoms.
+  molecule.swapAtom(0, 2);
+  MatrixX swapped = molecule.partialCharges("test");
+  ASSERT_EQ(swapped.rows(), 4);
+  EXPECT_DOUBLE_EQ(swapped(0, 0), 3.0);
+  EXPECT_DOUBLE_EQ(swapped(1, 0), 2.0);
+  EXPECT_DOUBLE_EQ(swapped(2, 0), 1.0);
+  EXPECT_DOUBLE_EQ(swapped(3, 0), 4.0);
+
+  // removeAtom() deliberately clears partial charges instead of reindexing
+  // them: any change to the atom set invalidates cached charge models.
+  ASSERT_TRUE(molecule.removeAtom(1));
+  EXPECT_TRUE(molecule.partialChargeTypes().empty());
+
+  molecule.setPartialCharges("test2",
+                             MatrixX::Constant(molecule.atomCount(), 1, 5.0));
+  molecule.clearAtoms();
+  molecule.addAtom(6);
+  EXPECT_TRUE(molecule.partialChargeTypes().empty());
+}
+
+/** Build a molecule carrying a spectrum, for the tests below. */
+static Molecule moleculeWithSpectra()
+{
+  Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(6);
+  molecule.addBond(0, 1, 1);
+  molecule.addBond(1, 2, 1);
+  MatrixX spectrum(2, 2);
+  spectrum << 1600.0, 12.0, 3000.0, 40.0;
+  molecule.setSpectra("IR", spectrum);
+  return molecule;
+}
+
+TEST_F(MoleculeTest, spectraDoNotSurviveStructuralEdits)
+{
+  // A spectrum describes one molecule. Any edit that changes which atoms or
+  // bonds exist makes it a different molecule, so the spectrum is dropped
+  // rather than left attached to something it does not describe.
+  Molecule removingAnAtom = moleculeWithSpectra();
+  ASSERT_FALSE(removingAnAtom.spectraTypes().empty());
+  ASSERT_TRUE(removingAnAtom.removeAtom(3));
+  EXPECT_TRUE(removingAnAtom.spectraTypes().empty());
+
+  Molecule removingABond = moleculeWithSpectra();
+  ASSERT_TRUE(removingABond.removeBond(0));
+  EXPECT_TRUE(removingABond.spectraTypes().empty());
+
+  Molecule cleared = moleculeWithSpectra();
+  cleared.clearAtoms();
+  EXPECT_TRUE(cleared.spectraTypes().empty());
+}
+
+TEST_F(MoleculeTest, clearBondsKeepsCalculatedResults)
+{
+  // clearBonds() is "re-perceive connectivity", not a structural edit: the
+  // player tool pairs it with perceiveBondsSimple() on every animation frame
+  // when dynamic bonding is on. Dropping the vibrations there would destroy
+  // the very normal modes being animated, so it must not.
+  Molecule molecule = moleculeWithSpectra();
+  molecule.setVibrationFrequencies(Array<double>(1, 1600.0));
+  Array<Array<Vector3>> modes(1);
+  for (int i = 0; i < 4; ++i)
+    modes[0].push_back(Vector3(0, 0, 1));
+  molecule.setVibrationLx(modes);
+
+  molecule.clearBonds();
+  molecule.perceiveBondsSimple();
+
+  EXPECT_FALSE(molecule.spectraTypes().empty());
+  EXPECT_FALSE(molecule.vibrationFrequencies().empty());
+  EXPECT_EQ(molecule.vibrationLx(0).size(), static_cast<size_t>(4));
+}
+
 TEST_F(MoleculeTest, formulaCompositionUnitCellCorner)
 {
   Molecule molecule;


### PR DESCRIPTION
Also invalidate spectra under edits

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved molecule editing so atom-associated information—such as labels, isotopes, coordinates, forces, and charges—remains correctly synchronized when atoms are reordered or removed.
  * Added a way to clear calculated molecular results, including partial charges, forces, vibrations, and spectra.
* **Bug Fixes**
  * Atom and bond edits now reliably invalidate results that are no longer valid, while bond clearing preserves compatible vibrational and spectral data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->