### PR TITLE
Fix parsing issue with numbers causing underflow 1.0e-500

### DIFF
--- a/avogadro/core/utilities.h
+++ b/avogadro/core/utilities.h
@@ -7,6 +7,10 @@
 #define AVOGADRO_CORE_UTILITIES_H
 
 #include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -116,6 +120,40 @@ std::optional<T> lexicalCast(const std::string& inputString)
   stream >> value;
   if (stream.fail())
     return std::nullopt;
+  return value;
+}
+
+/**
+ * @brief Cast the inputString to a double, tolerating out of range exponents.
+ *
+ * Some programs write coordinates (or other values) with exponents a double
+ * cannot represent, e.g. "2.61793E-500" or "-7.5467E-6000". The stream
+ * extractor reports these as errors, which would otherwise abort reading an
+ * entire file over a value that is effectively zero. Fall back to strtod for
+ * the range error alone: underflow becomes zero and overflow is clamped to the
+ * largest representable magnitude so that later arithmetic cannot see an
+ * infinity. Anything the extractor rejects for another reason (including the
+ * literals "nan" and "inf") is still an error.
+ */
+template <>
+inline std::optional<double> lexicalCast(const std::string& inputString)
+{
+  double value;
+  std::istringstream stream(inputString);
+  stream >> value;
+  if (!stream.fail())
+    return value;
+
+  const char* first = inputString.c_str();
+  char* last = nullptr;
+  errno = 0;
+  value = std::strtod(first, &last);
+  if (last == first || errno != ERANGE)
+    return std::nullopt;
+
+  if (std::isinf(value))
+    value = (value > 0.0) ? std::numeric_limits<double>::max()
+                          : std::numeric_limits<double>::lowest();
   return value;
 }
 

--- a/avogadro/io/xyzformat.cpp
+++ b/avogadro/io/xyzformat.cpp
@@ -11,8 +11,10 @@
 #include <avogadro/core/utilities.h>
 #include <avogadro/core/vector.h>
 
+#include <cctype>
 #include <iomanip>
-#include <iostream>
+#include <istream>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -111,9 +113,6 @@ bool XyzFormat::read(std::istream& inStream, Core::Molecule& mol)
 
     std::vector<string> tokens(split(lattice, ' '));
 
-    // check for size
-    std::cout << "Lattice size: " << tokens.size() << std::endl;
-
     if (tokens.size() >= 9) {
       if (auto tmp = lexicalCast<double>(tokens.begin(), tokens.begin() + 9)) {
         Vector3 v1(tmp->at(0), tmp->at(1), tmp->at(2));
@@ -121,8 +120,6 @@ bool XyzFormat::read(std::istream& inStream, Core::Molecule& mol)
         Vector3 v3(tmp->at(6), tmp->at(7), tmp->at(8));
 
         auto* cell = new Core::UnitCell(v1, v2, v3);
-        std::cout << " Lattice: " << cell->aVector() << " " << cell->bVector()
-                  << " " << cell->cVector() << std::endl;
         if (!cell->isRegular()) {
           appendError("Lattice vectors are not linear independent");
           delete cell;

--- a/tests/core/utilitiestest.cpp
+++ b/tests/core/utilitiestest.cpp
@@ -44,6 +44,25 @@ TEST(UtilitiesTest, lexicalCast)
   EXPECT_EQ(lexicalCast<double>("5.3E-10"), 5.3e-10);
 }
 
+TEST(UtilitiesTest, lexicalCastOutOfRange)
+{
+  // Some programs write exponents a double cannot represent. These are
+  // effectively zero and should not abort reading the rest of a file.
+  EXPECT_EQ(lexicalCast<double>("2.61793E-500"), 0.0);
+  EXPECT_EQ(lexicalCast<double>("-7.5467E-6000"), 0.0);
+
+  // Overflow is clamped rather than becoming an infinity.
+  EXPECT_EQ(lexicalCast<double>("1.0E+500"),
+            std::numeric_limits<double>::max());
+  EXPECT_EQ(lexicalCast<double>("-1.0E+500"),
+            std::numeric_limits<double>::lowest());
+
+  // Values that are not numbers still fail, including the special literals.
+  EXPECT_EQ(lexicalCast<double>("five"), std::nullopt);
+  EXPECT_EQ(lexicalCast<double>("NaN"), std::nullopt);
+  EXPECT_EQ(lexicalCast<double>(""), std::nullopt);
+}
+
 TEST(UtilitiesTest, lexicalCastCheck)
 {
   // Something simple that should pass.

--- a/tests/io/xyztest.cpp
+++ b/tests/io/xyztest.cpp
@@ -77,6 +77,28 @@ TEST(XyzTest, readTotalEnergy)
   }
 }
 
+// Some programs write coordinates with an exponent a double cannot hold, e.g.
+// "2.61793E-500". Those are effectively zero and must not abort the read.
+TEST(XyzTest, readUnderflowedCoordinates)
+{
+  XyzFormat xyz;
+  Molecule molecule;
+  std::string str = "2\nframe 1\n"
+                    "Ar 0.0 0.0 0.0\n"
+                    "Ar 0.0 0.0 4.0\n"
+                    "2\nframe 2\n"
+                    "Ar 2.61793E-500 0.0 0.0\n"
+                    "Ar 0.0 -7.5467E-6000 4.0\n";
+  ASSERT_TRUE(xyz.readString(str, molecule));
+  EXPECT_EQ(xyz.error(), std::string());
+
+  EXPECT_EQ(molecule.atomCount(), 2);
+  EXPECT_EQ(molecule.coordinate3dCount(), 2);
+  EXPECT_EQ(molecule.coordinate3d(1)[0].x(), 0.0);
+  EXPECT_EQ(molecule.coordinate3d(1)[1].y(), 0.0);
+  EXPECT_EQ(molecule.coordinate3d(1)[1].z(), 4.0);
+}
+
 TEST(XyzTest, readZeroAtomsNoHang)
 {
   XyzFormat xyz;


### PR DESCRIPTION
Fixes #2892 with example file
Added regression testing

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
