### PR TITLE
Add progress reporting (and cancel) for plugin scripts

### DIFF
--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -201,10 +201,15 @@ bool InterfaceScript::runCommand(const QJsonObject& options_,
     return false;
   }
 
+  // UniqueConnection: the connections are only torn down on the failure path
+  // below, so running the same instance again would otherwise stack duplicates
+  // and deliver every signal once per previous run.
   connect(m_interpreter, &PythonScript::finished, this,
-          &::Avogadro::QtGui::InterfaceScript::commandFinished);
+          &::Avogadro::QtGui::InterfaceScript::commandFinished,
+          Qt::UniqueConnection);
   connect(m_interpreter, &PythonScript::asyncProgress, this,
-          &::Avogadro::QtGui::InterfaceScript::handleProgress);
+          &::Avogadro::QtGui::InterfaceScript::handleProgress,
+          Qt::UniqueConnection);
   // Package-mode scripts take no command-line flag; the identifier is already
   // the positional argument and JSON arrives on stdin (mirrors
   // InputGenerator::generateInput() which passes QStringList()).

--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -203,20 +203,38 @@ bool InterfaceScript::runCommand(const QJsonObject& options_,
 
   connect(m_interpreter, &PythonScript::finished, this,
           &::Avogadro::QtGui::InterfaceScript::commandFinished);
+  connect(m_interpreter, &PythonScript::asyncProgress, this,
+          &::Avogadro::QtGui::InterfaceScript::handleProgress);
   // Package-mode scripts take no command-line flag; the identifier is already
   // the positional argument and JSON arrives on stdin (mirrors
   // InputGenerator::generateInput() which passes QStringList()).
   QStringList runArgs;
   if (!m_interpreter->isPackageMode())
     runArgs << QStringLiteral("--run-command");
-  if (!m_interpreter->asyncExecute(runArgs,
-                                   QJsonDocument(allOptions).toJson())) {
+  // Scan stdout for progress envelopes, and keep stderr on its own channel so
+  // library chatter (pixi, warnings, progress bars) cannot corrupt the result.
+  m_interpreter->setProgressScanning(true);
+  if (!m_interpreter->asyncExecute(runArgs, QJsonDocument(allOptions).toJson(),
+                                   /* mergedChannels = */ false)) {
     disconnect(m_interpreter, &PythonScript::finished, this,
                &::Avogadro::QtGui::InterfaceScript::commandFinished);
+    disconnect(m_interpreter, &PythonScript::asyncProgress, this,
+               &::Avogadro::QtGui::InterfaceScript::handleProgress);
     m_errors << m_interpreter->errorList();
     return false;
   }
   return true;
+}
+
+void InterfaceScript::handleProgress(const QJsonObject& payload)
+{
+  const QString message =
+    payload.value(QStringLiteral("message")).toString(QString());
+  // -1 marks "not supplied" - the bar keeps whatever state it had.
+  const int value = payload.value(QStringLiteral("value")).toInt(-1);
+  const int maximum = payload.value(QStringLiteral("maximum")).toInt(-1);
+
+  emit progress(message, value, maximum);
 }
 
 void InterfaceScript::commandFinished()
@@ -240,6 +258,12 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
 
   QJsonDocument doc;
   if (!parseJson(json, doc)) {
+    // The script ran with separate channels, so a python traceback never
+    // reached stdout. Surface it here or the failure has no explanation.
+    const QByteArray stderrOutput = m_interpreter->asyncStandardError();
+    if (!stderrOutput.isEmpty())
+      m_errors << tr("Script standard error:\n%1")
+                    .arg(QString::fromUtf8(stderrOutput));
     return false;
   }
 

--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -273,7 +273,6 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
   }
 
   // Update cache
-  bool result = true;
   if (doc.isObject()) {
     QJsonObject obj = doc.object();
 
@@ -327,7 +326,15 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
       }
 
       QtGui::Molecule newMol(guiMol->parent());
-      result = format->readString(moleculeString.toStdString(), newMol);
+      if (!format->readString(moleculeString.toStdString(), newMol)) {
+        // A failed parse can still leave atoms behind (a truncated xyz file
+        // reads several before it gives up), so this has to stop before
+        // anything touches guiMol: replacing the user's molecule with a
+        // fragment of what the script meant to return loses their structure.
+        m_errors << tr("Error reading molecule representation: %1")
+                      .arg(QString::fromStdString(format->error()));
+        return false;
+      }
 
       // check if the script wants us to perceive bonds first
       if (obj["bond"].toBool()) {
@@ -400,7 +407,7 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
       }
     }
   }
-  return result;
+  return true;
 }
 
 bool InterfaceScript::generateInput(const QJsonObject& options_,

--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -296,49 +296,57 @@ bool InterfaceScript::processCommand(Core::Molecule* mol)
       m_moleculeExtension = obj["moleculeFormat"].toString();
     }
 
-    Io::FileFormatManager& formats = Io::FileFormatManager::instance();
-    QScopedPointer<Io::FileFormat> format(
-      formats.newFormatFromFileExtension(m_moleculeExtension.toStdString()));
-
-    if (format.isNull()) {
-      m_errors << tr("Error reading molecule representation: "
-                     "Unrecognized file format: %1")
-                    .arg(m_moleculeExtension);
-      return false;
-    }
-
-    auto* guiMol = static_cast<QtGui::Molecule*>(mol);
-    QtGui::Molecule newMol(guiMol->parent());
+    // Pull out the molecule the script returned, if it returned one at all.
+    // Commands that only report a message (e.g. exporting an image) must leave
+    // the current molecule untouched rather than replacing it with an empty
+    // one.
+    QString moleculeString;
     if (m_moleculeExtension == "cjson") {
-      // convert the "cjson" field to a string
       QJsonObject cjsonObj = obj["cjson"].toObject();
-      QJsonDocument doc2(cjsonObj);
-      QString strCJSON(doc2.toJson(QJsonDocument::Compact));
-      if (!strCJSON.isEmpty()) {
-        result = format->readString(strCJSON.toStdString(), newMol);
+      if (!cjsonObj.isEmpty()) {
+        QJsonDocument doc2(cjsonObj);
+        moleculeString = QString(doc2.toJson(QJsonDocument::Compact));
       }
     } else if (obj.contains(m_moleculeExtension) &&
                obj[m_moleculeExtension].isString()) {
-      QString strFile = obj[m_moleculeExtension].toString();
-      result = format->readString(strFile.toStdString(), newMol);
+      moleculeString = obj[m_moleculeExtension].toString();
     }
 
-    // check if the script wants us to perceive bonds first
-    if (obj["bond"].toBool()) {
-      newMol.perceiveBondsSimple();
-      newMol.perceiveBondOrders();
-    }
+    auto* guiMol = static_cast<QtGui::Molecule*>(mol);
 
-    // how do we handle this result?
-    if (obj["readProperties"].toBool()) {
-      guiMol->readProperties(newMol);
-      guiMol->emitChanged(Molecule::Properties | Molecule::Added);
-    } else if (obj["append"].toBool()) {
-      guiMol->undoMolecule()->appendMolecule(newMol, m_displayName);
-    } else { // replace the whole molecule
-      Molecule::MoleculeChanges changes = (Molecule::Atoms | Molecule::Bonds |
-                                           Molecule::Added | Molecule::Removed);
-      guiMol->undoMolecule()->modifyMolecule(newMol, changes, m_displayName);
+    if (!moleculeString.isEmpty()) {
+      Io::FileFormatManager& formats = Io::FileFormatManager::instance();
+      QScopedPointer<Io::FileFormat> format(
+        formats.newFormatFromFileExtension(m_moleculeExtension.toStdString()));
+
+      if (format.isNull()) {
+        m_errors << tr("Error reading molecule representation: "
+                       "Unrecognized file format: %1")
+                      .arg(m_moleculeExtension);
+        return false;
+      }
+
+      QtGui::Molecule newMol(guiMol->parent());
+      result = format->readString(moleculeString.toStdString(), newMol);
+
+      // check if the script wants us to perceive bonds first
+      if (obj["bond"].toBool()) {
+        newMol.perceiveBondsSimple();
+        newMol.perceiveBondOrders();
+      }
+
+      // how do we handle this result?
+      if (obj["readProperties"].toBool()) {
+        guiMol->readProperties(newMol);
+        guiMol->emitChanged(Molecule::Properties | Molecule::Added);
+      } else if (obj["append"].toBool()) {
+        guiMol->undoMolecule()->appendMolecule(newMol, m_displayName);
+      } else { // replace the whole molecule
+        Molecule::MoleculeChanges changes =
+          (Molecule::Atoms | Molecule::Bonds | Molecule::Added |
+           Molecule::Removed);
+        guiMol->undoMolecule()->modifyMolecule(newMol, changes, m_displayName);
+      }
     }
 
     // select some atoms

--- a/avogadro/qtgui/interfacescript.h
+++ b/avogadro/qtgui/interfacescript.h
@@ -426,6 +426,66 @@ $$coords:[coordSpec]$$
  * - `$$atomCount$$`: Number of atoms in the molecule.
  * - `$$bondCount$$`: Number of bonds in the molecule.
  *
+ * Progress and Status Updates
+ * ===========================
+ *
+ * A long-running command script can report its progress while it works, so the
+ * user sees a determinate progress bar and/or a status message instead of an
+ * anonymous spinner. To do so, print a single line of JSON to standard output
+ * of the form:
+~~~{.js}
+{"avogadro": {"message": "Optimizing conformer 3 of 25", "value": 3, "maximum":
+25}}
+~~~
+ * All three members are optional:
+ * - `message`: status text to display, e.g. "Current energy: -135.2 eV".
+ * - `value`: the current step of a determinate progress bar.
+ * - `maximum`: the total number of steps. Supply `value` and `maximum`
+ *   together; a `message` on its own just updates the text and leaves the bar
+ *   as it was.
+ *
+ * These lines are consumed by Avogadro and removed from the script's output,
+ * so they do not interfere with the final result. A line is only treated as a
+ * progress update if it is a complete JSON object on one line with exactly one
+ * member, named `avogadro` — a pretty-printed result block is never mistaken
+ * for one, and any other output the script prints is passed through untouched.
+ *
+ * **`flush=True` is required.** Python block-buffers standard output when it is
+ * connected to a pipe rather than a terminal, so without an explicit flush the
+ * updates sit in the buffer and only reach Avogadro when the script exits — by
+ * which point the progress bar is gone.
+ *
+ * The `avogadro.command` module (shipped with Avogadro) provides a helper:
+~~~{.py}
+from avogadro.command import report_progress
+
+for i, conformer in enumerate(conformers, start=1):
+    report_progress(f"Conformer {i} of {len(conformers)}", i, len(conformers))
+    optimize(conformer)
+
+report_progress("Writing results")
+~~~
+ * That module is not importable in every environment a script may run in (for
+ * example a package plugin with its own pixi environment), so scripts are free
+ * to copy this self-contained equivalent instead:
+~~~{.py}
+import json
+
+def report_progress(message=None, value=None, maximum=None):
+    payload = {}
+    if message is not None: payload["message"] = message
+    if value is not None:   payload["value"] = value
+    if maximum is not None: payload["maximum"] = maximum
+    # flush=True is required - stdout is block-buffered when piped
+    print(json.dumps({"avogadro": payload}), flush=True)
+~~~
+ * Reporting progress is entirely optional; a script that prints nothing until
+ * it is finished behaves exactly as it always has.
+ *
+ * The progress dialog shown while a command runs has a Cancel button, which
+ * kills the script's process. Scripts that write files or otherwise touch state
+ * outside Avogadro should be prepared to be terminated partway through.
+ *
  * Error Handling
  * ==============
  *
@@ -434,6 +494,12 @@ $$coords:[coordSpec]$$
  * occurs that must be reported to the user, simply write the error message to
  * standard output as plain text (i.e. not JSON), and it will be shown to the
  * user.
+ *
+ * While a command script runs (`--run-command`), its standard output and
+ * standard error are kept separate: the result and any plain-text error belong
+ * on standard output, while standard error is captured for diagnostics and
+ * reported if the output cannot be parsed. This means library chatter and
+ * warnings on standard error cannot corrupt the result.
  *
  * Debugging
  * =========
@@ -633,6 +699,17 @@ public:
 signals:
   void finished();
 
+  /**
+   * A running command script reported its progress. See the "Progress and
+   * Status Updates" section above for the script-side protocol.
+   * @param message Status text to show, or an empty string if the script did
+   * not supply one.
+   * @param value The current step, or -1 if the script did not supply one.
+   * @param maximum The total number of steps, or -1 if the script did not
+   * supply one.
+   */
+  void progress(const QString& message, int value, int maximum);
+
 public slots:
   /**
    * Enable/disable debugging.
@@ -643,6 +720,13 @@ public slots:
    * Receives a signal when asynchronous command scripts are finished
    */
   void commandFinished();
+
+private slots:
+  /**
+   * Translate a progress envelope from a running command script into the
+   * progress() signal.
+   */
+  void handleProgress(const QJsonObject& payload);
 
 protected:
   bool parseJson(const QByteArray& json, QJsonDocument& doc) const;

--- a/avogadro/qtgui/interfacescript.h
+++ b/avogadro/qtgui/interfacescript.h
@@ -447,15 +447,25 @@ $$coords:[coordSpec]$$
  * These lines are consumed by Avogadro and removed from the script's output,
  * so they do not interfere with the final result. A line is only treated as a
  * progress update if it is a complete JSON object on one line with exactly one
- * member, named `avogadro` — a pretty-printed result block is never mistaken
- * for one, and any other output the script prints is passed through untouched.
+ * member, named `avogadro`, whose value is an object — a pretty-printed result
+ * block is never mistaken for one, and any other output the script prints is
+ * passed through untouched.
+ *
+ * **Check `AVO_PROGRESS_PROTOCOL` before printing an envelope.** Avogadro
+ * 2.0.0 and earlier read the whole of a script's standard output as a single
+ * JSON document, so an extra line makes that parse fail and the command
+ * reports an error instead of its result. Avogadro sets this environment
+ * variable only when it is reading progress updates, so a script that guards
+ * on it keeps working on older releases — it just shows the old indeterminate
+ * spinner. The value is the protocol revision, currently `1`.
  *
  * **`flush=True` is required.** Python block-buffers standard output when it is
  * connected to a pipe rather than a terminal, so without an explicit flush the
  * updates sit in the buffer and only reach Avogadro when the script exits — by
  * which point the progress bar is gone.
  *
- * The `avogadro.command` module (shipped with Avogadro) provides a helper:
+ * The `avogadro.command` module (shipped with Avogadro) handles both of these,
+ * and is a no-op when progress is unsupported, so it is always safe to call:
 ~~~{.py}
 from avogadro.command import report_progress
 
@@ -467,11 +477,15 @@ report_progress("Writing results")
 ~~~
  * That module is not importable in every environment a script may run in (for
  * example a package plugin with its own pixi environment), so scripts are free
- * to copy this self-contained equivalent instead:
+ * to copy this self-contained equivalent instead. Do not drop the environment
+ * check — without it the script breaks on Avogadro 2.0.0:
 ~~~{.py}
-import json
+import json, os
 
 def report_progress(message=None, value=None, maximum=None):
+    # Older Avogadro cannot parse these lines; stay silent there.
+    if not os.environ.get("AVO_PROGRESS_PROTOCOL"):
+        return
     payload = {}
     if message is not None: payload["message"] = message
     if value is not None:   payload["value"] = value

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -57,7 +57,18 @@ PythonScript::PythonScript(QObject* parent_)
   setDefaultPythonInterpreter();
 }
 
-PythonScript::~PythonScript() {}
+PythonScript::~PythonScript()
+{
+  if (m_process != nullptr) {
+    // Sever the connections before killing: finished() would otherwise be
+    // emitted into a half-destroyed object. Delete outright rather than
+    // deleteLater(), which never runs if no event loop outlives us.
+    disconnect(m_process, nullptr, this, nullptr);
+    m_process->kill();
+    delete m_process;
+    m_process = nullptr;
+  }
+}
 
 void PythonScript::setScriptFilePath(const QString& scriptFile)
 {
@@ -330,7 +341,9 @@ bool PythonScript::asyncExecute(const QStringList& args,
     disconnect(m_process, nullptr, this, nullptr);
     m_process->deleteLater();
   }
-  m_process = new QProcess(parent());
+  // Own the process outright: parenting it to parent() (which is often null)
+  // leaks it, and lets it outlive the script that is driving it.
+  m_process = new QProcess(this);
 
   if (mergedChannels)
     m_process->setProcessChannelMode(QProcess::MergedChannels);

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -20,6 +20,13 @@
 
 namespace Avogadro::QtGui {
 
+// Environment variable telling a script that Avogadro is reading its standard
+// output for progress envelopes, and which revision of that protocol it
+// speaks. Bump the version if the envelope format ever changes, so scripts can
+// feature-detect rather than guess from the Avogadro version.
+static const char progressEnvironmentVariable[] = "AVO_PROGRESS_PROTOCOL";
+static const char progressProtocolVersion[] = "1";
+
 // Check whether the plugin directory has a usable pixi-managed python
 static bool hasDefaultPixiManifest(const QString& pluginDir)
 {
@@ -128,11 +135,25 @@ void PythonScript::setDefaultPythonInterpreter()
 
 QString PythonScript::resolveCommand(QStringList& realArgs, QProcess& proc)
 {
-#ifdef Q_OS_WIN
   QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  bool customEnvironment = false;
+
+#ifdef Q_OS_WIN
   environment.insert(QStringLiteral("PYTHONUTF8"), QStringLiteral("1"));
-  proc.setProcessEnvironment(environment);
+  customEnvironment = true;
 #endif
+
+  if (m_scanProgress) {
+    // Advertise the progress protocol only when we are actually scanning for
+    // it, so a script that checks the variable can never be misled into
+    // printing envelopes at a version of Avogadro that would choke on them.
+    environment.insert(QLatin1String(progressEnvironmentVariable),
+                       QLatin1String(progressProtocolVersion));
+    customEnvironment = true;
+  }
+
+  if (customEnvironment)
+    proc.setProcessEnvironment(environment);
 
   // --- Package mode: pixi run <command> <identifier> [args] ---
   if (m_packageMode) {

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
+#include <QtCore/QJsonDocument>
 #include <QtCore/QLocale>
 #include <QtCore/QProcess>
 #include <QtCore/QProcessEnvironment>
@@ -302,13 +303,28 @@ bool PythonScript::asyncExecute(const QStringList& args,
   clearErrors();
   if (m_process != nullptr) {
     m_process->terminate();
-    disconnect(m_process, SIGNAL(finished()), this, SLOT(processsFinished()));
+    // Sever every connection, not just finished(): the abandoned process is
+    // still alive until deleteLater() runs, and its signals would otherwise
+    // arrive while m_process already points at the replacement.
+    disconnect(m_process, nullptr, this, nullptr);
     m_process->deleteLater();
   }
   m_process = new QProcess(parent());
 
   if (mergedChannels)
     m_process->setProcessChannelMode(QProcess::MergedChannels);
+
+  m_stdoutBuffer.clear();
+  m_stderrBuffer.clear();
+  m_lineBuffer.clear();
+  if (m_scanProgress) {
+    // Drain both channels as they arrive so progress envelopes can be acted on
+    // while the script is still running.
+    connect(m_process, &QProcess::readyReadStandardOutput, this,
+            &PythonScript::readAsyncStandardOutput);
+    connect(m_process, &QProcess::readyReadStandardError, this,
+            &PythonScript::readAsyncStandardError);
+  }
 
   QStringList realArgs(args);
   if (m_debug)
@@ -371,7 +387,86 @@ bool PythonScript::asyncExecute(const QStringList& args,
 
 void PythonScript::processFinished(int, QProcess::ExitStatus)
 {
+  if (m_scanProgress && m_process != nullptr) {
+    // readyRead() may not have fired for the last chunk, and a script's final
+    // line is not guaranteed to end with a newline.
+    readAsyncStandardError();
+    readAsyncStandardOutput();
+    if (!m_lineBuffer.isEmpty()) {
+      QJsonObject payload;
+      if (parseProgressEnvelope(m_lineBuffer, payload))
+        emit asyncProgress(payload);
+      else
+        m_stdoutBuffer += m_lineBuffer;
+      m_lineBuffer.clear();
+    }
+
+    if (m_debug && !m_stderrBuffer.isEmpty())
+      qDebug() << "Script standard error:" << m_stderrBuffer;
+  }
+
   emit finished();
+}
+
+bool PythonScript::parseProgressEnvelope(const QByteArray& line,
+                                         QJsonObject& payload)
+{
+  // Reject cheaply first: the result blob may be large and pretty-printed, and
+  // running the JSON parser over every one of its lines is wasted work.
+  const QByteArray trimmed = line.trimmed();
+  if (!trimmed.startsWith('{') || !trimmed.contains("\"avogadro\""))
+    return false;
+
+  QJsonParseError error;
+  const QJsonDocument doc = QJsonDocument::fromJson(trimmed, &error);
+  if (error.error != QJsonParseError::NoError || !doc.isObject())
+    return false;
+
+  // Require exactly one member, named "avogadro". A result object that merely
+  // happens to carry an "avogadro" key alongside others is not an envelope.
+  const QJsonObject object = doc.object();
+  if (object.size() != 1 || !object.contains(QStringLiteral("avogadro")))
+    return false;
+
+  payload = object.value(QStringLiteral("avogadro")).toObject();
+  return true;
+}
+
+void PythonScript::filterProgressLines(QByteArray& buffer, QByteArray& output,
+                                       QList<QJsonObject>& payloads)
+{
+  qsizetype start = 0;
+  qsizetype newline = buffer.indexOf('\n');
+  QJsonObject payload;
+  while (newline >= 0) {
+    if (parseProgressEnvelope(buffer.mid(start, newline - start), payload))
+      payloads.append(payload);
+    else // keep the line verbatim, newline included
+      output += buffer.mid(start, newline - start + 1);
+    start = newline + 1;
+    newline = buffer.indexOf('\n', start);
+  }
+  buffer.remove(0, start);
+}
+
+void PythonScript::readAsyncStandardOutput()
+{
+  if (m_process == nullptr)
+    return;
+
+  m_lineBuffer += m_process->readAllStandardOutput();
+  QList<QJsonObject> payloads;
+  filterProgressLines(m_lineBuffer, m_stdoutBuffer, payloads);
+  for (const QJsonObject& payload : payloads)
+    emit asyncProgress(payload);
+}
+
+void PythonScript::readAsyncStandardError()
+{
+  if (m_process == nullptr)
+    return;
+
+  m_stderrBuffer += m_process->readAllStandardError();
 }
 
 void PythonScript::asyncTerminate()
@@ -432,6 +527,15 @@ QByteArray PythonScript::asyncWriteAndResponseRaw(const QByteArray& input,
 
 QByteArray PythonScript::asyncResponse()
 {
+  if (m_scanProgress) {
+    // Standard output was drained as it arrived, so the buffer is complete
+    // (and outlives the process) once the script has finished.
+    if (m_process != nullptr && m_process->state() == QProcess::Running)
+      return QByteArray();
+
+    return m_stdoutBuffer;
+  }
+
   if (m_process == nullptr || m_process->state() == QProcess::Running)
     return QByteArray();
 

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -425,10 +425,16 @@ bool PythonScript::parseProgressEnvelope(const QByteArray& line,
   // Require exactly one member, named "avogadro". A result object that merely
   // happens to carry an "avogadro" key alongside others is not an envelope.
   const QJsonObject object = doc.object();
-  if (object.size() != 1 || !object.contains(QStringLiteral("avogadro")))
+  if (object.size() != 1)
     return false;
 
-  payload = object.value(QStringLiteral("avogadro")).toObject();
+  // The member must be an object. A scalar or null payload would otherwise
+  // yield an empty payload from toObject() and silently swallow the line.
+  const QJsonValue value = object.value(QStringLiteral("avogadro"));
+  if (!value.isObject())
+    return false;
+
+  payload = value.toObject();
   return true;
 }
 

--- a/avogadro/qtgui/pythonscript.h
+++ b/avogadro/qtgui/pythonscript.h
@@ -12,6 +12,8 @@
 #include <avogadro/core/avogadrocore.h>
 
 #include <QtCore/QByteArray>
+#include <QtCore/QJsonObject>
+#include <QtCore/QList>
 #include <QtCore/QProcess>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
@@ -139,6 +141,48 @@ public:
                     bool mergedChannels = true, bool closeWriteChannel = true);
 
   /**
+   * Enable incremental scanning of the asynchronous process' standard output
+   * for progress envelopes, i.e. single lines of the form
+   * `{"avogadro": { ... }}`. Matching lines are removed from the output and
+   * reported through the asyncProgress() signal; every other line is kept and
+   * returned by asyncResponse() as usual.
+   *
+   * This must be set before asyncExecute(). It is opt-in because scanning
+   * drains the process' output as it arrives, which is incompatible with
+   * callers that read the process directly (e.g. asyncWriteAndResponse() in
+   * "server mode").
+   */
+  void setProgressScanning(bool enable) { m_scanProgress = enable; }
+
+  /**
+   * @return True if standard output is being scanned for progress envelopes.
+   */
+  bool progressScanning() const { return m_scanProgress; }
+
+  /**
+   * Test whether a single line of script output is a progress envelope.
+   *
+   * To avoid mistaking part of a pretty-printed result for an envelope, the
+   * line must parse as a complete JSON object with exactly one member, named
+   * "avogadro".
+   *
+   * @param line The line to test, without its trailing newline.
+   * @param payload Set to the contents of the "avogadro" member on success.
+   * @return True if @p line is a progress envelope.
+   */
+  static bool parseProgressEnvelope(const QByteArray& line,
+                                    QJsonObject& payload);
+
+  /**
+   * Split @p buffer into complete lines, appending the payload of any progress
+   * envelope to @p payloads and every other line (newline included) verbatim
+   * to @p output. A trailing partial line is left in @p buffer for the next
+   * call.
+   */
+  static void filterProgressLines(QByteArray& buffer, QByteArray& output,
+                                  QList<QJsonObject>& payloads);
+
+  /**
    * Write input to the asynchronous process' standard input and return the
    * standard output when ready. Does not wait for the process to terminate
    * before returning (e.g. "server mode").
@@ -163,14 +207,31 @@ public:
 
   /**
    * Returns the standard output of the asynchronous process when finished.
+   * If progress scanning is enabled, progress envelope lines have been
+   * removed and the remainder is returned even after the process is gone.
    */
   QByteArray asyncResponse();
+
+  /**
+   * @return The standard error collected from the asynchronous process. Only
+   * populated when the process was started with separate channels; useful for
+   * reporting a python traceback that never reached standard output.
+   */
+  QByteArray asyncStandardError() const { return m_stderrBuffer; }
 
 signals:
   /**
    * The asynchronous execution is finished or timed out
    */
   void finished();
+
+  /**
+   * A progress envelope was read from the asynchronous process' standard
+   * output. Only emitted when setProgressScanning(true) was called before
+   * asyncExecute().
+   * @param payload The contents of the "avogadro" member of the envelope.
+   */
+  void asyncProgress(const QJsonObject& payload);
 
 public slots:
   /**
@@ -182,6 +243,16 @@ public slots:
    * Handle a finished process;
    */
   void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+private slots:
+  /**
+   * Drain whatever the asynchronous process has written so far, filtering
+   * progress envelopes out of standard output.
+   * @{
+   */
+  void readAsyncStandardOutput();
+  void readAsyncStandardError();
+  /**@}*/
 
 protected:
   bool m_debug;
@@ -197,6 +268,16 @@ protected:
   QProcess* m_process;
 
 private:
+  // Scan the asynchronous process' stdout for progress envelopes, buffering
+  // the rest for asyncResponse(). Off by default; see setProgressScanning().
+  bool m_scanProgress = false;
+  // Standard output with any progress envelopes removed.
+  QByteArray m_stdoutBuffer;
+  // Standard error, kept for diagnostics (separate channels only).
+  QByteArray m_stderrBuffer;
+  // Trailing partial line of standard output, awaiting its newline.
+  QByteArray m_lineBuffer;
+
   /**
    * Resolve the executable and finalize the argument list for either
    * execute() or asyncExecute().  On entry @p realArgs already contains

--- a/avogadro/qtgui/pythonscript.h
+++ b/avogadro/qtgui/pythonscript.h
@@ -151,6 +151,12 @@ public:
    * drains the process' output as it arrives, which is incompatible with
    * callers that read the process directly (e.g. asyncWriteAndResponse() in
    * "server mode").
+   *
+   * When enabled, the script is run with `AVO_PROGRESS_PROTOCOL` set in its
+   * environment so it can tell that Avogadro is listening. Scripts must check
+   * for it before printing envelopes: releases up to and including Avogadro
+   * 2.0.0 read the script's whole standard output as a single JSON document,
+   * and the extra lines make that parse fail outright.
    */
   void setProgressScanning(bool enable) { m_scanProgress = enable; }
 

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -293,8 +293,7 @@ void Command::run()
   if (m_currentDialog)
     m_currentDialog->accept();
 
-  if (m_progress)
-    m_progress->deleteLater();
+  closeProgressDialog();
 
   if (m_currentScript) {
     disconnect(m_currentScript, SIGNAL(finished()), this,
@@ -372,13 +371,25 @@ void Command::updateProgress(const QString& message, int value, int maximum)
     m_progress->setLabelText(message);
 }
 
+void Command::closeProgressDialog()
+{
+  if (m_progress == nullptr)
+    return;
+
+  // Clear the member and drop the connection before closing: close() emits
+  // canceled() even for a dialog that was never shown, and cancelCommand()
+  // would then delete the dialog (and the running script) out from under
+  // whoever called us.
+  QProgressDialog* dialog = m_progress;
+  m_progress = nullptr;
+  disconnect(dialog, &QProgressDialog::canceled, this, &Command::cancelCommand);
+  dialog->close();
+  dialog->deleteLater();
+}
+
 void Command::cancelCommand()
 {
-  if (m_progress) {
-    m_progress->close();
-    m_progress->deleteLater();
-    m_progress = nullptr;
-  }
+  closeProgressDialog();
 
   if (m_currentScript == nullptr)
     return;
@@ -394,11 +405,7 @@ void Command::cancelCommand()
 
 void Command::commandFailed(const QStringList& errors)
 {
-  if (m_progress) {
-    m_progress->close();
-    m_progress->deleteLater();
-    m_progress = nullptr;
-  }
+  closeProgressDialog();
 
   QString details = errors.join(QStringLiteral("\n"));
   if (details.isEmpty())
@@ -420,22 +427,26 @@ void Command::processFinished()
   if (m_currentScript == nullptr)
     return;
 
-  if (m_progress) {
-    m_progress->close();
-    m_progress->deleteLater();
-    m_progress = nullptr;
-  }
+  // Take the script and its molecule locally before doing anything that can
+  // run the event loop (closing the dialog, writing results back): a
+  // re-entrant call must see this command as already finished rather than act
+  // on a script that is being torn down here.
+  QtGui::InterfaceScript* script = m_currentScript;
+  m_currentScript = nullptr;
+  QtGui::Molecule* target = m_runningMolecule.data();
+  m_runningMolecule.clear();
+
+  closeProgressDialog();
 
   // Drop results if the launch-time molecule was destroyed, or if the user
   // has since swapped to a different molecule (its atom count/ordering may
   // no longer match what the script is about to write back).
-  QtGui::Molecule* target = m_runningMolecule.data();
   if (target != nullptr && target == m_molecule) {
-    m_currentScript->processCommand(target);
+    script->processCommand(target);
 
     // collect errors
-    if (m_currentScript->hasErrors()) {
-      qWarning() << m_currentScript->errorList();
+    if (script->hasErrors()) {
+      qWarning() << script->errorList();
     }
   } else if (target == nullptr) {
     qWarning() << "Command: discarding script results; molecule was closed "
@@ -445,9 +456,7 @@ void Command::processFinished()
                   "changed while the command was running.";
   }
 
-  m_currentScript->deleteLater();
-  m_currentScript = nullptr;
-  m_runningMolecule.clear();
+  script->deleteLater();
 }
 
 void Command::configurePython()

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -328,12 +328,21 @@ void Command::run()
       options = collected;
     }
     connect(m_currentScript, SIGNAL(finished()), this, SLOT(processFinished()));
+    connect(m_currentScript, &QtGui::InterfaceScript::progress, this,
+            &Command::updateProgress);
 
-    // no cancel button - just an indication we're waiting...
+    // Starts indeterminate; a script that reports progress switches it to a
+    // determinate bar. See InterfaceScript for the script-side protocol.
     QString title = tr("Processing %1").arg(iface.displayName());
-    m_progress = new QProgressDialog(title, QString(), 0, 0,
+    m_progress = new QProgressDialog(title, tr("Cancel"), 0, 0,
                                      qobject_cast<QWidget*>(parent()));
     m_progress->setMinimumDuration(1000); // 1 second
+    // Don't let a script that reports its final step and then keeps working
+    // (writing files, etc.) make the dialog vanish early.
+    m_progress->setAutoClose(false);
+    m_progress->setAutoReset(false);
+    connect(m_progress, &QProgressDialog::canceled, this,
+            &Command::cancelCommand);
 
     // Snapshot so processFinished() can detect if the molecule was closed
     // or swapped before the async script returned.
@@ -345,6 +354,42 @@ void Command::run()
       commandFailed(m_currentScript->errorList());
     }
   }
+}
+
+void Command::updateProgress(const QString& message, int value, int maximum)
+{
+  if (m_progress == nullptr)
+    return;
+
+  if (maximum > 0 && m_progress->maximum() != maximum)
+    m_progress->setRange(0, maximum);
+
+  // Only meaningful once a script has given the bar a determinate range.
+  if (value >= 0 && m_progress->maximum() > 0)
+    m_progress->setValue(value);
+
+  if (!message.isEmpty())
+    m_progress->setLabelText(message);
+}
+
+void Command::cancelCommand()
+{
+  if (m_progress) {
+    m_progress->close();
+    m_progress->deleteLater();
+    m_progress = nullptr;
+  }
+
+  if (m_currentScript == nullptr)
+    return;
+
+  // Kill the child process and drop whatever partial output it produced.
+  disconnect(m_currentScript, SIGNAL(finished()), this,
+             SLOT(processFinished()));
+  m_currentScript->interpreter().asyncTerminate();
+  m_currentScript->deleteLater();
+  m_currentScript = nullptr;
+  m_runningMolecule.clear();
 }
 
 void Command::commandFailed(const QStringList& errors)

--- a/avogadro/qtplugins/commandscripts/command.h
+++ b/avogadro/qtplugins/commandscripts/command.h
@@ -107,6 +107,13 @@ private:
    */
   void commandFailed(const QStringList& errors);
 
+  /**
+   * Close and destroy the progress dialog, if there is one. Disconnects it
+   * first: QProgressDialog::close() emits canceled(), which would otherwise
+   * re-enter cancelCommand() and tear down state the caller still holds.
+   */
+  void closeProgressDialog();
+
   QList<QAction*> m_actions;
   QtGui::Molecule* m_molecule;
   // Launch-time molecule for the async script; QPointer detects deletion.

--- a/avogadro/qtplugins/commandscripts/command.h
+++ b/avogadro/qtplugins/commandscripts/command.h
@@ -83,6 +83,19 @@ public slots:
                          const QString& command, const QString& identifier);
 
 private slots:
+  /**
+   * Show a progress report from the running script.
+   * @param message Status text, or empty to leave the label alone.
+   * @param value The current step, or -1 if the script did not supply one.
+   * @param maximum The total number of steps, or -1 if not supplied.
+   */
+  void updateProgress(const QString& message, int value, int maximum);
+
+  /**
+   * Kill the running script after the user hits Cancel.
+   */
+  void cancelCommand();
+
   void menuActivated();
   void configurePython();
   void moleculeChanged(unsigned int change);

--- a/python/avogadro/__init__.py
+++ b/python/avogadro/__init__.py
@@ -1,4 +1,5 @@
 from . import cjson
+from . import command
 from . import connect
 from . import core
 from . import energy

--- a/python/avogadro/command.py
+++ b/python/avogadro/command.py
@@ -1,0 +1,44 @@
+"""
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-clause BSD License, (the "License").
+******************************************************************************/
+"""
+import json
+
+
+def report_progress(message=None, value=None, maximum=None):
+    """
+    Report the progress of a running command script to Avogadro.
+
+    Avogadro shows a progress dialog while a command script runs. Calling this
+    function updates that dialog: pass a `message` to change the status text,
+    and/or `value` and `maximum` to turn the spinner into a determinate
+    progress bar.
+
+    The update is written to standard output as a single line of JSON, which
+    Avogadro removes from the script's output before parsing the result, so it
+    will not interfere with the JSON the script prints when it finishes.
+
+    Example:
+
+        for i, conformer in enumerate(conformers, start=1):
+            report_progress(f"Conformer {i} of {len(conformers)}",
+                            i, len(conformers))
+            optimize(conformer)
+
+    :param message: status text to display, e.g. "Current energy: -135.2 eV"
+    :param value: the current step of a determinate progress bar
+    :param maximum: the total number of steps of a determinate progress bar
+    """
+    payload = {}
+    if message is not None:
+        payload["message"] = message
+    if value is not None:
+        payload["value"] = value
+    if maximum is not None:
+        payload["maximum"] = maximum
+
+    # flush is required: Python block-buffers stdout when it is a pipe rather
+    # than a terminal, so without it these updates would only arrive at exit.
+    print(json.dumps({"avogadro": payload}), flush=True)

--- a/python/avogadro/command.py
+++ b/python/avogadro/command.py
@@ -5,6 +5,23 @@
 ******************************************************************************/
 """
 import json
+import os
+
+# Set by Avogadro when it is reading standard output for progress reports.
+PROGRESS_ENVIRONMENT_VARIABLE = "AVO_PROGRESS_PROTOCOL"
+
+
+def progress_supported():
+    """
+    Report whether the running version of Avogadro understands progress
+    updates.
+
+    Avogadro 2.0.0 and earlier read the whole of a script's standard output as
+    a single JSON document, so progress lines would make that parse fail and
+    the command would report an error instead of its result. Those versions do
+    not set the environment variable, and report_progress() stays silent.
+    """
+    return bool(os.environ.get(PROGRESS_ENVIRONMENT_VARIABLE))
 
 
 def report_progress(message=None, value=None, maximum=None):
@@ -20,6 +37,10 @@ def report_progress(message=None, value=None, maximum=None):
     Avogadro removes from the script's output before parsing the result, so it
     will not interfere with the JSON the script prints when it finishes.
 
+    This is a no-op on versions of Avogadro that do not support progress
+    reporting, so it is always safe to call: a script that uses it still runs
+    correctly on Avogadro 2.0.0, just without the progress bar.
+
     Example:
 
         for i, conformer in enumerate(conformers, start=1):
@@ -31,6 +52,11 @@ def report_progress(message=None, value=None, maximum=None):
     :param value: the current step of a determinate progress bar
     :param maximum: the total number of steps of a determinate progress bar
     """
+    # Checked on every call rather than at import, so that a script which is
+    # imported before Avogadro's environment is in place still works.
+    if not progress_supported():
+        return
+
     payload = {}
     if message is not None:
         payload["message"] = message

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -30,6 +30,7 @@ set(tests
 
 if(Python3_EXECUTABLE)
   list(APPEND tests
+    InterfaceScript
     PythonScript
   )
 endif()

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -25,6 +25,7 @@ set(tests
   Molecule
   PackageManager
   RWMolecule
+  ScriptProgress
 )
 
 if(Python3_EXECUTABLE)

--- a/tests/qtgui/interfacescripttest.cpp
+++ b/tests/qtgui/interfacescripttest.cpp
@@ -1,0 +1,82 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/molecule.h>
+#include <avogadro/qtgui/interfacescript.h>
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QFile>
+#include <QtCore/QJsonObject>
+#include <QtCore/QTemporaryDir>
+#include <QtTest/QSignalSpy>
+
+using Avogadro::QtGui::InterfaceScript;
+
+namespace {
+
+// Ensure a QCoreApplication exists (required to run an event loop while the
+// script executes). The test binary uses gtest_main, which does not create one.
+QCoreApplication* ensureApp()
+{
+  if (QCoreApplication::instance())
+    return QCoreApplication::instance();
+  static int argc = 1;
+  static char name[] = "InterfaceScriptTest";
+  static char* argv[] = { name, nullptr };
+  static QCoreApplication app(argc, argv);
+  return &app;
+}
+
+} // namespace
+
+TEST(InterfaceScriptTest, RerunDeliversSignalsOnce)
+{
+  ensureApp();
+
+  QTemporaryDir temporaryDirectory;
+  ASSERT_TRUE(temporaryDirectory.isValid());
+
+  // A minimal command script: one progress envelope, then a result.
+  QFile script(temporaryDirectory.filePath("command.py"));
+  ASSERT_TRUE(script.open(QIODevice::WriteOnly | QIODevice::Text));
+  const QByteArray source(
+    "import json, sys\n"
+    "sys.stdin.read()\n"
+    "print(json.dumps({'avogadro': {'message': 'Working', 'value': 1,"
+    " 'maximum': 1}}), flush=True)\n"
+    "print(json.dumps({'moleculeFormat': 'cjson'}))\n");
+  ASSERT_EQ(script.write(source), source.size());
+  script.close();
+
+  InterfaceScript interface(script.fileName());
+  // Skip the --print-options round trip; "None" means the molecule is not
+  // serialized into the options at all.
+  QJsonObject opts;
+  opts.insert(QStringLiteral("inputMoleculeFormat"), QStringLiteral("None"));
+  interface.setOptionsJson(opts);
+
+  Avogadro::Core::Molecule molecule;
+
+  QSignalSpy finishedSpy(&interface, &InterfaceScript::finished);
+  QSignalSpy progressSpy(&interface, &InterfaceScript::progress);
+
+  // First run.
+  ASSERT_TRUE(interface.runCommand(QJsonObject(), &molecule));
+  ASSERT_TRUE(finishedSpy.wait(30000));
+  EXPECT_EQ(finishedSpy.count(), 1);
+  EXPECT_EQ(progressSpy.count(), 1);
+
+  // Second run on the same instance. Re-connecting the interpreter's signals
+  // must not stack duplicate connections, or each signal would be delivered
+  // once per previous run.
+  finishedSpy.clear();
+  progressSpy.clear();
+  ASSERT_TRUE(interface.runCommand(QJsonObject(), &molecule));
+  ASSERT_TRUE(finishedSpy.wait(30000));
+  EXPECT_EQ(finishedSpy.count(), 1);
+  EXPECT_EQ(progressSpy.count(), 1);
+}

--- a/tests/qtgui/interfacescripttest.cpp
+++ b/tests/qtgui/interfacescripttest.cpp
@@ -7,6 +7,7 @@
 
 #include <avogadro/core/molecule.h>
 #include <avogadro/qtgui/interfacescript.h>
+#include <avogadro/qtgui/molecule.h>
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
@@ -79,4 +80,50 @@ TEST(InterfaceScriptTest, RerunDeliversSignalsOnce)
   ASSERT_TRUE(finishedSpy.wait(30000));
   EXPECT_EQ(finishedSpy.count(), 1);
   EXPECT_EQ(progressSpy.count(), 1);
+}
+
+// A script that returns a molecule Avogadro cannot parse must leave the user's
+// molecule alone. The xyz below declares five atoms and supplies one, so the
+// reader fails partway through with atoms already added: taking that result
+// would swap a water molecule for a lone carbon.
+TEST(InterfaceScriptTest, UnreadableMoleculeLeavesMoleculeUntouched)
+{
+  ensureApp();
+
+  QTemporaryDir temporaryDirectory;
+  ASSERT_TRUE(temporaryDirectory.isValid());
+
+  QFile script(temporaryDirectory.filePath("command.py"));
+  ASSERT_TRUE(script.open(QIODevice::WriteOnly | QIODevice::Text));
+  const QByteArray source("import json, sys\n"
+                          "sys.stdin.read()\n"
+                          "print(json.dumps({'moleculeFormat': 'xyz',"
+                          " 'xyz': '5\\ntruncated\\nC 0.0 0.0 0.0\\n'}))\n");
+  ASSERT_EQ(script.write(source), source.size());
+  script.close();
+
+  InterfaceScript interface(script.fileName());
+  QJsonObject opts;
+  opts.insert(QStringLiteral("inputMoleculeFormat"), QStringLiteral("None"));
+  interface.setOptionsJson(opts);
+
+  Avogadro::QtGui::Molecule molecule;
+  molecule.addAtom(8).setPosition3d(Avogadro::Vector3(0.0, 0.0, 0.0));
+  molecule.addAtom(1).setPosition3d(Avogadro::Vector3(0.76, 0.59, 0.0));
+  molecule.addAtom(1).setPosition3d(Avogadro::Vector3(-0.76, 0.59, 0.0));
+  molecule.addBond(molecule.atom(0), molecule.atom(1), 1);
+  molecule.addBond(molecule.atom(0), molecule.atom(2), 1);
+
+  QSignalSpy finishedSpy(&interface, &InterfaceScript::finished);
+  ASSERT_TRUE(interface.runCommand(QJsonObject(), &molecule));
+  ASSERT_TRUE(finishedSpy.wait(30000));
+
+  EXPECT_FALSE(interface.processCommand(&molecule));
+  EXPECT_TRUE(interface.hasErrors());
+
+  ASSERT_EQ(molecule.atomCount(), 3u);
+  EXPECT_EQ(molecule.bondCount(), 2u);
+  EXPECT_EQ(molecule.atom(0).atomicNumber(), 8);
+  EXPECT_EQ(molecule.atom(1).atomicNumber(), 1);
+  EXPECT_EQ(molecule.atom(2).atomicNumber(), 1);
 }

--- a/tests/qtgui/pythonscripttest.cpp
+++ b/tests/qtgui/pythonscripttest.cpp
@@ -109,3 +109,27 @@ TEST(PythonScriptTest, AsyncProgressScanning)
   EXPECT_TRUE(
     pythonScript.asyncStandardError().contains("DEBUG library noise"));
 }
+
+// Scripts must be able to tell whether Avogadro is listening: releases up to
+// 2.0.0 cannot parse output containing progress envelopes.
+TEST(PythonScriptTest, AdvertisesProgressProtocol)
+{
+  QTemporaryDir temporaryDirectory;
+  ASSERT_TRUE(temporaryDirectory.isValid());
+
+  QFile script(temporaryDirectory.filePath("environment.py"));
+  ASSERT_TRUE(script.open(QIODevice::WriteOnly | QIODevice::Text));
+  const QByteArray source(
+    "import os\nprint(os.environ.get('AVO_PROGRESS_PROTOCOL', 'unset'))\n");
+  ASSERT_EQ(script.write(source), source.size());
+  script.close();
+
+  // Not scanning: the variable must be absent, or a script would print
+  // envelopes that nothing is there to strip out.
+  PythonScript quiet(script.fileName());
+  EXPECT_EQ(quiet.execute({}).trimmed(), QByteArray("unset"));
+
+  PythonScript scanning(script.fileName());
+  scanning.setProgressScanning(true);
+  EXPECT_EQ(scanning.execute({}).trimmed(), QByteArray("1"));
+}

--- a/tests/qtgui/pythonscripttest.cpp
+++ b/tests/qtgui/pythonscripttest.cpp
@@ -7,10 +7,37 @@
 
 #include <avogadro/qtgui/pythonscript.h>
 
+#include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
+#include <QtCore/QJsonObject>
 #include <QtCore/QTemporaryDir>
+#include <QtTest/QSignalSpy>
 
 using Avogadro::QtGui::PythonScript;
+
+namespace {
+
+// Ensure a QCoreApplication exists (required to run an event loop while the
+// script executes). The test binary uses gtest_main, which does not create one.
+QCoreApplication* ensureApp()
+{
+  if (QCoreApplication::instance())
+    return QCoreApplication::instance();
+  static int argc = 1;
+  static char name[] = "PythonScriptTest";
+  static char* argv[] = { name, nullptr };
+  static QCoreApplication app(argc, argv);
+  return &app;
+}
+
+// Windows line endings would otherwise make byte comparisons brittle.
+QByteArray withoutCarriageReturns(QByteArray data)
+{
+  data.replace('\r', "");
+  return data;
+}
+
+} // namespace
 
 TEST(PythonScriptTest, WindowsUsesUtf8Mode)
 {
@@ -29,4 +56,56 @@ TEST(PythonScriptTest, WindowsUsesUtf8Mode)
   PythonScript pythonScript(script.fileName());
   EXPECT_EQ(pythonScript.execute({}).trimmed(), QByteArray("1"));
 #endif
+}
+
+TEST(PythonScriptTest, AsyncProgressScanning)
+{
+  ensureApp();
+
+  QTemporaryDir temporaryDirectory;
+  ASSERT_TRUE(temporaryDirectory.isValid());
+
+  // Mimics a real command script: progress envelopes and plain output on
+  // stdout, log noise on stderr, and a pretty-printed result at the end.
+  QFile script(temporaryDirectory.filePath("progress.py"));
+  ASSERT_TRUE(script.open(QIODevice::WriteOnly | QIODevice::Text));
+  const QByteArray source(
+    "import json, sys\n"
+    "print(json.dumps({'avogadro': {'message': 'Step 1 of 3', 'value': 1,"
+    " 'maximum': 3}}), flush=True)\n"
+    "sys.stderr.write('DEBUG library noise\\n')\n"
+    "print('plain output', flush=True)\n"
+    "print(json.dumps({'avogadro': {'message': 'Finishing'}}), flush=True)\n"
+    "print(json.dumps({'result': 42, 'avogadro': 'not an envelope'},"
+    " indent=2))\n");
+  ASSERT_EQ(script.write(source), source.size());
+  script.close();
+
+  PythonScript pythonScript(script.fileName());
+  pythonScript.setProgressScanning(true);
+  QSignalSpy progressSpy(&pythonScript, &PythonScript::asyncProgress);
+  QSignalSpy finishedSpy(&pythonScript, &PythonScript::finished);
+
+  ASSERT_TRUE(pythonScript.asyncExecute({}, QByteArray(),
+                                        /* mergedChannels = */ false));
+  ASSERT_TRUE(finishedSpy.wait(30000));
+
+  ASSERT_EQ(progressSpy.count(), 2);
+  const auto first = progressSpy.at(0).at(0).value<QJsonObject>();
+  EXPECT_EQ(first.value("message").toString(), QString("Step 1 of 3"));
+  EXPECT_EQ(first.value("value").toInt(-1), 1);
+  EXPECT_EQ(first.value("maximum").toInt(-1), 3);
+  const auto second = progressSpy.at(1).at(0).value<QJsonObject>();
+  EXPECT_EQ(second.value("message").toString(), QString("Finishing"));
+  EXPECT_EQ(second.value("value").toInt(-1), -1);
+
+  // Envelopes are gone; everything else survives, including the multi-line
+  // result and its top-level "avogadro" member.
+  EXPECT_EQ(withoutCarriageReturns(pythonScript.asyncResponse()),
+            QByteArray("plain output\n{\n  \"result\": 42,\n"
+                       "  \"avogadro\": \"not an envelope\"\n}\n"));
+
+  // stderr is captured separately rather than corrupting the result.
+  EXPECT_TRUE(
+    pythonScript.asyncStandardError().contains("DEBUG library noise"));
 }

--- a/tests/qtgui/scriptprogresstest.cpp
+++ b/tests/qtgui/scriptprogresstest.cpp
@@ -68,6 +68,18 @@ TEST(ScriptProgressTest, RejectsNonEnvelopes)
   EXPECT_FALSE(PythonScript::parseProgressEnvelope(
     R"({"avogadro": {"value": 1}, "cjson": {}})", payload));
 
+  // The "avogadro" member has to be an object. A scalar or null would parse
+  // into an empty payload, so the line would vanish from the output while
+  // reporting progress nobody asked for.
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"({"avogadro": 1})", payload));
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"({"avogadro": null})", payload));
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"({"avogadro": "text"})", payload));
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"({"avogadro": []})", payload));
+
   // Truncated JSON must not be mistaken for an envelope.
   EXPECT_FALSE(PythonScript::parseProgressEnvelope(
     R"({"avogadro": {"value": 1})", payload));
@@ -86,6 +98,8 @@ TEST(ScriptProgressTest, FiltersProgressFromOutput)
                     "\n"
                     R"({"avogadro": {"message": "Done"}})"
                     "\n"
+                    R"({"avogadro": 1})"
+                    "\n"
                     "{\n"
                     "  \"cjson\": {}\n"
                     "}\n");
@@ -99,8 +113,10 @@ TEST(ScriptProgressTest, FiltersProgressFromOutput)
   EXPECT_EQ(payloads.at(0).value("value").toInt(-1), 1);
   EXPECT_EQ(payloads.at(1).value("message").toString(), QString("Done"));
 
-  // Everything else survives byte for byte, newlines included.
-  EXPECT_EQ(output, QByteArray("Loading model...\n{\n  \"cjson\": {}\n}\n"));
+  // Everything else survives byte for byte, newlines included - including the
+  // scalar "avogadro" line, which is not an envelope.
+  EXPECT_EQ(output, QByteArray("Loading model...\n{\"avogadro\": 1}\n"
+                               "{\n  \"cjson\": {}\n}\n"));
 }
 
 TEST(ScriptProgressTest, BuffersPartialLines)

--- a/tests/qtgui/scriptprogresstest.cpp
+++ b/tests/qtgui/scriptprogresstest.cpp
@@ -1,0 +1,126 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/qtgui/pythonscript.h>
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QList>
+
+using Avogadro::QtGui::PythonScript;
+
+TEST(ScriptProgressTest, ParsesEnvelope)
+{
+  QJsonObject payload;
+  const QByteArray line(
+    R"({"avogadro": {"message": "Conformer 3 of 25", "value": 3,)"
+    R"( "maximum": 25}})");
+
+  ASSERT_TRUE(PythonScript::parseProgressEnvelope(line, payload));
+  EXPECT_EQ(payload.value("message").toString(), QString("Conformer 3 of 25"));
+  EXPECT_EQ(payload.value("value").toInt(-1), 3);
+  EXPECT_EQ(payload.value("maximum").toInt(-1), 25);
+}
+
+TEST(ScriptProgressTest, ParsesPartialEnvelope)
+{
+  QJsonObject payload;
+
+  // A message on its own is valid; absent members stay absent.
+  ASSERT_TRUE(PythonScript::parseProgressEnvelope(
+    R"({"avogadro": {"message": "Writing results"}})", payload));
+  EXPECT_EQ(payload.value("message").toString(), QString("Writing results"));
+  EXPECT_EQ(payload.value("value").toInt(-1), -1);
+  EXPECT_EQ(payload.value("maximum").toInt(-1), -1);
+
+  // So is an empty payload.
+  EXPECT_TRUE(
+    PythonScript::parseProgressEnvelope(R"({"avogadro": {}})", payload));
+}
+
+TEST(ScriptProgressTest, IgnoresSurroundingWhitespace)
+{
+  QJsonObject payload;
+
+  // Windows line endings leave a stray carriage return on the line.
+  EXPECT_TRUE(PythonScript::parseProgressEnvelope(
+    "  {\"avogadro\": {\"value\": 1, \"maximum\": 2}}\r", payload));
+  EXPECT_EQ(payload.value("value").toInt(-1), 1);
+}
+
+TEST(ScriptProgressTest, RejectsNonEnvelopes)
+{
+  QJsonObject payload;
+
+  // Plain output from a script.
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope("Starting up...", payload));
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope(QByteArray(), payload));
+
+  // Valid JSON, but not an envelope.
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"({"message": "hello"})", payload));
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope(R"(["avogadro"])", payload));
+
+  // An "avogadro" member alongside others is a result, not an envelope.
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope(
+    R"({"avogadro": {"value": 1}, "cjson": {}})", payload));
+
+  // Truncated JSON must not be mistaken for an envelope.
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope(
+    R"({"avogadro": {"value": 1})", payload));
+
+  // A pretty-printed result mentioning "avogadro" arrives one line at a time,
+  // and no individual line parses as a complete object.
+  EXPECT_FALSE(PythonScript::parseProgressEnvelope("{", payload));
+  EXPECT_FALSE(
+    PythonScript::parseProgressEnvelope(R"(  "avogadro": {)", payload));
+}
+
+TEST(ScriptProgressTest, FiltersProgressFromOutput)
+{
+  QByteArray buffer("Loading model...\n"
+                    R"({"avogadro": {"value": 1, "maximum": 2}})"
+                    "\n"
+                    R"({"avogadro": {"message": "Done"}})"
+                    "\n"
+                    "{\n"
+                    "  \"cjson\": {}\n"
+                    "}\n");
+  QByteArray output;
+  QList<QJsonObject> payloads;
+
+  PythonScript::filterProgressLines(buffer, output, payloads);
+
+  EXPECT_TRUE(buffer.isEmpty()); // no partial line left over
+  ASSERT_EQ(payloads.size(), 2);
+  EXPECT_EQ(payloads.at(0).value("value").toInt(-1), 1);
+  EXPECT_EQ(payloads.at(1).value("message").toString(), QString("Done"));
+
+  // Everything else survives byte for byte, newlines included.
+  EXPECT_EQ(output, QByteArray("Loading model...\n{\n  \"cjson\": {}\n}\n"));
+}
+
+TEST(ScriptProgressTest, BuffersPartialLines)
+{
+  QByteArray buffer;
+  QByteArray output;
+  QList<QJsonObject> payloads;
+
+  // An envelope split across two reads is not acted on until it is complete.
+  buffer += R"({"avogadro": {"value")";
+  PythonScript::filterProgressLines(buffer, output, payloads);
+  EXPECT_TRUE(payloads.isEmpty());
+  EXPECT_TRUE(output.isEmpty());
+
+  buffer += ": 7}}\nresult";
+  PythonScript::filterProgressLines(buffer, output, payloads);
+  ASSERT_EQ(payloads.size(), 1);
+  EXPECT_EQ(payloads.at(0).value("value").toInt(-1), 7);
+
+  // The unterminated final line stays buffered rather than being emitted.
+  EXPECT_TRUE(output.isEmpty());
+  EXPECT_EQ(buffer, QByteArray("result"));
+}


### PR DESCRIPTION
Sending a progress JSON to stdout will provide:
- status messages (e.g., current energy)
- progress bar (e.g., conformer 5 of 10)

Add a convenience method to the python package as well: avogadro.command.report_progres()

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added progress reporting for command scripts, including status messages, completion values, maximums, and cancellation.
  - Progress dialogs now display determinate updates while scripts run.
  - Added a scripting helper for reporting progress during execution.

- **Bug Fixes**
  - Improved separation of progress messages, regular output, and error output.
  - Preserved final progress updates and partial output when scripts finish.
  - Message-only commands no longer replace the current molecule unnecessarily.

- **Documentation**
  - Documented progress reporting, output handling, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->