### PR TITLE
Fix bug with torsion (and angular) constraints

### DIFF
--- a/avogadro/calc/energycalculator.cpp
+++ b/avogadro/calc/energycalculator.cpp
@@ -9,6 +9,7 @@
 #include <cppoptlib/utils/derivatives.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <avogadro/core/angletools.h>
 
@@ -34,6 +35,15 @@ struct FiniteDifferenceObjective
 
   EnergyCalculator* calculator;
 };
+
+// Torsions are periodic, so the shortest path to the restrained value has to
+// be used. Without this a current angle of -179 degrees reads as 358 degrees
+// away from a +179 degree restraint instead of 2, and the restraint drives the
+// torsion the long way around.
+inline Real wrapToPi(Real delta)
+{
+  return std::remainder(delta, 2.0 * PI);
+}
 } // namespace
 
 Real EnergyCalculator::evaluate(const Eigen::VectorXd& x, Eigen::VectorXd* grad)
@@ -59,11 +69,12 @@ void EnergyCalculator::finiteGradient(const Eigen::VectorXd& x,
 
 void EnergyCalculator::gradient(const Eigen::VectorXd& x, Eigen::VectorXd& grad)
 {
+  // Derived value() implementations add constraintEnergies(), so the finite
+  // difference already contains the restraint terms - adding
+  // constraintGradients() here as well would count them twice.
   finiteGradient(x, grad);
   // clean and handle frozen atoms
   cleanGradients(grad);
-  // add any constraints
-  constraintGradients(x, grad);
 }
 
 std::vector<Real> EnergyCalculator::valueBatch(
@@ -212,8 +223,9 @@ Real EnergyCalculator::constraintEnergies(const Eigen::VectorXd& x)
     const Vector3d vA = x.segment<3>(3 * a);
     const Vector3d vB = x.segment<3>(3 * b);
     const Vector3d vC = x.segment<3>(3 * c);
-    const Real angle = calculateAngle(vA, vB, vC);
-    const Real delta = angle - constraint.value();
+    // work in radians to match the analytic gradients in constraintGradients()
+    const Real angle = calculateAngle(vA, vB, vC) * DEG_TO_RAD;
+    const Real delta = angle - constraint.value() * DEG_TO_RAD;
 
     // harmonic restraint
     totalEnergy += constraint.k() * delta * delta;
@@ -233,8 +245,8 @@ Real EnergyCalculator::constraintEnergies(const Eigen::VectorXd& x)
     const Vector3d vB = x.segment<3>(3 * b);
     const Vector3d vC = x.segment<3>(3 * c);
     const Vector3d vD = x.segment<3>(3 * d);
-    const Real angle = calculateDihedral(vA, vB, vC, vD);
-    const Real delta = angle - constraint.value();
+    const Real angle = calculateDihedral(vA, vB, vC, vD) * DEG_TO_RAD;
+    const Real delta = wrapToPi(angle - constraint.value() * DEG_TO_RAD);
 
     // harmonic restraint
     totalEnergy += constraint.k() * delta * delta;
@@ -254,8 +266,9 @@ Real EnergyCalculator::constraintEnergies(const Eigen::VectorXd& x)
     const Vector3d vB = x.segment<3>(3 * b);
     const Vector3d vC = x.segment<3>(3 * c);
     const Vector3d vD = x.segment<3>(3 * d);
-    const Real angle = outOfPlaneAngle(vA, vB, vC, vD);
-    const Real delta = angle - constraint.value();
+    // Wilson angles are limited to +/- 90 degrees, so no wrapping needed
+    const Real angle = outOfPlaneAngle(vA, vB, vC, vD) * DEG_TO_RAD;
+    const Real delta = angle - constraint.value() * DEG_TO_RAD;
 
     // harmonic restraint
     totalEnergy += constraint.k() * delta * delta;
@@ -299,8 +312,9 @@ void EnergyCalculator::constraintGradients(const Eigen::VectorXd& x,
     const Vector3d vC = x.segment<3>(3 * c);
 
     Vector3d aGrad, bGrad, cGrad;
+    // angleGradient() returns radians and d(radians)/dx
     Real angle = angleGradient(vA, vB, vC, aGrad, bGrad, cGrad);
-    const Real delta = angle - constraint.value();
+    const Real delta = angle - constraint.value() * DEG_TO_RAD;
     const Real dE = constraint.k() * 2 * delta;
 
     grad.segment<3>(3 * a) += dE * aGrad;
@@ -323,9 +337,10 @@ void EnergyCalculator::constraintGradients(const Eigen::VectorXd& x,
     const Vector3d vC = x.segment<3>(3 * c);
     const Vector3d vD = x.segment<3>(3 * d);
     Vector3d aGrad, bGrad, cGrad, dGrad;
+    // dihedralGradient() returns radians and d(radians)/dx
     const Real angle =
       dihedralGradient(vA, vB, vC, vD, aGrad, bGrad, cGrad, dGrad);
-    const Real delta = angle - constraint.value();
+    const Real delta = wrapToPi(angle - constraint.value() * DEG_TO_RAD);
     const Real dE = constraint.k() * 2 * delta;
 
     grad.segment<3>(3 * a) += dE * aGrad;
@@ -350,9 +365,10 @@ void EnergyCalculator::constraintGradients(const Eigen::VectorXd& x,
     const Vector3d vC = x.segment<3>(3 * c);
     const Vector3d vD = x.segment<3>(3 * d);
     Vector3d aGrad, bGrad, cGrad, dGrad;
+    // outOfPlaneGradient() returns radians and d(radians)/dx
     const Real angle =
       outOfPlaneGradient(vA, vB, vC, vD, aGrad, bGrad, cGrad, dGrad);
-    const Real delta = angle - constraint.value();
+    const Real delta = angle - constraint.value() * DEG_TO_RAD;
     const Real dE = constraint.k() * 2 * delta;
 
     grad.segment<3>(3 * a) += dE * aGrad;
@@ -360,6 +376,11 @@ void EnergyCalculator::constraintGradients(const Eigen::VectorXd& x,
     grad.segment<3>(3 * c) += dE * cGrad;
     grad.segment<3>(3 * d) += dE * dGrad;
   }
+
+  // Callers mask frozen atoms before adding these terms, so re-apply the mask
+  // here - otherwise a restraint can drag a frozen atom around.
+  if (m_mask.rows() == grad.rows())
+    grad = grad.cwiseProduct(m_mask);
 }
 
 } // namespace Avogadro::Calc

--- a/avogadro/core/constraint.h
+++ b/avogadro/core/constraint.h
@@ -23,10 +23,20 @@ namespace Core {
  * during optimization or dynamics. More technically, these are implemented as
  * stiff harmonic oscillators restraining a particular atom set towards the
  * value.
+ *
+ * Distances are stored in Angstrom and angles / torsions in degrees, matching
+ * what the user sees in the property tables and constraint dialog. Energy
+ * calculators convert angular values to radians internally, so the angular
+ * force constants are in kJ/mol/radian^2.
  */
 class AVOGADROCORE_EXPORT Constraint
 {
 public:
+  /** Default force constant for distance restraints, in kJ/mol/Angstrom^2 */
+  static constexpr Real DefaultDistanceK = 41840.0;
+  /** Default force constant for angular restraints, in kJ/mol/radian^2 */
+  static constexpr Real DefaultAngularK = 10000.0;
+
   enum Type
   {
     None = 0,
@@ -44,8 +54,8 @@ public:
    * @param c Atom index of the third atom (for angles or torsions) or MaxIndex
    * @param d Atom index of the fourth atom (for torsion constraints) or
    * MaxIndex
-   * @param value The value of the constraint, either Angstrom for distance or
-   * radians)
+   * @param value The value of the constraint, either Angstrom for distance
+   * or degrees for angles and torsions
    */
   Constraint(Index a, Index b, Index c = MaxIndex, Index d = MaxIndex,
              Real value = 0.0)
@@ -59,8 +69,8 @@ public:
    * @param c Atom index of the third atom (for angles or torsions) or MaxIndex
    * @param d Atom index of the fourth atom (for torsion constraints) or
    * MaxIndex
-   * @param value The value of the constraint, either Angstrom for distance or
-   * radians)
+   * @param value The value of the constraint, either Angstrom for distance
+   * or degrees for angles and torsions
    */
   void set(Index a, Index b, Index c = MaxIndex, Index d = MaxIndex,
            Real value = 0.0)
@@ -74,8 +84,8 @@ public:
 
   /**
    * Set the constraint value (distance, angle, dihedral)
-   * @param value The value of the constraint, either Angstrom for distance or
-   * radians)
+   * @param value The value of the constraint, either Angstrom for distance
+   * or degrees for angles and torsions
    */
   void setValue(Real value) { m_value = value; }
 
@@ -100,8 +110,25 @@ public:
   Index cIndex() const { return m_cIndex; }
   Index dIndex() const { return m_dIndex; }
 
-  Real k() const { return m_k; }
-  void setK(Real k) { m_k = k; }
+  /**
+   * @return the harmonic force constant, either kJ/mol/Angstrom^2 for a
+   * distance restraint or kJ/mol/radian^2 for an angular one. If no force
+   * constant has been set explicitly, a type-appropriate default is used --
+   * the two have different units and cannot share a value.
+   */
+  Real k() const
+  {
+    if (m_kSet)
+      return m_k;
+
+    return (type() == DistanceConstraint) ? DefaultDistanceK : DefaultAngularK;
+  }
+
+  void setK(Real k)
+  {
+    m_k = k;
+    m_kSet = true;
+  }
 
   /**
    * @return the type of constraint
@@ -135,7 +162,8 @@ protected:
   Index m_cIndex = MaxIndex;
   Index m_dIndex = MaxIndex;
   Real m_value = 0.0;
-  Real m_k = 41840.0; // force constant, default in kJ/mol/Angstrom^2
+  Real m_k = DefaultDistanceK;            // units depend on the constraint type
+  bool m_kSet = false;                    // true once setK() has been called
   mutable Constraint::Type m_type = None; // cached type, initialized to None
 };
 

--- a/avogadro/core/constraint.h
+++ b/avogadro/core/constraint.h
@@ -80,6 +80,12 @@ public:
     m_cIndex = c;
     m_dIndex = d;
     m_value = value;
+
+    // The atom indices decide the inferred type, so a cached guess is stale
+    // now -- leaving it would keep, e.g., a distance force constant on what
+    // is now a torsion. A type set explicitly via setType() is kept.
+    if (!m_typeExplicit)
+      m_type = None;
   }
 
   /**
@@ -151,10 +157,17 @@ public:
   }
 
   /**
-   * Set the type of constraint
+   * Set the type of constraint. An explicit type survives later set() calls,
+   * since it cannot always be inferred from the atom indices -- an
+   * out-of-plane constraint has the same four indices as a torsion. Pass None
+   * to go back to inferring the type from the indices.
    * @param type The type of constraint
    */
-  void setType(Constraint::Type type) const { m_type = type; }
+  void setType(Constraint::Type type) const
+  {
+    m_type = type;
+    m_typeExplicit = (type != None);
+  }
 
 protected:
   Index m_aIndex = MaxIndex;
@@ -165,6 +178,7 @@ protected:
   Real m_k = DefaultDistanceK;            // units depend on the constraint type
   bool m_kSet = false;                    // true once setK() has been called
   mutable Constraint::Type m_type = None; // cached type, initialized to None
+  mutable bool m_typeExplicit = false;    // true once setType() has been called
 };
 
 } // End namespace Core

--- a/tests/calc/energycalculatortest.cpp
+++ b/tests/calc/energycalculatortest.cpp
@@ -10,6 +10,7 @@
 #include <avogadro/core/avogadrocore.h>
 #include <avogadro/calc/energycalculator.h>
 #include <avogadro/calc/energyoptimizer.h>
+#include <avogadro/core/angletools.h>
 #include <avogadro/core/constraint.h>
 #include <avogadro/core/molecule.h>
 
@@ -794,6 +795,207 @@ TEST_F(EnergyCalculatorTest, ConstraintGradients)
   calculator->setConstraints(constraints);
 
   EXPECT_NO_THROW(calculator->constraintGradients(x, grad));
+}
+
+// Restraint unit / periodicity regression tests
+//
+// constraintEnergies() and constraintGradients() must agree: the restraint
+// values are stored in degrees but the analytic gradient helpers work in
+// radians, so a missing conversion silently made the gradient ~57x too large
+// and pointed it at the wrong target, which sent constrained torsions
+// wind-milling with energies in the millions of kJ/mol.
+
+// Reports only the restraint terms, so finite differences of value() can be
+// compared directly against constraintGradients().
+class RestraintOnlyCalculator : public EnergyCalculator
+{
+public:
+  EnergyCalculator* newInstance() const override
+  {
+    return new RestraintOnlyCalculator();
+  }
+  std::string identifier() const override { return "restraint_test"; }
+  std::string name() const override { return "Restraint Test"; }
+  std::string description() const override { return "Restraint terms only"; }
+  Molecule::ElementMask elements() const override
+  {
+    Molecule::ElementMask mask;
+    mask.set();
+    return mask;
+  }
+  void setMolecule(Molecule* /*mol*/) override {}
+
+  Real value(const Eigen::VectorXd& x) override
+  {
+    return constraintEnergies(x);
+  }
+};
+
+namespace {
+
+// A gauche-ish butane skeleton, C1 C2 C3 C4.
+Eigen::VectorXd butaneSkeleton()
+{
+  Eigen::VectorXd x(12);
+  x << 1.430, -0.510, -0.240, 0.760, 0.180, 0.940, -0.760, 0.180, 0.560, -1.430,
+    -0.510, -0.640;
+  return x;
+}
+
+// Largest disagreement between the analytic restraint gradient and a central
+// difference of the restraint energy.
+Real maxGradientError(RestraintOnlyCalculator& calc, const Eigen::VectorXd& x)
+{
+  Eigen::VectorXd analytic = Eigen::VectorXd::Zero(x.size());
+  calc.constraintGradients(x, analytic);
+
+  const Real h = 1.0e-6;
+  Real worst = 0.0;
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
+    Eigen::VectorXd xp = x, xm = x;
+    xp[i] += h;
+    xm[i] -= h;
+    const Real numeric = (calc.value(xp) - calc.value(xm)) / (2.0 * h);
+    worst = std::max(worst, std::abs(numeric - analytic[i]));
+  }
+  return worst;
+}
+
+} // namespace
+
+TEST(RestraintTest, TorsionEnergyUsesDegreesAndRadianForceConstant)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  const Real current = Avogadro::calculateDihedral(
+    x.segment<3>(0), x.segment<3>(3), x.segment<3>(6), x.segment<3>(9));
+
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 45.0) });
+
+  const Real delta = (current - 45.0) * Avogadro::DEG_TO_RAD;
+  EXPECT_NEAR(calc.value(x), Constraint::DefaultAngularK * delta * delta, 1e-6);
+}
+
+TEST(RestraintTest, TorsionGradientMatchesFiniteDifference)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 45.0) });
+
+  EXPECT_LT(maxGradientError(calc, x), 1e-3);
+}
+
+TEST(RestraintTest, AngleGradientMatchesFiniteDifference)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, MaxIndex, 105.0) });
+
+  const Real current =
+    Avogadro::calculateAngle(x.segment<3>(0), x.segment<3>(3), x.segment<3>(6));
+  const Real delta = (current - 105.0) * Avogadro::DEG_TO_RAD;
+  EXPECT_NEAR(calc.value(x), Constraint::DefaultAngularK * delta * delta, 1e-6);
+  EXPECT_LT(maxGradientError(calc, x), 1e-3);
+}
+
+TEST(RestraintTest, DistanceGradientMatchesFiniteDifference)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, MaxIndex, MaxIndex, 1.60) });
+
+  const Real current = (x.segment<3>(0) - x.segment<3>(3)).norm();
+  const Real delta = current - 1.60;
+  EXPECT_NEAR(calc.value(x), Constraint::DefaultDistanceK * delta * delta,
+              1e-6);
+  EXPECT_LT(maxGradientError(calc, x), 1e-3);
+}
+
+TEST(RestraintTest, OutOfPlaneGradientMatchesFiniteDifference)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  RestraintOnlyCalculator calc;
+  Constraint oop(1, 0, 2, 3, 10.0);
+  oop.setType(Constraint::OutOfPlaneConstraint);
+  calc.setConstraints({ oop });
+
+  const Real current = Avogadro::outOfPlaneAngle(
+    x.segment<3>(3), x.segment<3>(0), x.segment<3>(6), x.segment<3>(9));
+  const Real delta = (current - 10.0) * Avogadro::DEG_TO_RAD;
+  EXPECT_NEAR(calc.value(x), Constraint::DefaultAngularK * delta * delta, 1e-6);
+  EXPECT_LT(maxGradientError(calc, x), 1e-3);
+}
+
+TEST(RestraintTest, SatisfiedRestraintIsAMinimum)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  const Real current = Avogadro::calculateDihedral(
+    x.segment<3>(0), x.segment<3>(3), x.segment<3>(6), x.segment<3>(9));
+
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, current) });
+
+  EXPECT_NEAR(calc.value(x), 0.0, 1e-9);
+
+  Eigen::VectorXd grad = Eigen::VectorXd::Zero(12);
+  calc.constraintGradients(x, grad);
+  EXPECT_NEAR(grad.norm(), 0.0, 1e-9);
+}
+
+TEST(RestraintTest, TorsionTakesTheShortWayAroundThePeriodicSeam)
+{
+  // Build a -175 degree torsion by rotating the last atom about the b-c axis,
+  // which lies along x here, then restrain it to +175 degrees. The shortest
+  // path is 10 degrees, not 350.
+  const Real t = -175.0 * Avogadro::DEG_TO_RAD;
+  Eigen::VectorXd x(12);
+  x << -0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 1.5, 0.0, 0.0, 2.0, std::cos(t),
+    std::sin(t);
+
+  ASSERT_NEAR(Avogadro::calculateDihedral(x.segment<3>(0), x.segment<3>(3),
+                                          x.segment<3>(6), x.segment<3>(9)),
+              -175.0, 1e-6);
+
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 175.0) });
+
+  const Real tenDegrees = 10.0 * Avogadro::DEG_TO_RAD;
+  EXPECT_NEAR(calc.value(x),
+              Constraint::DefaultAngularK * tenDegrees * tenDegrees, 1e-6);
+  EXPECT_LT(maxGradientError(calc, x), 1e-3);
+}
+
+TEST(RestraintTest, FrozenAtomsAreNotDraggedByARestraint)
+{
+  const Eigen::VectorXd x = butaneSkeleton();
+  RestraintOnlyCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 45.0) });
+
+  Eigen::VectorXd mask = Eigen::VectorXd::Ones(12);
+  mask.segment<3>(0).setZero(); // freeze the first carbon
+  calc.setMask(mask);
+
+  Eigen::VectorXd grad = Eigen::VectorXd::Zero(12);
+  calc.constraintGradients(x, grad);
+
+  EXPECT_NEAR(grad.segment<3>(0).norm(), 0.0, 1e-12);
+  // the remaining atoms must still feel the restraint
+  EXPECT_GT(grad.segment<9>(3).norm(), 1e-6);
+}
+
+TEST(RestraintTest, DefaultForceConstantDependsOnType)
+{
+  Constraint distance(0, 1, MaxIndex, MaxIndex, 1.5);
+  Constraint angle(0, 1, 2, MaxIndex, 109.5);
+  Constraint torsion(0, 1, 2, 3, 180.0);
+
+  EXPECT_DOUBLE_EQ(distance.k(), Constraint::DefaultDistanceK);
+  EXPECT_DOUBLE_EQ(angle.k(), Constraint::DefaultAngularK);
+  EXPECT_DOUBLE_EQ(torsion.k(), Constraint::DefaultAngularK);
+
+  // an explicit force constant always wins
+  torsion.setK(250.0);
+  EXPECT_DOUBLE_EQ(torsion.k(), 250.0);
 }
 
 // Mask Tests

--- a/tests/calc/energycalculatortest.cpp
+++ b/tests/calc/energycalculatortest.cpp
@@ -831,6 +831,46 @@ public:
   }
 };
 
+// Mirrors the convention every shipping calculator follows: value() reports a
+// real energy term *plus* constraintEnergies(). The base-class gradient()
+// finite-differences value(), so the restraint contribution must appear in the
+// gradient exactly once. Set includeRestraints(false) to model a value()
+// override that forgets constraintEnergies().
+class RestrainedQuadraticCalculator : public EnergyCalculator
+{
+public:
+  EnergyCalculator* newInstance() const override
+  {
+    return new RestrainedQuadraticCalculator();
+  }
+  std::string identifier() const override { return "restrained_quadratic"; }
+  std::string name() const override { return "Restrained Quadratic"; }
+  std::string description() const override
+  {
+    return "Quadratic energy plus restraint terms";
+  }
+  Molecule::ElementMask elements() const override
+  {
+    Molecule::ElementMask mask;
+    mask.set();
+    return mask;
+  }
+  void setMolecule(Molecule* /*mol*/) override {}
+
+  Real value(const Eigen::VectorXd& x) override
+  {
+    Real energy = x.squaredNorm();
+    if (m_includeRestraints)
+      energy += constraintEnergies(x);
+    return energy;
+  }
+
+  void includeRestraints(bool include) { m_includeRestraints = include; }
+
+private:
+  bool m_includeRestraints = true;
+};
+
 namespace {
 
 // A gauche-ish butane skeleton, C1 C2 C3 C4.
@@ -996,6 +1036,81 @@ TEST(RestraintTest, DefaultForceConstantDependsOnType)
   // an explicit force constant always wins
   torsion.setK(250.0);
   EXPECT_DOUBLE_EQ(torsion.k(), 250.0);
+}
+
+TEST(RestraintTest, SetReclassifiesTheConstraintType)
+{
+  Constraint c(0, 1);
+  // resolve and cache the inferred type
+  ASSERT_EQ(c.type(), Constraint::DistanceConstraint);
+  ASSERT_DOUBLE_EQ(c.k(), Constraint::DefaultDistanceK);
+
+  // the same object is now a torsion -- a stale cached type would keep the
+  // distance force constant (wrong units) and file it in the wrong bucket
+  c.set(0, 1, 2, 3, 45.0);
+  EXPECT_EQ(c.type(), Constraint::TorsionConstraint);
+  EXPECT_DOUBLE_EQ(c.k(), Constraint::DefaultAngularK);
+}
+
+TEST(RestraintTest, ExplicitTypeSurvivesSet)
+{
+  // Out-of-plane cannot be inferred -- it has the same four indices as a
+  // torsion -- so an explicitly assigned type must not be reset by set().
+  Constraint c(1, 0, 2, 3, 10.0);
+  c.setType(Constraint::OutOfPlaneConstraint);
+  ASSERT_EQ(c.type(), Constraint::OutOfPlaneConstraint);
+
+  c.set(2, 0, 1, 3, 15.0);
+  EXPECT_EQ(c.type(), Constraint::OutOfPlaneConstraint);
+
+  // passing None goes back to inferring from the indices
+  c.setType(Constraint::None);
+  EXPECT_EQ(c.type(), Constraint::TorsionConstraint);
+}
+
+TEST(RestraintTest, BaseGradientIncludesRestraintsExactlyOnce)
+{
+  // EnergyCalculator::gradient() finite-differences value(), which by
+  // convention already contains constraintEnergies(). Adding
+  // constraintGradients() on top of that would double the restraint force.
+  const Eigen::VectorXd x = butaneSkeleton();
+
+  RestrainedQuadraticCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 45.0) }); // violated restraint
+
+  Eigen::VectorXd restraint = Eigen::VectorXd::Zero(x.size());
+  calc.constraintGradients(x, restraint);
+  ASSERT_GT(restraint.norm(), 1.0); // the restraint really is violated
+
+  Eigen::VectorXd grad = Eigen::VectorXd::Zero(x.size());
+  calc.gradient(x, grad);
+
+  const Eigen::VectorXd quadratic = 2.0 * x;
+  const Real scale = restraint.norm();
+
+  // counted once
+  EXPECT_LT((grad - (quadratic + restraint)).norm() / scale, 1e-4);
+  // not missing
+  EXPECT_GT((grad - quadratic).norm() / scale, 0.5);
+  // not doubled
+  EXPECT_GT((grad - (quadratic + 2.0 * restraint)).norm() / scale, 0.5);
+}
+
+TEST(RestraintTest, BaseGradientDependsOnValueReportingRestraints)
+{
+  // Documents the contract the test above relies on: the base gradient() has
+  // no restraint term of its own, so a value() override that omits
+  // constraintEnergies() silently drops the restraint from the gradient.
+  const Eigen::VectorXd x = butaneSkeleton();
+
+  RestrainedQuadraticCalculator calc;
+  calc.setConstraints({ Constraint(0, 1, 2, 3, 45.0) });
+  calc.includeRestraints(false);
+
+  Eigen::VectorXd grad = Eigen::VectorXd::Zero(x.size());
+  calc.gradient(x, grad);
+
+  EXPECT_TRUE(grad.isApprox(2.0 * x, 1e-5));
 }
 
 // Mask Tests


### PR DESCRIPTION
Fixes #2930
- Constraints were in radians, but UI in degrees
- Use std::remainder to handle periodicity
- Split force constants for distance and angles

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of distance, angle, torsion, and out-of-plane restraints.
  * Corrected torsion handling across periodic angle boundaries.
  * Prevented duplicate restraint contributions in gradient calculations.
  * Ensured frozen coordinates remain respected when applying restraint gradients.

* **Improvements**
  * Added sensible default force constants for distance and angular restraints.
  * Clarified that angular restraint values use degrees while force constants use radians.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->