### PR TITLE
Fix for reading Gaussian through Open Babel

### DIFF
--- a/avogadro/qtplugins/openbabel/openbabel.cpp
+++ b/avogadro/qtplugins/openbabel/openbabel.cpp
@@ -260,19 +260,25 @@ void OpenBabel::handleReadFormatUpdate(const QMultiMap<QString, QString>& fmts)
 
   m_readFormats = fmts;
 
-  // Emit a signal indicating the file formats are ready if read and write
-  // formats have both returned their results.
-  if (!m_readFormatsPending && !m_writeFormatsPending) {
-    // Update the default format if cjson is available
-    if (m_readFormats.contains("Chemical JSON") &&
-        m_writeFormats.contains("Chemical JSON")) {
-      m_defaultFormat = "cjson";
+  formatQueryFinished();
+}
 
-      qDebug() << "Setting default format to " << m_defaultFormat.c_str();
-    }
+void OpenBabel::formatQueryFinished()
+{
+  // Wait until both the read and write queries have returned their results.
+  if (m_readFormatsPending || m_writeFormatsPending)
+    return;
 
-    emit fileFormatsReady();
+  // Update the default format if cjson is available. This must happen *before*
+  // fileFormatsReady() is emitted: fileFormats() copies m_defaultFormat into
+  // every OBFileFormat it creates, and CML cannot round-trip vibrations,
+  // spectra, or other calculated data.
+  if (m_readFormats.contains("Chemical JSON") &&
+      m_writeFormats.contains("Chemical JSON")) {
+    m_defaultFormat = "cjson";
   }
+
+  emit fileFormatsReady();
 }
 
 void OpenBabel::refreshWriteFormats()
@@ -297,18 +303,7 @@ void OpenBabel::handleWriteFormatUpdate(const QMultiMap<QString, QString>& fmts)
 
   m_writeFormats = fmts;
 
-  // Emit a signal indicating the file formats are ready if read and write
-  // formats have both returned their results.
-  if (!m_readFormatsPending && !m_writeFormatsPending) {
-    emit fileFormatsReady();
-
-    // Update the default format if cjson is available
-    if (m_readFormats.contains("Chemical JSON") &&
-        m_writeFormats.contains("Chemical JSON")) {
-      m_defaultFormat = "cjson";
-      qDebug() << "Setting default format to cjson.";
-    }
-  }
+  formatQueryFinished();
 }
 
 void OpenBabel::refreshForceFields()

--- a/avogadro/qtplugins/openbabel/openbabel.h
+++ b/avogadro/qtplugins/openbabel/openbabel.h
@@ -95,6 +95,9 @@ private:
                                 bool showDialog = true);
   void showProcessInUseError(const QString& title) const;
   QString autoDetectForceField() const;
+  /// Pick the default interchange format and announce the file formats once
+  /// both the read and write format queries have finished.
+  void formatQueryFinished();
 
   QtGui::Molecule* m_molecule;
   OBProcess* m_process;

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -93,14 +93,17 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
     }
   }
 
-  // Reset every time to be sure we don't return the *last* identifier
-  const std::lock_guard<std::mutex> lock(m_identifierMutex);
-  m_identifier = "Avogadro: Generic Output";
+  // Reset every time to be sure we don't return the *last* identifier.
+  // Work out the new value before taking the lock and take it exactly once:
+  // m_identifierMutex is not recursive, so locking it a second time here
+  // deadlocks this thread, and identifier() then blocks every caller too.
+  std::string identifier("Avogadro: Generic Output");
+  if (reader != nullptr)
+    identifier = reader->identifier();
 
-  if (reader != nullptr) {
-    // now update the identifier
+  {
     const std::lock_guard<std::mutex> lock(m_identifierMutex);
-    m_identifier = reader->identifier();
+    m_identifier = identifier;
   }
 
   // rewind the stream


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-format loading so format options appear only after all available information is ready.
  * Ensured the preferred CJSON format is selected consistently when available.
  * Fixed format detection when reading files, including proper reset and update of the detected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->