### PR TITLE
Fix conformers with Open Babel via CML

### DIFF
--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -61,6 +61,8 @@ public:
         success = atoms();
       if (success)
         success = bonds();
+      if (success)
+        success = conformers();
     } else {
       error += "Error, no molecule node found.";
       success = false;
@@ -386,6 +388,94 @@ public:
         return false;
       }
     }
+
+    return true;
+  }
+
+  // Reads the 3D geometry of @a node into @a positions, checking that the node
+  // describes the molecule that has already been parsed. Returns false if the
+  // atoms differ in count, element, or order, or if any of them lack a 3D
+  // position -- in those cases the node is a different molecule, not another
+  // geometry of this one.
+  bool geometry(const xml_node& node, Array<Vector3>& positions) const
+  {
+    xml_node atomArray = node.child("atomArray");
+    if (!atomArray)
+      return false;
+
+    positions.reserve(molecule->atomCount());
+
+    Index index = 0;
+    for (xml_node atomNode = atomArray.child("atom"); atomNode;
+         atomNode = atomNode.next_sibling("atom")) {
+      if (index >= molecule->atomCount())
+        return false;
+
+      // The atoms have to line up with the first molecule, or the coordinates
+      // would be applied to the wrong atoms.
+      xml_attribute elementAtt = atomNode.attribute("elementType");
+      if (!elementAtt || Elements::atomicNumberFromSymbol(elementAtt.value()) !=
+                           molecule->atomicNumber(index))
+        return false;
+
+      Vector3 position;
+      xml_attribute x3Att = atomNode.attribute("x3");
+      xml_attribute xFractAtt = atomNode.attribute("xFract");
+      if (x3Att) {
+        xml_attribute y3 = atomNode.attribute("y3");
+        xml_attribute z3 = atomNode.attribute("z3");
+        if (!y3 || !z3)
+          return false;
+        auto x = lexicalCast<double>(x3Att.value());
+        auto y = lexicalCast<double>(y3.value());
+        auto z = lexicalCast<double>(z3.value());
+        if (!x || !y || !z)
+          return false;
+        position = Vector3(*x, *y, *z);
+      } else if (xFractAtt && molecule->unitCell()) {
+        xml_attribute yFract = atomNode.attribute("yFract");
+        xml_attribute zFract = atomNode.attribute("zFract");
+        if (!yFract || !zFract)
+          return false;
+        position = Vector3(static_cast<Real>(xFractAtt.as_float()),
+                           static_cast<Real>(yFract.as_float()),
+                           static_cast<Real>(zFract.as_float()));
+        molecule->unitCell()->toCartesian(position, position);
+      } else {
+        return false;
+      }
+
+      positions.push_back(position);
+      ++index;
+    }
+
+    return index == molecule->atomCount();
+  }
+
+  // A CML file can hold several <molecule> elements, either wrapped in <cml> or
+  // -- as Open Babel writes them for a conformer search -- concatenated one
+  // after another. When every sibling turns out to be another geometry of the
+  // first molecule, keep them as coordinate sets instead of discarding them.
+  // Anything else is a genuine multi-molecule file, and only the first molecule
+  // is read, as before.
+  bool conformers()
+  {
+    if (!moleculeNode.next_sibling("molecule"))
+      return true;
+
+    std::vector<Array<Vector3>> coordinateSets;
+    for (xml_node node = moleculeNode.next_sibling("molecule"); node;
+         node = node.next_sibling("molecule")) {
+      Array<Vector3> positions;
+      if (!geometry(node, positions))
+        return true;
+      coordinateSets.push_back(positions);
+    }
+
+    // Coordinate set 0 is the geometry already loaded onto the atoms.
+    molecule->setCoordinate3d(molecule->atomPositions3d(), 0);
+    for (size_t i = 0; i < coordinateSets.size(); ++i)
+      molecule->setCoordinate3d(coordinateSets[i], i + 1);
 
     return true;
   }

--- a/avogadro/io/cmlformat.cpp
+++ b/avogadro/io/cmlformat.cpp
@@ -437,9 +437,12 @@ public:
         xml_attribute zFract = atomNode.attribute("zFract");
         if (!yFract || !zFract)
           return false;
-        position = Vector3(static_cast<Real>(xFractAtt.as_float()),
-                           static_cast<Real>(yFract.as_float()),
-                           static_cast<Real>(zFract.as_float()));
+        auto x = lexicalCast<double>(xFractAtt.value());
+        auto y = lexicalCast<double>(yFract.value());
+        auto z = lexicalCast<double>(zFract.value());
+        if (!x || !y || !z)
+          return false;
+        position = Vector3(*x, *y, *z);
         molecule->unitCell()->toCartesian(position, position);
       } else {
         return false;

--- a/avogadro/qtplugins/openbabel/conformersearchdialog.cpp
+++ b/avogadro/qtplugins/openbabel/conformersearchdialog.cpp
@@ -27,6 +27,11 @@ ConformerSearchDialog::ConformerSearchDialog(QWidget* parent) : QDialog(parent)
   connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton*)), this,
           SLOT(buttonClicked(QAbstractButton*)));
 
+  // Open Babel matches these tokens exactly, so keep them out of the visible
+  // (and translated) item text.
+  ui.scoringComboBox->setItemData(0, QStringLiteral("rmsd"));
+  ui.scoringComboBox->setItemData(1, QStringLiteral("energy"));
+
   m_method = 1; // systematic
   m_numConformers = 100;
 
@@ -73,7 +78,9 @@ QStringList ConformerSearchDialog::options() const
     options << "--mutability" << QString::number(ui.mutabilitySpinBox->value());
     options << "--convergence"
             << QString::number(ui.convergenceSpinBox->value());
-    options << "--scoring" << ui.scoringComboBox->currentText();
+    const QString scoring = ui.scoringComboBox->currentData().toString();
+    options << "--score"
+            << (scoring.isEmpty() ? QStringLiteral("rmsd") : scoring);
   }
 
   return options;

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -10,8 +10,10 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
+#include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 #include <QtCore/QProcess>
+#include <QtCore/QTemporaryFile>
 
 #include <QRegularExpression>
 
@@ -19,7 +21,7 @@ namespace Avogadro::QtPlugins {
 
 OBProcess::OBProcess(QObject* parent_)
   : QObject(parent_), m_processLocked(false), m_aborted(false),
-    m_process(new QProcess(this)),
+    m_process(new QProcess(this)), m_conformerOutputFile(nullptr),
 #if defined(_WIN32)
     m_obabelExecutable("obabel.exe")
 #else
@@ -449,6 +451,29 @@ bool OBProcess::generateConformers(const QByteArray& mol,
                 << "-ocml"
                 << "--writeconformers";
   }
+  // Open Babel's genetic algorithm search logs to stdout rather than stderr
+  // (OBConformerSearch defaults m_logstream to std::cout and the --conformer
+  // operation never redirects it), so anything written to stdout arrives
+  // interleaved with the molecule. Collect the molecule in a file instead --
+  // that keeps the two apart on every Open Babel release.
+  clearConformerOutputFile();
+  m_conformerOutputFile =
+    new QTemporaryFile(QDir::tempPath() + "/avogadro_conformers_XXXXXX." +
+                         QString::fromStdString(format),
+                       this);
+  if (!m_conformerOutputFile->open()) {
+    qWarning() << "OBProcess::generateConformers(): could not create a "
+                  "temporary file for the conformer search output.";
+    clearConformerOutputFile();
+    releaseProcess();
+    return false;
+  }
+  // Close it so obabel can write to it, but keep the object alive: it owns the
+  // file name, and removes the file when it is destroyed.
+  m_conformerOutputFile->close();
+
+  realOptions << "-O" << m_conformerOutputFile->fileName();
+
   realOptions << "--conformer"
               << "--noh" // new in OB 3.0.1
               << "--log" << options;
@@ -482,14 +507,33 @@ void OBProcess::optimizeGeometryPrepare()
 void OBProcess::conformerPrepare()
 {
   if (m_aborted) {
+    clearConformerOutputFile();
     releaseProcess();
     return;
   }
 
-  QByteArray result = m_process->readAllStandardOutput();
+  // The molecules were written to a file rather than stdout, so that the
+  // genetic algorithm's log could not corrupt them.
+  QByteArray result;
+  if (m_conformerOutputFile) {
+    QFile output(m_conformerOutputFile->fileName());
+    if (output.open(QIODevice::ReadOnly))
+      result = output.readAll();
+    else
+      qWarning() << "OBProcess::conformerPrepare(): could not read the "
+                    "conformer search output from"
+                 << m_conformerOutputFile->fileName();
+  }
+  clearConformerOutputFile();
 
   releaseProcess();
   emit generateConformersFinished(result);
+}
+
+void OBProcess::clearConformerOutputFile()
+{
+  delete m_conformerOutputFile;
+  m_conformerOutputFile = nullptr;
 }
 
 void OBProcess::optimizeGeometryReadLog()

--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -437,11 +437,17 @@ bool OBProcess::generateConformers(const QByteArray& mol,
 
   QStringList realOptions;
   if (format == "cjson") {
+    // The cjson writer stores every conformer in one document, as 3dSets.
     realOptions << "-icjson"
                 << "-ocjson";
   } else {
+    // The CML writer has no conformer support, so it would only give us the
+    // lowest-energy geometry. --writeconformers writes each conformer as its
+    // own <molecule> instead, which the CML reader turns into coordinate sets.
+    // Open Babel gained cjson after 3.1.1, so this is the path most users take.
     realOptions << "-icml"
-                << "-ocml";
+                << "-ocml"
+                << "--writeconformers";
   }
   realOptions << "--conformer"
               << "--noh" // new in OB 3.0.1

--- a/avogadro/qtplugins/openbabel/obprocess.h
+++ b/avogadro/qtplugins/openbabel/obprocess.h
@@ -13,6 +13,7 @@
 #include <QtCore/QStringList>
 
 class QProcess;
+class QTemporaryFile;
 
 namespace Avogadro {
 namespace QtPlugins {
@@ -415,6 +416,12 @@ executeObabel(options, this, SLOT(mySlot()));
 
   void resetState();
 
+  /**
+   * Delete the temporary file used to collect conformer search output, if one
+   * is present. Destroying the QTemporaryFile removes it from disk.
+   */
+  void clearConformerOutputFile();
+
   // Not thread safe -- just uses a bool.
   bool tryLockProcess()
   {
@@ -436,6 +443,9 @@ executeObabel(options, this, SLOT(mySlot()));
   int m_optimizeGeometryMaxSteps;
   unsigned m_maxConformers;
   QString m_optimizeGeometryLog;
+
+  // Conformer searches write their molecules here rather than to stdout.
+  QTemporaryFile* m_conformerOutputFile;
 };
 
 } // namespace QtPlugins

--- a/tests/io/cmltest.cpp
+++ b/tests/io/cmltest.cpp
@@ -287,6 +287,53 @@ void expectKekulizedBenzene(const Molecule& molecule)
   EXPECT_EQ(ringDouble, 3); // The ring bonds specifically must alternate.
 }
 
+/**
+ * One standalone CML document holding a two-atom molecule, exactly as Open
+ * Babel writes each conformer under --writeconformers: its own XML prolog and
+ * its own root <molecule>, with no enclosing <cml>. Concatenating several of
+ * these is the legacy multi-conformer format.
+ *
+ * @a firstElement is the first atom's element, so a document can be made to
+ * describe a different molecule, and @a xOffset shifts the geometry so the
+ * coordinate sets are distinguishable.
+ */
+std::string conformerDocument(const std::string& firstElement, double xOffset)
+{
+  std::string cml("<?xml version=\"1.0\"?>\n"
+                  "<molecule xmlns=\"http://www.xml-cml.org/schema\">"
+                  "<atomArray>");
+  cml += "<atom id=\"a1\" elementType=\"" + firstElement + "\" x3=\"" +
+         std::to_string(xOffset) + "\" y3=\"0.0\" z3=\"0.0\"/>";
+  cml += "<atom id=\"a2\" elementType=\"O\" x3=\"" +
+         std::to_string(xOffset + 1.2) + "\" y3=\"0.0\" z3=\"0.0\"/>";
+  cml += "</atomArray><bondArray>"
+         "<bond atomRefs2=\"a1 a2\" order=\"1\"/>"
+         "</bondArray></molecule>\n";
+  return cml;
+}
+
+/**
+ * The same idea for a crystal: a standalone document with a unit cell whose
+ * single atom is placed with fractional coordinates. @a xFract goes in
+ * verbatim so a malformed value can be exercised.
+ */
+std::string fractionalDocument(const std::string& xFract)
+{
+  return "<?xml version=\"1.0\"?>\n"
+         "<molecule xmlns=\"http://www.xml-cml.org/schema\"><crystal>"
+         "<scalar title=\"a\" units=\"units:angstrom\">5.0</scalar>"
+         "<scalar title=\"b\" units=\"units:angstrom\">5.0</scalar>"
+         "<scalar title=\"c\" units=\"units:angstrom\">5.0</scalar>"
+         "<scalar title=\"alpha\" units=\"units:degree\">90.0</scalar>"
+         "<scalar title=\"beta\" units=\"units:degree\">90.0</scalar>"
+         "<scalar title=\"gamma\" units=\"units:degree\">90.0</scalar>"
+         "</crystal><atomArray>"
+         "<atom id=\"a1\" elementType=\"Na\" xFract=\"" +
+         xFract +
+         "\" yFract=\"0.25\" zFract=\"0.25\"/>"
+         "</atomArray></molecule>\n";
+}
+
 } // namespace
 
 TEST(CmlTest, aromaticBondOrderAIsKekulized)
@@ -310,4 +357,77 @@ TEST(CmlTest, aromaticBondOrderAromaticSpellingIsKekulized)
   Molecule molecule;
   ASSERT_TRUE(cml.readString(benzeneCml("aromatic"), molecule)) << cml.error();
   expectKekulizedBenzene(molecule);
+}
+
+TEST(CmlTest, legacyConcatenatedConformersBecomeCoordinateSets)
+{
+  // Open Babel's CML writer has no conformer support, so Avogadro passes
+  // --writeconformers and gets each conformer back as its own top-level
+  // document rather than as siblings inside <cml>. All but the first used to
+  // be discarded, which is why a conformer search appeared to return nothing.
+  const std::string file = conformerDocument("C", 0.0) +
+                           conformerDocument("C", 1.0) +
+                           conformerDocument("C", 2.0);
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(file, molecule)) << cml.error();
+
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(2));
+  EXPECT_EQ(molecule.bondCount(), static_cast<size_t>(1));
+  ASSERT_EQ(molecule.coordinate3dCount(), static_cast<size_t>(3));
+
+  // Set 0 is the geometry already loaded onto the atoms, then one set per
+  // sibling, in document order.
+  EXPECT_DOUBLE_EQ(molecule.coordinate3d(0)[0].x(), 0.0);
+  EXPECT_DOUBLE_EQ(molecule.coordinate3d(1)[0].x(), 1.0);
+  EXPECT_DOUBLE_EQ(molecule.coordinate3d(2)[0].x(), 2.0);
+}
+
+TEST(CmlTest, concatenatedDifferentMoleculesAreNotConformers)
+{
+  // Same atom count, but the first atom is a different element, so these are
+  // two molecules rather than two geometries of one. Only the first is read,
+  // and no coordinate sets are invented for it.
+  const std::string file =
+    conformerDocument("C", 0.0) + conformerDocument("N", 1.0);
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(file, molecule)) << cml.error();
+
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(2));
+  EXPECT_EQ(molecule.coordinate3dCount(), static_cast<size_t>(0));
+  EXPECT_EQ(molecule.atom(0).atomicNumber(), 6);
+}
+
+TEST(CmlTest, fractionalConformersAreConvertedToCartesian)
+{
+  const std::string file =
+    fractionalDocument("0.25") + fractionalDocument("0.75");
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(file, molecule)) << cml.error();
+
+  ASSERT_EQ(molecule.coordinate3dCount(), static_cast<size_t>(2));
+  // A 5 A cubic cell, so the fractional x values land at 1.25 and 3.75 A.
+  EXPECT_NEAR(molecule.coordinate3d(0)[0].x(), 1.25, 1e-5);
+  EXPECT_NEAR(molecule.coordinate3d(1)[0].x(), 3.75, 1e-5);
+}
+
+TEST(CmlTest, malformedFractionalConformerIsRejected)
+{
+  // A sibling whose fractional coordinate will not parse is not a usable
+  // geometry. It must be rejected rather than silently read as zero, which is
+  // what pugixml's as_float() would hand back.
+  const std::string file =
+    fractionalDocument("0.25") + fractionalDocument("not-a-number");
+
+  CmlFormat cml;
+  Molecule molecule;
+  ASSERT_TRUE(cml.readString(file, molecule)) << cml.error();
+
+  EXPECT_EQ(molecule.atomCount(), static_cast<size_t>(1));
+  EXPECT_EQ(molecule.coordinate3dCount(), static_cast<size_t>(0));
 }


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CML files can now include multiple matching molecular conformers, including Cartesian and fractional coordinates.
  * Conformer searches now support stable RMSD and energy scoring options.
  * Generated conformers are preserved and imported from CML output.

* **Bug Fixes**
  * Improved handling of incompatible molecule entries, temporary output files, aborted searches, and file-read failures.
  * Conformer generation now provides more reliable results without losing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->