### PR TITLE
Fix some bugs in which pixi was installed after first launch

### DIFF
--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -132,41 +132,81 @@ static QString findInstalledScript(const QString& packageDir,
   return {};
 }
 
+// Names to try, in order of preference, when looking for a Python
+// interpreter to install a package with.
+static QStringList pythonExecutableNames()
+{
+#ifdef Q_OS_WIN
+  return { QStringLiteral("python.exe"), QStringLiteral("python3.exe") };
+#else
+  return { QStringLiteral("python3"), QStringLiteral("python") };
+#endif
+}
+
+// Full path to the pixi executable, or an empty string if it is not installed.
+static QString findPixiExecutable()
+{
+#ifdef Q_OS_WIN
+  const QString pixiName = QStringLiteral("pixi.exe");
+#else
+  const QString pixiName = QStringLiteral("pixi");
+#endif
+  const QString pixiDir = Utilities::findExecutablePath(pixiName);
+  return pixiDir.isEmpty() ? QString() : pixiDir + '/' + pixiName;
+}
+
+QString PackageManager::pixiScriptPath(const QString& packageDir,
+                                       const QString& command)
+{
+  if (packageDir.isEmpty() || command.isEmpty())
+    return {};
+  return findInstalledScript(packageDir, command, true);
+}
+
+QString PackageManager::venvScriptPath(const QString& packageDir,
+                                       const QString& command)
+{
+  if (packageDir.isEmpty() || command.isEmpty())
+    return {};
+  return findInstalledScript(packageDir, command, false);
+}
+
+PackageManager::CommandLine PackageManager::resolveCommandLine(
+  const QString& packageDir, const QString& command)
+{
+  CommandLine commandLine;
+
+  const QString pixiExe = findPixiExecutable();
+  if (!pixiExe.isEmpty() && !pixiScriptPath(packageDir, command).isEmpty()) {
+    commandLine.program = pixiExe;
+    commandLine.prefixArgs = { QStringLiteral("run"), QStringLiteral("--as-is"),
+                               command };
+    return commandLine;
+  }
+
+  commandLine.program = venvScriptPath(packageDir, command);
+  return commandLine;
+}
+
 QJsonObject PackageManager::loadOptionsFromScript(const QString& packageDir,
                                                   const QString& command,
                                                   const QString& identifier)
 {
-  // Locate pixi or the venv-installed script.
-#ifdef Q_OS_WIN
-  QString pixiName = QStringLiteral("pixi.exe");
-#else
-  QString pixiName = QStringLiteral("pixi");
-#endif
-  QString pixiDir = Utilities::findExecutablePath(pixiName);
-  QString pixiExe = pixiDir.isEmpty() ? QString() : pixiDir + '/' + pixiName;
-  QProcess proc;
-  proc.setWorkingDirectory(packageDir);
+  const CommandLine commandLine = resolveCommandLine(packageDir, command);
+  if (commandLine.program.isEmpty()) {
+    qWarning() << "PackageManager: no installed environment providing"
+               << command << "in" << packageDir;
+    return {};
+  }
 
-  QStringList userOptsArgs;
+  QStringList userOptsArgs = commandLine.prefixArgs;
   if (!identifier.isEmpty())
     userOptsArgs << identifier;
   userOptsArgs << QStringLiteral("--user-options");
 
-  if (!pixiExe.isEmpty()) {
-    QStringList pixiArgs = { QStringLiteral("run"), QStringLiteral("--as-is"),
-                             command };
-    pixiArgs << userOptsArgs;
-    proc.start(pixiExe, pixiArgs);
-  } else {
-    // Try the venv-installed script directly.
-    QString scriptExe = findInstalledScript(packageDir, command, false);
-    if (scriptExe.isEmpty()) {
-      qWarning() << "PackageManager: cannot find pixi or venv script for"
-                 << command << "in" << packageDir;
-      return {};
-    }
-    proc.start(scriptExe, userOptsArgs);
-  }
+  QProcess proc;
+  proc.setWorkingDirectory(packageDir);
+  proc.start(commandLine.program, userOptsArgs);
 
   // Plugins may always expect some valid JSON as input over stdin, even if it's
   // just an empty object
@@ -306,10 +346,60 @@ PackageManager::FeatureEntry PackageManager::featureEntryFromJson(
 // Installation
 // ---------------------------------------------------------------------------
 
-// Read the *-setup script name from [project.scripts], if any.
-static QString readSetupCommand(const QString& packageDir)
+// Entry-point names read from [project.scripts].
+struct PackageCommands
 {
-  QString tomlPath = packageDir + QStringLiteral("/pyproject.toml");
+  QString command;      ///< the avogadro-* entry point
+  QString setupCommand; ///< the avogadro-*-setup helper, if any
+};
+
+// Only allow script names with safe characters (letters, digits, hyphen,
+// underscore) to prevent path traversal when the name is used to build
+// an executable path.
+static bool isSafeScriptName(const QString& name)
+{
+  for (const QChar ch : name) {
+    const ushort u = ch.unicode();
+    if (!((u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') ||
+          (u >= '0' && u <= '9') || u == '-' || u == '_'))
+      return false;
+  }
+  return !name.isEmpty();
+}
+
+// Pick the avogadro-* entry points out of a parsed [project.scripts] table.
+// @p tomlPath is used only for warnings.
+static PackageCommands selectScriptCommands(const QVariantMap& scripts,
+                                            const QString& tomlPath)
+{
+  PackageCommands commands;
+
+  for (auto it = scripts.constBegin(); it != scripts.constEnd(); ++it) {
+    if (!it.key().startsWith(QStringLiteral("avogadro-")) ||
+        !isSafeScriptName(it.key()))
+      continue;
+
+    // *-setup scripts are post-install helpers, not the main command.
+    if (it.key().endsWith(QStringLiteral("-setup"))) {
+      if (commands.setupCommand.isEmpty())
+        commands.setupCommand = it.key();
+    } else if (commands.command.isEmpty()) {
+      commands.command = it.key();
+    } else {
+      // in principle we should stop at the first, but check for multiple
+      // entries and warn about them
+      qWarning() << "PackageManager: multiple avogadro-* entry points in"
+                 << tomlPath;
+    }
+  }
+
+  return commands;
+}
+
+// Read the entry-point names from [project.scripts], if any.
+static PackageCommands readScriptCommands(const QString& packageDir)
+{
+  const QString tomlPath = packageDir + QStringLiteral("/pyproject.toml");
   QFile tomlFile(tomlPath);
   if (!tomlFile.open(QIODevice::ReadOnly))
     return {};
@@ -321,30 +411,38 @@ static QString readSetupCommand(const QString& packageDir)
   if (!ok)
     return {};
 
-  const QVariantMap scripts = root.value(QStringLiteral("project"))
+  return selectScriptCommands(root.value(QStringLiteral("project"))
                                 .toMap()
                                 .value(QStringLiteral("scripts"))
-                                .toMap();
-  // Only allow script names with safe characters (letters, digits, hyphen,
-  // underscore) to prevent path traversal when the name is used to build
-  // an executable path.
-  auto isSafeScriptName = [](const QString& name) {
-    for (const QChar ch : name) {
-      const ushort u = ch.unicode();
-      if (!((u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') ||
-            (u >= '0' && u <= '9') || u == '-' || u == '_'))
-        return false;
-    }
-    return !name.isEmpty();
-  };
+                                .toMap(),
+                              tomlPath);
+}
 
-  for (auto it = scripts.constBegin(); it != scripts.constEnd(); ++it) {
-    if (it.key().startsWith(QStringLiteral("avogadro-")) &&
-        it.key().endsWith(QStringLiteral("-setup")) &&
-        isSafeScriptName(it.key()))
-      return it.key();
+bool PackageManager::removeSupersededVenv(const QString& packageDir,
+                                          const QString& command)
+{
+  // Never build a path to remove recursively out of an empty directory.
+  if (packageDir.isEmpty())
+    return false;
+
+  const QString venvDir = packageDir + QStringLiteral("/.venv");
+  if (!QDir(venvDir).exists())
+    return false;
+
+  // Only give up the venv once pixi can actually run the command, so that a
+  // failed or partial install cannot leave the package unrunnable.
+  if (pixiScriptPath(packageDir, command).isEmpty()) {
+    qWarning() << "Keeping" << venvDir
+               << "because the pixi environment does not provide" << command;
+    return false;
   }
-  return {};
+
+  if (!QDir(venvDir).removeRecursively()) {
+    qWarning() << "Could not remove superseded virtual environment" << venvDir;
+    return false;
+  }
+
+  return true;
 }
 
 // Run a package's *-setup command (e.g. to download ML model weights).
@@ -383,35 +481,25 @@ static void runSetupScript(const QString& packageDir, const QString& setupCmd,
 
 void PackageManager::installPackages(const QStringList& packageDirs)
 {
-#ifdef Q_OS_WIN
-  const QString pixiName = QStringLiteral("pixi.exe");
-  const QStringList pythonNames = { QStringLiteral("python.exe"),
-                                    QStringLiteral("python3.exe") };
-#else
-  const QString pixiName = QStringLiteral("pixi");
-  const QStringList pythonNames = { QStringLiteral("python3"),
-                                    QStringLiteral("python") };
-#endif
-  QString pixiDir = Utilities::findExecutablePath(pixiName);
-  QString pixiExe = pixiDir.isEmpty() ? QString() : pixiDir + '/' + pixiName;
+  QString pixiExe = findPixiExecutable();
   QString pythonExe;
   if (pixiExe.isEmpty()) {
-    for (const QString& pythonName : pythonNames) {
-      const QString pythonDir = Utilities::findExecutablePath(pythonName);
-      if (!pythonDir.isEmpty()) {
-        pythonExe = pythonDir + '/' + pythonName;
-        break;
-      }
-    }
+    // Paths come back in the order the names were given, so the first hit is
+    // the most preferred interpreter.
+    const QStringList pythons =
+      Utilities::findExecutablePaths(pythonExecutableNames());
+    if (!pythons.isEmpty())
+      pythonExe = pythons.constFirst();
   }
 
-  // Pre-read setup commands on the main thread so the install thread doesn't
-  // need to re-parse pyproject.toml (parsePackage() will read it again later).
-  QMap<QString, QString> setupCommands;
+  // Pre-read entry-point names on the main thread so the install thread
+  // doesn't need to re-parse pyproject.toml (parsePackage() reads it again
+  // later).
+  QMap<QString, PackageCommands> packageCommands;
   for (const QString& dir : packageDirs)
-    setupCommands[dir] = readSetupCommand(dir);
+    packageCommands[dir] = readScriptCommands(dir);
   QThread* installThread =
-    QThread::create([pixiExe, pythonExe, packageDirs, setupCommands]() {
+    QThread::create([pixiExe, pythonExe, packageDirs, packageCommands]() {
       constexpr int installTimeoutMs = 10 * 60 * 1000; // 10 minutes
       for (const QString& packageDir : packageDirs) {
         if (pixiExe.isEmpty() && pythonExe.isEmpty())
@@ -442,10 +530,16 @@ void PackageManager::installPackages(const QStringList& packageDirs)
             qWarning() << "pixi install failed for" << packageDir << ":"
                        << QString::fromUtf8(installProc.readAllStandardError());
           } else {
+            // A package set up before pixi was available was pip-installed
+            // into .venv. Now that pixi has taken over, drop that tree.
+            removeSupersededVenv(packageDir,
+                                 packageCommands.value(packageDir).command);
+
             // Run the *-setup script if one is declared (e.g. to download ML
             // model weights).
-            runSetupScript(packageDir, setupCommands.value(packageDir), pixiExe,
-                           true, installTimeoutMs);
+            runSetupScript(packageDir,
+                           packageCommands.value(packageDir).setupCommand,
+                           pixiExe, true, installTimeoutMs);
           }
         } else {
           // Step 1: create a venv
@@ -486,7 +580,8 @@ void PackageManager::installPackages(const QStringList& packageDirs)
                        << installProc.readAllStandardError();
           } else {
             // Run the *-setup script if one is declared.
-            runSetupScript(packageDir, setupCommands.value(packageDir),
+            runSetupScript(packageDir,
+                           packageCommands.value(packageDir).setupCommand,
                            QStringLiteral(), false, installTimeoutMs);
           }
         }
@@ -547,6 +642,31 @@ bool PackageManager::unregisterPackage(const QString& packageName)
 // Directory scanning
 // ---------------------------------------------------------------------------
 
+// Decide whether an already-registered package whose pyproject.toml is
+// unchanged should nevertheless be installed again. Nothing about the package
+// itself has changed, but the environment it was installed into may be missing
+// or may have been built with a backend we no longer prefer: a package
+// pip-installed into .venv predates pixi being available on this machine, and
+// "pixi run --as-is" will not create the pixi environment on demand. Both are
+// repaired by installing again.
+static bool environmentNeedsInstall(const QString& packageDir,
+                                    const QString& command, bool pixiAvailable,
+                                    bool canInstall)
+{
+  // Nothing to install with, or nothing to install — don't ask every launch.
+  if (!canInstall || command.isEmpty())
+    return false;
+
+  if (!PackageManager::pixiScriptPath(packageDir, command).isEmpty())
+    return false; // usable pixi environment, the preferred backend
+
+  if (PackageManager::venvScriptPath(packageDir, command).isEmpty())
+    return true; // no usable environment at all
+
+  // A working .venv, but pixi has been installed since it was created.
+  return pixiAvailable;
+}
+
 QStringList PackageManager::scanDirectory(const QString& directoryPath)
 {
   QStringList result;
@@ -559,6 +679,12 @@ QStringList PackageManager::scanDirectory(const QString& directoryPath)
 #endif
     return result;
   }
+
+  // Whether we could repair a package with a missing or outdated environment.
+  const bool pixiAvailable = !findPixiExecutable().isEmpty();
+  const bool canInstall =
+    pixiAvailable ||
+    !Utilities::findExecutablePaths(pythonExecutableNames()).isEmpty();
 
   const QStringList subdirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
@@ -591,7 +717,8 @@ QStringList PackageManager::scanDirectory(const QString& directoryPath)
         QByteArray cachedHash =
           settings.value(prefix + "tomlHash").toByteArray();
         if (cachedHash == currentHash) {
-          needsRegistration = false;
+          needsRegistration = environmentNeedsInstall(
+            packageDir, info.command, pixiAvailable, canInstall);
         }
         break;
       }
@@ -734,20 +861,9 @@ bool PackageManager::parsePackage(const QString& packageDir, PackageInfo& info,
   }
 
   // --- [project.scripts] → find the avogadro- entry point ---
-  // Skip *-setup scripts; those are post-install helpers, not the main command.
-  QVariantMap scripts = project.value(QStringLiteral("scripts")).toMap();
-  for (auto it = scripts.constBegin(); it != scripts.constEnd(); ++it) {
-    if (it.key().startsWith(QStringLiteral("avogadro-")) &&
-        !it.key().endsWith(QStringLiteral("-setup"))) {
-      if (info.command.isEmpty())
-        info.command = it.key();
-      // in principle we should break, but check for multiple entries
-      // and warn about them
-      else
-        qWarning() << "PackageManager: multiple avogadro-* entry points in"
-                   << tomlPath;
-    }
-  }
+  info.command = selectScriptCommands(
+                   project.value(QStringLiteral("scripts")).toMap(), tomlPath)
+                   .command;
   if (info.command.isEmpty()) {
     qWarning() << "PackageManager: no avogadro-* entry in [project.scripts]"
                << "in" << tomlPath;

--- a/avogadro/qtgui/packagemanager.h
+++ b/avogadro/qtgui/packagemanager.h
@@ -70,6 +70,54 @@ public:
   static void mergeOptionsFromFile(QJsonObject& opts,
                                    const QString& userOptionsPath);
 
+  // --- Installed environments ---
+
+  /**
+   * Absolute path to @p command as installed in the pixi environment of
+   * @p packageDir (@c .pixi/envs/default), or an empty string if the package
+   * has no pixi environment with that command in it.
+   *
+   * Package commands are run with @c "pixi run --as-is", which is shorthand
+   * for @c --no-install @c --frozen and so will never create a missing
+   * environment. Callers must therefore check this rather than merely
+   * checking that the pixi executable exists.
+   */
+  static QString pixiScriptPath(const QString& packageDir,
+                                const QString& command);
+
+  /**
+   * Absolute path to @p command as installed in the virtual environment of
+   * @p packageDir (@c .venv), or an empty string if there is none. This is
+   * the fallback for packages that were pip-installed because pixi was not
+   * available when they were set up.
+   */
+  static QString venvScriptPath(const QString& packageDir,
+                                const QString& command);
+
+  /** How to launch a package command. */
+  struct CommandLine
+  {
+    QString program;        ///< empty if no environment can run the command
+    QStringList prefixArgs; ///< arguments preceding the command's own
+  };
+
+  /**
+   * Resolve how to run @p command from @p packageDir, so that every caller
+   * applies the same backend policy.
+   *
+   * Prefers the package's pixi environment and falls back to the console
+   * script pip installed into @c .venv. Having the pixi executable is not on
+   * its own enough to choose pixi, because @c "pixi run --as-is" is shorthand
+   * for @c --no-install @c --frozen and will not create a missing
+   * environment: a package installed before pixi was available has to keep
+   * running from @c .venv until it is installed again.
+   *
+   * @return a CommandLine whose @c program is empty when neither environment
+   *         provides @p command.
+   */
+  static CommandLine resolveCommandLine(const QString& packageDir,
+                                        const QString& command);
+
   /**
    * Run the package script with @c --user-options and parse the JSON output.
    * Uses pixi (preferred) or the venv-installed script as fallback.
@@ -100,6 +148,22 @@ public:
    * Safe to call from the main thread.
    */
   void installPackages(const QStringList& packageDirs);
+
+  /**
+   * Delete the @c .venv directory of @p packageDir once its pixi environment
+   * can run @p command, so that a package migrated to pixi does not keep a
+   * stale pip-installed tree around. Nothing will ever update that tree, and
+   * it would silently serve outdated code if the pixi environment were later
+   * removed.
+   *
+   * Does nothing if there is no @c .venv, or if the pixi environment does not
+   * provide @p command — a half-finished install must never leave the package
+   * with no way to run at all.
+   *
+   * @return true if a @c .venv directory was removed.
+   */
+  static bool removeSupersededVenv(const QString& packageDir,
+                                   const QString& command);
 
   // --- Registration ---
 

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -182,7 +182,9 @@ QString PythonScript::resolveCommand(QStringList& realArgs, QProcess& proc)
       return QString();
     }
 
-    realArgs.prepend(m_packageIdentifier);
+    // An empty identifier would otherwise be passed as an empty argument.
+    if (!m_packageIdentifier.isEmpty())
+      realArgs.prepend(m_packageIdentifier);
     realArgs = commandLine.prefixArgs + realArgs;
     return commandLine.program;
   }

--- a/avogadro/qtgui/pythonscript.cpp
+++ b/avogadro/qtgui/pythonscript.cpp
@@ -6,6 +6,7 @@
 #include "pythonscript.h"
 
 #include "avogadropython.h"
+#include "packagemanager.h"
 #include "utilities.h"
 
 #include <QtCore/QDebug>
@@ -166,25 +167,24 @@ QString PythonScript::resolveCommand(QStringList& realArgs, QProcess& proc)
   if (customEnvironment)
     proc.setProcessEnvironment(environment);
 
-  // --- Package mode: pixi run <command> <identifier> [args] ---
+  // --- Package mode: run the command from the package's environment ---
   if (m_packageMode) {
-    if (m_pixi.isEmpty()) {
-      m_errors << tr("Package mode requires pixi but it was not found.");
+    proc.setWorkingDirectory(m_packageDir);
+
+    const PackageManager::CommandLine commandLine =
+      PackageManager::resolveCommandLine(m_packageDir, m_packageCommand);
+    if (commandLine.program.isEmpty()) {
+      m_errors << tr("The package '%1' has no installed Python environment, so "
+                     "'%2' cannot be run. Try installing the package again.")
+                    .arg(m_packageDisplayName.isEmpty() ? m_packageDir
+                                                        : m_packageDisplayName,
+                         m_packageCommand);
       return QString();
     }
 
     realArgs.prepend(m_packageIdentifier);
-    realArgs.prepend(m_packageCommand);
-    realArgs.prepend("--as-is");
-    realArgs.prepend("run");
-
-    proc.setWorkingDirectory(m_packageDir);
-
-#ifdef Q_OS_WIN
-    return m_pixi + "/pixi.exe";
-#else
-    return m_pixi + "/pixi";
-#endif
+    realArgs = commandLine.prefixArgs + realArgs;
+    return commandLine.program;
   }
 
   // --- Script file mode ---

--- a/avogadro/qtgui/utilities.cpp
+++ b/avogadro/qtgui/utilities.cpp
@@ -55,6 +55,40 @@ QString highestVersionedDirectory(const QString& base)
   return QDir::cleanPath(dir.absoluteFilePath(newest));
 }
 
+// Directories to search for an executable, highest priority first.
+//
+// pixi installs itself into $PIXI_HOME/bin (by default $HOME/.pixi/bin) and
+// adds that directory to PATH from the user's shell profile. An application
+// started from a desktop launcher, the Dock or Finder never sources that
+// profile, so pixi is invisible to us even though the user's terminal finds
+// it. Search the directory explicitly, after PATH so that a pixi the user has
+// deliberately put on PATH still wins.
+QStringList executableSearchPaths()
+{
+  const QProcessEnvironment system = QProcessEnvironment::systemEnvironment();
+#ifdef Q_OS_WIN32
+  QStringList paths = system.value("PATH").split(';', Qt::SkipEmptyParts);
+#else
+  QStringList paths = system.value("PATH").split(':', Qt::SkipEmptyParts);
+  // check standard locations first
+  paths.prepend("/usr/bin");
+  paths.prepend("/usr/local/bin");
+#endif
+
+  // check the current application directory too
+  paths.prepend(QCoreApplication::applicationDirPath());
+  // and check "../bin" too
+  paths.prepend(QCoreApplication::applicationDirPath() + "/../bin");
+
+  QString pixiHome = system.value("PIXI_HOME");
+  if (pixiHome.isEmpty())
+    pixiHome = QDir::homePath() + "/.pixi";
+  paths.append(pixiHome + "/bin");
+
+  paths.removeDuplicates();
+  return paths;
+}
+
 } // namespace
 
 QString libraryDirectory()
@@ -102,23 +136,7 @@ QString openBabelLibraryDirectory()
 
 QString findExecutablePath(QString program)
 {
-  // we want to return the path to a program if it exists
-  // using the PATH system environment variable
-  QProcessEnvironment system = QProcessEnvironment::systemEnvironment();
-  QString path = system.value("PATH");
-#ifdef Q_OS_WIN32
-  QStringList paths = path.split(';');
-#else
-  QStringList paths = path.split(':');
-  // check standard locations first
-  paths.prepend("/usr/bin");
-  paths.prepend("/usr/local/bin");
-#endif
-
-  // check the current application directory too
-  paths.prepend(QCoreApplication::applicationDirPath());
-  // and check "../bin" too
-  paths.prepend(QCoreApplication::applicationDirPath() + "/../bin");
+  const QStringList paths = executableSearchPaths();
 
   // check to see if we find the program in that path
   for (const auto& dir : paths) {
@@ -136,21 +154,7 @@ QStringList findExecutablePaths(QStringList programs)
 {
   QStringList result;
 
-  // we want to return the path to a program if it exists
-  // using the PATH system environment variable
-  QProcessEnvironment system = QProcessEnvironment::systemEnvironment();
-  QString path = system.value("PATH");
-#ifdef Q_OS_WIN32
-  QStringList paths = path.split(';');
-#else
-  QStringList paths = path.split(':');
-  // check standard locations first
-  paths.prepend("/usr/bin");
-  paths.prepend("/usr/local/bin");
-#endif
-
-  // check the current application directory too
-  paths.prepend(QCoreApplication::applicationDirPath());
+  const QStringList paths = executableSearchPaths();
 
   // loop through all programs and all possible paths
   for (const auto& program : programs) {

--- a/tests/qtgui/CMakeLists.txt
+++ b/tests/qtgui/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
   PackageManager
   RWMolecule
   ScriptProgress
+  Utilities
 )
 
 if(Python3_EXECUTABLE)

--- a/tests/qtgui/packagemanagertest.cpp
+++ b/tests/qtgui/packagemanagertest.cpp
@@ -6,10 +6,12 @@
 #include <gtest/gtest.h>
 
 #include <avogadro/qtgui/packagemanager.h>
+#include <avogadro/qtgui/utilities.h>
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 #include <QtCore/QSettings>
 #include <QtCore/QTemporaryDir>
 #include <QtCore/QVariantMap>
@@ -73,6 +75,7 @@ protected:
     settings.sync();
   }
 
+public:
   static QByteArray sampleToml()
   {
     return R"(
@@ -133,6 +136,7 @@ input-format = "cjson"
 )";
   }
 
+protected:
   std::unique_ptr<QTemporaryDir> m_tmpDir;
   QString m_packageDir;
 };
@@ -850,4 +854,285 @@ nested.key = "val"
   EXPECT_EQ(nested["key"].toString(), "val");
 
   pm->unregisterPackage("parse-test");
+}
+
+// ---------------------------------------------------------------------------
+// Installed-environment probing
+//
+// Package commands run as "pixi run --as-is", which is shorthand for
+// --no-install --frozen and so never creates a missing environment. A package
+// installed while pixi was absent lives in .venv instead, and must keep
+// running from there until it is installed again.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Relative path of the directory a console script is installed into.
+QString pixiBinDir()
+{
+#ifdef Q_OS_WIN
+  return QStringLiteral("/.pixi/envs/default/Scripts");
+#else
+  return QStringLiteral("/.pixi/envs/default/bin");
+#endif
+}
+
+QString venvBinDir()
+{
+#ifdef Q_OS_WIN
+  return QStringLiteral("/.venv/Scripts");
+#else
+  return QStringLiteral("/.venv/bin");
+#endif
+}
+
+// Create a stand-in for a pip/pixi installed console script.
+bool createConsoleScript(const QString& binDir, const QString& command,
+                         bool executable = true)
+{
+  if (!QDir().mkpath(binDir))
+    return false;
+
+#ifdef Q_OS_WIN
+  const QString path = binDir + '/' + command + ".exe";
+#else
+  const QString path = binDir + '/' + command;
+#endif
+  if (writeTextFile(path, "#!/bin/sh\n").isEmpty())
+    return false;
+
+  QFile::Permissions perms = QFile::ReadOwner | QFile::WriteOwner;
+  if (executable)
+    perms |= QFile::ExeOwner;
+  return QFile::setPermissions(path, perms);
+}
+
+} // namespace
+
+TEST_F(PackageManagerTest, scriptPathsEmptyWithoutEnvironment)
+{
+  EXPECT_TRUE(
+    PackageManager::pixiScriptPath(m_packageDir, "avogadro-test-plugin")
+      .isEmpty());
+  EXPECT_TRUE(
+    PackageManager::venvScriptPath(m_packageDir, "avogadro-test-plugin")
+      .isEmpty());
+}
+
+TEST_F(PackageManagerTest, scriptPathsRejectEmptyArguments)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "cmd"));
+
+  EXPECT_TRUE(PackageManager::pixiScriptPath(QString(), "cmd").isEmpty());
+  EXPECT_TRUE(
+    PackageManager::pixiScriptPath(m_packageDir, QString()).isEmpty());
+  EXPECT_TRUE(PackageManager::venvScriptPath(QString(), "cmd").isEmpty());
+  EXPECT_TRUE(
+    PackageManager::venvScriptPath(m_packageDir, QString()).isEmpty());
+}
+
+TEST_F(PackageManagerTest, pixiScriptPathFindsInstalledCommand)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd"));
+
+  const QString found = PackageManager::pixiScriptPath(m_packageDir, "avo-cmd");
+  ASSERT_FALSE(found.isEmpty());
+  EXPECT_TRUE(found.startsWith(m_packageDir + pixiBinDir()));
+  EXPECT_TRUE(QFileInfo(found).isExecutable());
+
+  // A pixi environment is not a venv, and vice versa.
+  EXPECT_TRUE(
+    PackageManager::venvScriptPath(m_packageDir, "avo-cmd").isEmpty());
+}
+
+TEST_F(PackageManagerTest, venvScriptPathFindsInstalledCommand)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+
+  const QString found = PackageManager::venvScriptPath(m_packageDir, "avo-cmd");
+  ASSERT_FALSE(found.isEmpty());
+  EXPECT_TRUE(found.startsWith(m_packageDir + venvBinDir()));
+
+  EXPECT_TRUE(
+    PackageManager::pixiScriptPath(m_packageDir, "avo-cmd").isEmpty());
+}
+
+TEST_F(PackageManagerTest, scriptPathsIgnoreNonExecutableFiles)
+{
+  // A package directory copied off a read-only medium (or unpacked without
+  // permissions) can hold a .pixi tree whose contents cannot be run.
+  ASSERT_TRUE(
+    createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd", false));
+
+  EXPECT_TRUE(
+    PackageManager::pixiScriptPath(m_packageDir, "avo-cmd").isEmpty());
+}
+
+// ---------------------------------------------------------------------------
+// scanDirectory() environment checks
+//
+// The pyproject.toml hash alone is not enough to decide that a registered
+// package is ready to use: installing pixi after a package was pip-installed
+// leaves the manifest untouched but changes which backend we should use.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// scanDirectory() looks at the immediate subdirectories of what it is given,
+// so nest a package one level below the directory that will be scanned.
+// Returns the package directory, or an empty string on failure.
+QString createScannablePackage(const QString& scanDir, const QByteArray& toml)
+{
+  const QString packageDir = scanDir + "/test-plugin";
+  if (!QDir().mkpath(packageDir))
+    return {};
+  if (writeTextFile(packageDir + "/pyproject.toml", toml).isEmpty())
+    return {};
+  return packageDir;
+}
+
+// Whether this machine has anything capable of building an environment.
+// scanDirectory() will not ask to re-install when it cannot help.
+bool pixiIsInstalled()
+{
+#ifdef Q_OS_WIN
+  return !Avogadro::QtGui::Utilities::findExecutablePath("pixi.exe").isEmpty();
+#else
+  return !Avogadro::QtGui::Utilities::findExecutablePath("pixi").isEmpty();
+#endif
+}
+
+bool canInstallPackages()
+{
+#ifdef Q_OS_WIN
+  const QStringList pythonNames = { "python.exe", "python3.exe" };
+#else
+  const QStringList pythonNames = { "python3", "python" };
+#endif
+  for (const QString& name : pythonNames) {
+    if (!Avogadro::QtGui::Utilities::findExecutablePath(name).isEmpty())
+      return true;
+  }
+  return pixiIsInstalled();
+}
+
+} // namespace
+
+TEST_F(PackageManagerTest, scanDirectoryReturnsUnregisteredPackage)
+{
+  const QString scanDir = m_packageDir + "/scan";
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  EXPECT_TRUE(PackageManager::instance()->scanDirectory(scanDir).contains(
+    QDir(pkgDir).absolutePath()));
+}
+
+TEST_F(PackageManagerTest, scanDirectorySkipsPackageWithPixiEnvironment)
+{
+  const QString scanDir = m_packageDir + "/scan";
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  auto* pm = PackageManager::instance();
+  ASSERT_TRUE(pm->registerPackage(pkgDir));
+  ASSERT_TRUE(
+    createConsoleScript(pkgDir + pixiBinDir(), "avogadro-test-plugin"));
+
+  // Manifest unchanged and the preferred backend is in place: nothing to do.
+  EXPECT_FALSE(
+    pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()));
+}
+
+TEST_F(PackageManagerTest, scanDirectoryRescansPackageWithMissingEnvironment)
+{
+  if (!canInstallPackages())
+    GTEST_SKIP() << "no pixi or python available to install with";
+
+  const QString scanDir = m_packageDir + "/scan";
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  auto* pm = PackageManager::instance();
+  ASSERT_TRUE(pm->registerPackage(pkgDir));
+
+  // Registered, manifest unchanged, but nothing was ever installed — the
+  // install failed, or the environment was removed. Offer to install again.
+  EXPECT_TRUE(pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()));
+}
+
+TEST_F(PackageManagerTest, scanDirectoryRescansVenvPackageOncePixiIsAvailable)
+{
+  const QString scanDir = m_packageDir + "/scan";
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  auto* pm = PackageManager::instance();
+  ASSERT_TRUE(pm->registerPackage(pkgDir));
+  ASSERT_TRUE(
+    createConsoleScript(pkgDir + venvBinDir(), "avogadro-test-plugin"));
+
+  // A pip-installed package still runs, so it is only worth re-installing in
+  // order to migrate it to pixi — and only if pixi is actually here now.
+  EXPECT_EQ(pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()),
+            pixiIsInstalled());
+}
+
+// ---------------------------------------------------------------------------
+// removeSupersededVenv()
+//
+// Deleting the pip-installed tree is the one destructive step in a migration,
+// so it must happen only once pixi can demonstrably run the command.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, removeSupersededVenvDeletesVenvOncePixiProvidesIt)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd"));
+
+  EXPECT_TRUE(PackageManager::removeSupersededVenv(m_packageDir, "avo-cmd"));
+  EXPECT_FALSE(QDir(m_packageDir + "/.venv").exists());
+
+  // The pixi environment must be left alone.
+  EXPECT_FALSE(
+    PackageManager::pixiScriptPath(m_packageDir, "avo-cmd").isEmpty());
+}
+
+TEST_F(PackageManagerTest, removeSupersededVenvKeepsVenvWithoutPixiCommand)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+
+  // No pixi environment at all: removing the venv would leave the package
+  // with no way to run.
+  EXPECT_FALSE(PackageManager::removeSupersededVenv(m_packageDir, "avo-cmd"));
+  EXPECT_TRUE(QDir(m_packageDir + "/.venv").exists());
+}
+
+TEST_F(PackageManagerTest, removeSupersededVenvKeepsVenvWhenPixiEnvLacksCommand)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+  // A pixi environment exists, but the install did not put our command in it.
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "other-cmd"));
+
+  EXPECT_FALSE(PackageManager::removeSupersededVenv(m_packageDir, "avo-cmd"));
+  EXPECT_TRUE(QDir(m_packageDir + "/.venv").exists());
+}
+
+TEST_F(PackageManagerTest, removeSupersededVenvIgnoresPackageWithoutVenv)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd"));
+
+  EXPECT_FALSE(PackageManager::removeSupersededVenv(m_packageDir, "avo-cmd"));
+}
+
+TEST_F(PackageManagerTest, removeSupersededVenvRejectsEmptyArguments)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd"));
+
+  // An empty package directory must never be turned into a path to delete,
+  // and an unknown command is not evidence that pixi can take over.
+  EXPECT_FALSE(PackageManager::removeSupersededVenv(QString(), "avo-cmd"));
+  EXPECT_FALSE(PackageManager::removeSupersededVenv(m_packageDir, QString()));
+  EXPECT_TRUE(QDir(m_packageDir + "/.venv").exists());
 }

--- a/tests/qtgui/packagemanagertest.cpp
+++ b/tests/qtgui/packagemanagertest.cpp
@@ -21,8 +21,21 @@
 using Avogadro::QtGui::PackageManager;
 
 namespace {
+// Ensure a QCoreApplication exists and that QSettings has an organisation and
+// application to write under. findExecutablePath(), reached via
+// resolveCommandLine(), searches applicationDirPath(), which warns and returns
+// an empty string without an application object — turning the first search
+// entries into root-relative paths. The test binary uses gtest_main, which
+// creates none. argv[0] matches the name set below, so the QSettings scope is
+// the same either way.
 void ensureSettingsContext()
 {
+  if (!QCoreApplication::instance()) {
+    static int argc = 1;
+    static char name[] = "AvogadroLibsTests";
+    static char* argv[] = { name, nullptr };
+    static QCoreApplication app(argc, argv);
+  }
   if (QCoreApplication::organizationName().isEmpty())
     QCoreApplication::setOrganizationName(QStringLiteral("OpenChemistry"));
   if (QCoreApplication::applicationName().isEmpty())
@@ -1135,4 +1148,60 @@ TEST_F(PackageManagerTest, removeSupersededVenvRejectsEmptyArguments)
   EXPECT_FALSE(PackageManager::removeSupersededVenv(QString(), "avo-cmd"));
   EXPECT_FALSE(PackageManager::removeSupersededVenv(m_packageDir, QString()));
   EXPECT_TRUE(QDir(m_packageDir + "/.venv").exists());
+}
+
+// ---------------------------------------------------------------------------
+// resolveCommandLine()
+//
+// The single place that decides which backend runs a package command, so both
+// the run sites (PythonScript and loadOptionsFromScript) inherit the policy.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, resolveCommandLinePrefersPixiEnvironment)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + pixiBinDir(), "avo-cmd"));
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+
+  const auto commandLine =
+    PackageManager::resolveCommandLine(m_packageDir, "avo-cmd");
+
+  // Only meaningful where pixi is installed; elsewhere the venv is the only
+  // option and the fallback case below covers it.
+#ifdef Q_OS_WIN
+  const bool pixiInstalled =
+    !Avogadro::QtGui::Utilities::findExecutablePath("pixi.exe").isEmpty();
+#else
+  const bool pixiInstalled =
+    !Avogadro::QtGui::Utilities::findExecutablePath("pixi").isEmpty();
+#endif
+  if (!pixiInstalled)
+    GTEST_SKIP() << "pixi is not installed on this machine";
+
+  EXPECT_TRUE(commandLine.program.endsWith("pixi") ||
+              commandLine.program.endsWith("pixi.exe"));
+  EXPECT_EQ(commandLine.prefixArgs,
+            QStringList({ "run", "--as-is", "avo-cmd" }));
+}
+
+TEST_F(PackageManagerTest, resolveCommandLineFallsBackToVenvScript)
+{
+  ASSERT_TRUE(createConsoleScript(m_packageDir + venvBinDir(), "avo-cmd"));
+
+  // No pixi environment, so the console script is run directly and needs no
+  // arguments in front of its own.
+  const auto commandLine =
+    PackageManager::resolveCommandLine(m_packageDir, "avo-cmd");
+
+  EXPECT_EQ(commandLine.program,
+            PackageManager::venvScriptPath(m_packageDir, "avo-cmd"));
+  EXPECT_TRUE(commandLine.prefixArgs.isEmpty());
+}
+
+TEST_F(PackageManagerTest, resolveCommandLineEmptyWithoutAnyEnvironment)
+{
+  const auto commandLine =
+    PackageManager::resolveCommandLine(m_packageDir, "avo-cmd");
+
+  EXPECT_TRUE(commandLine.program.isEmpty());
+  EXPECT_TRUE(commandLine.prefixArgs.isEmpty());
 }

--- a/tests/qtgui/utilitiestest.cpp
+++ b/tests/qtgui/utilitiestest.cpp
@@ -7,6 +7,7 @@
 
 #include <avogadro/qtgui/utilities.h>
 
+#include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QTemporaryDir>
@@ -14,6 +15,21 @@
 using Avogadro::QtGui::Utilities::findExecutablePath;
 
 namespace {
+
+// Ensure a QCoreApplication exists (findExecutablePath() searches
+// applicationDirPath(), which warns and returns an empty string without one,
+// turning the first search entries into root-relative paths).
+// The test binary uses gtest_main which does not create one.
+QCoreApplication* ensureApp()
+{
+  if (QCoreApplication::instance())
+    return QCoreApplication::instance();
+  static int argc = 1;
+  static char name[] = "UtilitiesTest";
+  static char* argv[] = { name, nullptr };
+  static QCoreApplication app(argc, argv);
+  return &app;
+}
 
 // A name no real installation can supply, so that a pixi (or anything else)
 // genuinely present on the test machine cannot decide the result.
@@ -74,6 +90,7 @@ private:
 // to be searched explicitly or pixi looks uninstalled.
 TEST(UtilitiesTest, findsPixiInPixiHomeWhenNotOnPath)
 {
+  ensureApp();
   ScopedEnvironment restoreEnvironment;
 
   QTemporaryDir tmp;
@@ -92,6 +109,7 @@ TEST(UtilitiesTest, findsPixiInPixiHomeWhenNotOnPath)
 // A pixi the user has deliberately put on PATH must still win.
 TEST(UtilitiesTest, pathTakesPrecedenceOverPixiHome)
 {
+  ensureApp();
   ScopedEnvironment restoreEnvironment;
 
   QTemporaryDir tmp;
@@ -111,6 +129,7 @@ TEST(UtilitiesTest, pathTakesPrecedenceOverPixiHome)
 
 TEST(UtilitiesTest, missingProgramReturnsEmptyPath)
 {
+  ensureApp();
   ScopedEnvironment restoreEnvironment;
 
   QTemporaryDir tmp;
@@ -126,6 +145,7 @@ TEST(UtilitiesTest, missingProgramReturnsEmptyPath)
 // An empty PATH entry must not turn into a search of the filesystem root.
 TEST(UtilitiesTest, emptyPathEntriesAreIgnored)
 {
+  ensureApp();
   ScopedEnvironment restoreEnvironment;
 
   QTemporaryDir tmp;

--- a/tests/qtgui/utilitiestest.cpp
+++ b/tests/qtgui/utilitiestest.cpp
@@ -1,0 +1,142 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/qtgui/utilities.h>
+
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryDir>
+
+using Avogadro::QtGui::Utilities::findExecutablePath;
+
+namespace {
+
+// A name no real installation can supply, so that a pixi (or anything else)
+// genuinely present on the test machine cannot decide the result.
+#ifdef Q_OS_WIN
+const char* fakeProgram = "avogadro-test-pixi.exe";
+const char* pathSeparator = ";";
+#else
+const char* fakeProgram = "avogadro-test-pixi";
+const char* pathSeparator = ":";
+#endif
+
+// Create an executable stand-in for a program at @a dir/@a name.
+bool createExecutable(const QString& dir, const QString& name)
+{
+  if (!QDir().mkpath(dir))
+    return false;
+
+  const QString path = dir + '/' + name;
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly))
+    return false;
+  file.write("#!/bin/sh\n");
+  file.close();
+
+  return QFile::setPermissions(path, QFile::ReadOwner | QFile::WriteOwner |
+                                       QFile::ExeOwner);
+}
+
+// Save and restore the environment variables these tests scribble on, so the
+// order in which gtest runs them cannot matter.
+class ScopedEnvironment
+{
+public:
+  ScopedEnvironment()
+    : m_path(qgetenv("PATH")), m_pixiHome(qgetenv("PIXI_HOME"))
+  {
+  }
+
+  ~ScopedEnvironment()
+  {
+    qputenv("PATH", m_path);
+    if (m_pixiHome.isEmpty())
+      qunsetenv("PIXI_HOME");
+    else
+      qputenv("PIXI_HOME", m_pixiHome);
+  }
+
+private:
+  QByteArray m_path;
+  QByteArray m_pixiHome;
+};
+
+} // namespace
+
+// pixi installs into $PIXI_HOME/bin (default $HOME/.pixi/bin) and puts that
+// directory on PATH from the shell profile. Avogadro started from a desktop
+// launcher, the Dock or Finder never sees that profile, so the directory has
+// to be searched explicitly or pixi looks uninstalled.
+TEST(UtilitiesTest, findsPixiInPixiHomeWhenNotOnPath)
+{
+  ScopedEnvironment restoreEnvironment;
+
+  QTemporaryDir tmp;
+  ASSERT_TRUE(tmp.isValid());
+
+  const QString binDir = tmp.path() + "/bin";
+  ASSERT_TRUE(createExecutable(binDir, fakeProgram));
+
+  qputenv("PIXI_HOME", tmp.path().toUtf8());
+  qputenv("PATH", QByteArray());
+
+  EXPECT_EQ(QDir(findExecutablePath(fakeProgram)).absolutePath(),
+            QDir(binDir).absolutePath());
+}
+
+// A pixi the user has deliberately put on PATH must still win.
+TEST(UtilitiesTest, pathTakesPrecedenceOverPixiHome)
+{
+  ScopedEnvironment restoreEnvironment;
+
+  QTemporaryDir tmp;
+  ASSERT_TRUE(tmp.isValid());
+
+  const QString pixiHomeBin = tmp.path() + "/pixi-home/bin";
+  const QString pathBin = tmp.path() + "/on-path";
+  ASSERT_TRUE(createExecutable(pixiHomeBin, fakeProgram));
+  ASSERT_TRUE(createExecutable(pathBin, fakeProgram));
+
+  qputenv("PIXI_HOME", (tmp.path() + "/pixi-home").toUtf8());
+  qputenv("PATH", pathBin.toUtf8());
+
+  EXPECT_EQ(QDir(findExecutablePath(fakeProgram)).absolutePath(),
+            QDir(pathBin).absolutePath());
+}
+
+TEST(UtilitiesTest, missingProgramReturnsEmptyPath)
+{
+  ScopedEnvironment restoreEnvironment;
+
+  QTemporaryDir tmp;
+  ASSERT_TRUE(tmp.isValid());
+
+  qputenv("PIXI_HOME", tmp.path().toUtf8());
+  qputenv("PATH", QByteArray());
+
+  EXPECT_TRUE(
+    findExecutablePath("avogadro-no-such-program-should-exist").isEmpty());
+}
+
+// An empty PATH entry must not turn into a search of the filesystem root.
+TEST(UtilitiesTest, emptyPathEntriesAreIgnored)
+{
+  ScopedEnvironment restoreEnvironment;
+
+  QTemporaryDir tmp;
+  ASSERT_TRUE(tmp.isValid());
+
+  const QString binDir = tmp.path() + "/bin";
+  ASSERT_TRUE(createExecutable(binDir, fakeProgram));
+
+  qputenv("PIXI_HOME", tmp.path().toUtf8());
+  qputenv("PATH", QByteArray(pathSeparator) + pathSeparator);
+
+  EXPECT_EQ(QDir(findExecutablePath(fakeProgram)).absolutePath(),
+            QDir(binDir).absolutePath());
+}


### PR DESCRIPTION
- Ensure ${HOME}/.pixi/bin is checked for pixi
- Packages were never repaired b/c the checksum didn't change
- scanDirectory() now checks for valid .pixi or venv and re-installs if needed
- Cleanup venv if switching to pixi install works cleanly

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package command discovery across Pixi environments and Python virtual environments.
  * Added safer support for package setup commands and console scripts.
  * Python package execution now uses the best available installed environment.

* **Bug Fixes**
  * Packages are reinstalled when their environment is missing or Pixi becomes available.
  * Obsolete virtual environments are removed only after successful Pixi validation.
  * Improved executable discovery, including Pixi installation locations.

* **Tests**
  * Added coverage for command discovery, environment migration, executable lookup, and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->