### PR TITLE
Fix bug that would register two clicks to the same atom

### DIFF
--- a/avogadro/qtplugins/templatetool/CMakeLists.txt
+++ b/avogadro/qtplugins/templatetool/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ExternalProject)
 find_package(Qt${QT_VERSION} REQUIRED COMPONENTS Svg)
 
 set(template_srcs
+  templateattachment.cpp
   templatetool.cpp
   templatetoolwidget.cpp
 )

--- a/avogadro/qtplugins/templatetool/templateattachment.cpp
+++ b/avogadro/qtplugins/templatetool/templateattachment.cpp
@@ -1,0 +1,83 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "templateattachment.h"
+
+#include <avogadro/core/molecule.h>
+#include <avogadro/core/vector.h>
+#include <avogadro/io/cjsonformat.h>
+
+#include <QtCore/QFile>
+#include <QtCore/QTextStream>
+
+namespace Avogadro {
+namespace QtPlugins {
+
+Index templateAttachmentDummy(const Core::Molecule& templateMolecule)
+{
+  // For haptic ligands we have more than one dummy atom, so we pick the one
+  // furthest from the centroid of the carbon atoms.
+  Vector3 centroid(0.0, 0.0, 0.0);
+  unsigned carbonCount = 0;
+  for (Index i = 0; i < templateMolecule.atomCount(); ++i) {
+    if (templateMolecule.atomicNumber(i) == 6) {
+      carbonCount++;
+      centroid += templateMolecule.atomPosition3d(i);
+    }
+  }
+  if (carbonCount > 1)
+    centroid = centroid / carbonCount;
+
+  Index dummyIndex = MaxIndex;
+  Real maxDistance = 0.0;
+  for (Index i = 0; i < templateMolecule.atomCount(); ++i) {
+    if (templateMolecule.atomicNumber(i) != 0)
+      continue;
+
+    Vector3 delta = templateMolecule.atomPosition3d(i) - centroid;
+    if (dummyIndex != MaxIndex && delta.squaredNorm() < maxDistance)
+      continue; // too close to the centroid
+
+    maxDistance = delta.squaredNorm();
+    dummyIndex = i;
+  }
+
+  return dummyIndex;
+}
+
+std::vector<Index> templateAttachmentPoints(
+  const Core::Molecule& templateMolecule, Index dummyIndex)
+{
+  std::vector<Index> attachmentPoints;
+  if (dummyIndex == MaxIndex || dummyIndex >= templateMolecule.atomCount())
+    return attachmentPoints;
+
+  for (const Core::Bond* bond : templateMolecule.bonds(dummyIndex))
+    attachmentPoints.push_back(bond->getOtherAtom(dummyIndex).index());
+
+  return attachmentPoints;
+}
+
+int templateDenticity(const QString& fileName)
+{
+  QFile templateFile(fileName);
+  if (!templateFile.open(QFile::ReadOnly | QFile::Text))
+    return 0;
+
+  QTextStream templateStream(&templateFile);
+  Core::Molecule templateMolecule;
+  Io::CjsonFormat format;
+  if (!format.readString(templateStream.readAll().toStdString(),
+                         templateMolecule))
+    return 0;
+
+  return static_cast<int>(
+    templateAttachmentPoints(templateMolecule,
+                             templateAttachmentDummy(templateMolecule))
+      .size());
+}
+
+} // namespace QtPlugins
+} // namespace Avogadro

--- a/avogadro/qtplugins/templatetool/templateattachment.h
+++ b/avogadro/qtplugins/templatetool/templateattachment.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_QTPLUGINS_TEMPLATEATTACHMENT_H
+#define AVOGADRO_QTPLUGINS_TEMPLATEATTACHMENT_H
+
+#include <avogadro/core/avogadrocore.h>
+
+#include <QtCore/QString>
+
+#include <vector>
+
+namespace Avogadro {
+namespace Core {
+class Molecule;
+}
+namespace QtPlugins {
+
+/**
+ * Ligand templates mark the metal center with a dummy atom. These helpers are
+ * shared by the tool and the tool widget so both agree on which dummy atom a
+ * template attaches through, and on how many attachment points it offers.
+ */
+
+/**
+ * @return the index of the dummy atom @a templateMolecule attaches through, or
+ * MaxIndex if it has none. Haptic ligands carry more than one dummy atom, in
+ * which case the one furthest from the centroid of the carbons is used.
+ */
+Index templateAttachmentDummy(const Core::Molecule& templateMolecule);
+
+/**
+ * @return the atoms bonded to @a dummyIndex, i.e. the donor atoms that will be
+ * bonded to the metal center. Empty if @a dummyIndex is not a valid atom.
+ */
+std::vector<Index> templateAttachmentPoints(
+  const Core::Molecule& templateMolecule, Index dummyIndex);
+
+/**
+ * @return the number of attachment points offered by the CJSON template in
+ * @a fileName, i.e. its denticity, or 0 if the file cannot be read.
+ */
+int templateDenticity(const QString& fileName);
+
+} // namespace QtPlugins
+} // namespace Avogadro
+
+#endif // AVOGADRO_QTPLUGINS_TEMPLATEATTACHMENT_H

--- a/avogadro/qtplugins/templatetool/templatetool.cpp
+++ b/avogadro/qtplugins/templatetool/templatetool.cpp
@@ -27,6 +27,7 @@
 #include <avogadro/rendering/glrenderer.h>
 
 #include <avogadro/rendering/groupnode.h>
+#include <avogadro/rendering/spheregeometry.h>
 #include <avogadro/rendering/textlabel2d.h>
 #include <avogadro/rendering/textlabel3d.h>
 #include <avogadro/rendering/textproperties.h>
@@ -46,6 +47,7 @@
 #include <QtCore/QMimeData>
 #include <QtCore/QTimer>
 
+#include <algorithm>
 #include <limits>
 
 namespace {
@@ -67,6 +69,7 @@ using Avogadro::Io::CjsonFormat;
 using Avogadro::Rendering::GeometryNode;
 using Avogadro::Rendering::GroupNode;
 using Avogadro::Rendering::Identifier;
+using Avogadro::Rendering::SphereGeometry;
 using Avogadro::Rendering::TextLabel2D;
 using Avogadro::Rendering::TextLabel3D;
 using Avogadro::Rendering::TextProperties;
@@ -323,7 +326,55 @@ QUndoCommand* TemplateTool::keyPressEvent(QKeyEvent* e)
   return nullptr;
 }
 
-void TemplateTool::draw(Rendering::GroupNode&) {}
+void TemplateTool::draw(Rendering::GroupNode& node)
+{
+  if (m_molecule == nullptr || m_toolWidget == nullptr)
+    return;
+
+  // Mark the placeholder atoms picked so far for a polydentate ligand.
+  const std::vector<size_t>& selectedUIDs = m_toolWidget->selectedUIDs();
+  if (selectedUIDs.empty())
+    return;
+
+  auto* geo = new GeometryNode;
+  node.addChild(geo);
+
+  // Translucent red, to keep these distinct from the blue selection color.
+  // The identifier is left unset so these never intercept atom picking.
+  auto* spheres = new SphereGeometry;
+  spheres->setOpacity(0.55f);
+  spheres->setRenderPass(Rendering::TranslucentPass);
+  geo->addDrawable(spheres);
+
+  TextProperties labelProp;
+  labelProp.setFontFamily(TextProperties::SansSerif);
+  labelProp.setAlign(TextProperties::HCenter, TextProperties::VCenter);
+  labelProp.setColorRgb(255, 255, 255);
+
+  unsigned int count = 0;
+  for (size_t UID : selectedUIDs) {
+    RWAtom atom = m_molecule->atomByUniqueId(UID);
+    if (!atom.isValid())
+      continue;
+
+    Vector3f position = atom.position3d().cast<float>();
+    // Big enough to show around a ball-and-stick hydrogen or a dummy atom.
+    float radius = std::max(
+      static_cast<float>(Elements::radiusVDW(atom.atomicNumber())) * 0.4f,
+      0.35f);
+    spheres->addSphere(position, Vector3ub(255, 0, 0), radius, count);
+
+    // Number the attachment points in the order they were clicked.
+    auto* label = new TextLabel3D;
+    label->setText(QString("#%1").arg(count + 1).toStdString());
+    label->setTextProperties(labelProp);
+    label->setAnchor(position);
+    label->setRadius(radius);
+    geo->addDrawable(label);
+
+    ++count;
+  }
+}
 
 void TemplateTool::updatePressedButtons(QMouseEvent* e, bool release)
 {
@@ -384,6 +435,7 @@ void TemplateTool::emptyLeftClick(QMouseEvent* e)
     return;
 
   m_toolWidget->selectedUIDs().clear();
+  emit drawablesChanged();
   Vector2f windowPos(e->localPos().x(), e->localPos().y());
   Vector3f atomPos = m_renderer->camera().unProject(windowPos);
   // center of inserted template
@@ -551,13 +603,18 @@ Vector3 rotateLigandCoords(Vector3 in, Vector3 centerVector, Vector3 outVector)
   return rot * in;
 }
 
-Matrix3 applyKabsch(std::vector<Vector3> templatePoints,
-                    std::vector<Vector3> moleculePoints)
+Matrix3 applyKabsch(const std::vector<Vector3>& templatePoints,
+                    const std::vector<Vector3>& moleculePoints)
 {
-  assert(templatePoints.size() == moleculePoints.size());
-  MatrixX TP(templatePoints.size(), 3);
-  MatrixX MP(templatePoints.size(), 3);
-  for (size_t i = 0; i < templatePoints.size(); i++) {
+  // The two sets should always match, but a mismatched template would
+  // otherwise read past the end of the shorter one.
+  size_t count = std::min(templatePoints.size(), moleculePoints.size());
+  if (count == 0)
+    return Matrix3::Identity();
+
+  MatrixX TP(count, 3);
+  MatrixX MP(count, 3);
+  for (size_t i = 0; i < count; i++) {
     TP.row(i) = templatePoints[i];
     MP.row(i) = moleculePoints[i];
   }
@@ -578,11 +635,30 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
   if (m_molecule->atom(selectedIndex).isValid() &&
       (m_molecule->atomicNumber(selectedIndex) == 1 ||
        m_molecule->atomicNumber(selectedIndex) == 0)) {
-    m_toolWidget->selectedUIDs().push_back(
-      m_molecule->atomUniqueId(selectedIndex));
-    if (static_cast<int>(m_toolWidget->selectedUIDs().size()) !=
-        m_toolWidget->denticity())
+    std::vector<size_t>& selectedUIDs = m_toolWidget->selectedUIDs();
+
+    // Drop any stale selections (e.g. atoms removed by an undo) so we never
+    // try to attach a ligand to an atom that no longer exists.
+    selectedUIDs.erase(
+      std::remove_if(selectedUIDs.begin(), selectedUIDs.end(),
+                     [this](size_t uid) {
+                       return !m_molecule->atomByUniqueId(uid).isValid();
+                     }),
+      selectedUIDs.end());
+
+    // Every attachment point of a polydentate ligand has to be a distinct
+    // atom, so ignore repeat clicks on an atom that is already selected.
+    size_t selectedUID = m_molecule->atomUniqueId(selectedIndex);
+    if (std::find(selectedUIDs.begin(), selectedUIDs.end(), selectedUID) !=
+        selectedUIDs.end())
       return;
+
+    selectedUIDs.push_back(selectedUID);
+    if (static_cast<int>(selectedUIDs.size()) != m_toolWidget->denticity()) {
+      // Show the marker for this attachment point and wait for the rest.
+      emit drawablesChanged();
+      return;
+    }
 
     // Get the ligand template
     // - check if we should use the clipboard
@@ -700,7 +776,7 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
       moleculeCenterIndex =
         m_molecule->bonds(selectedIndex)[0].getOtherAtom(selectedIndex).index();
       moleculeCenterUID = m_molecule->atomUniqueId(moleculeCenterIndex);
-      for (size_t UID : m_toolWidget->selectedUIDs()) {
+      for (size_t UID : selectedUIDs) {
         size_t index = m_molecule->atomByUniqueId(UID).index();
         Vector3 newPos = m_molecule->atomPosition3d(index);
         moleculeLigandOutVector +=
@@ -751,7 +827,7 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
           templateMolecule.atomPosition3d(index) -
           m_molecule->atomPosition3d(moleculeCenterIndex));
       std::vector<Vector3> moleculeLigandPositions;
-      for (size_t UID : m_toolWidget->selectedUIDs())
+      for (size_t UID : selectedUIDs)
         moleculeLigandPositions.push_back(
           m_molecule->atomPosition3d(m_molecule->atomByUniqueId(UID).index()) -
           m_molecule->atomPosition3d(moleculeCenterIndex));
@@ -803,7 +879,7 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
     // Remove selected atoms and insert ligand
     // (unless there wasn't a bond to begin with)
     if (m_molecule->bonds(selectedIndex).size() != 0) {
-      for (size_t UID : m_toolWidget->selectedUIDs())
+      for (size_t UID : selectedUIDs)
         m_molecule->removeAtom(m_molecule->atomByUniqueId(UID).index());
     }
     size_t moleculeBaseIndex = m_molecule->atomCount();
@@ -815,7 +891,8 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
     for (size_t index : templateNewLigandIndices)
       m_molecule->addBond(index + moleculeBaseIndex, moleculeCenterNewIndex);
 
-    m_toolWidget->selectedUIDs().clear();
+    selectedUIDs.clear();
+    emit drawablesChanged();
   }
 }
 

--- a/avogadro/qtplugins/templatetool/templatetool.cpp
+++ b/avogadro/qtplugins/templatetool/templatetool.cpp
@@ -4,6 +4,7 @@
 ******************************************************************************/
 
 #include "templatetool.h"
+#include "templateattachment.h"
 #include "templatetoolkeymap.h"
 #include "templatetoolwidget.h"
 
@@ -97,6 +98,10 @@ TemplateTool::TemplateTool(QObject* parent_)
       .arg(shortcut));
   setIcon();
   reset();
+
+  // Discard the markers when the widget drops a pending ligand selection.
+  connect(m_toolWidget, &TemplateToolWidget::selectionCleared, this,
+          &TemplateTool::drawablesChanged);
 }
 
 TemplateTool::~TemplateTool() {}
@@ -428,14 +433,22 @@ void TemplateTool::reset()
   emit drawablesChanged();
 }
 
+void TemplateTool::clearLigandSelection()
+{
+  if (m_toolWidget == nullptr || m_toolWidget->selectedUIDs().empty())
+    return;
+
+  m_toolWidget->selectedUIDs().clear();
+  emit drawablesChanged();
+}
+
 void TemplateTool::emptyLeftClick(QMouseEvent* e)
 {
   // Get the coordinates of the clicked position
   if (m_renderer == nullptr)
     return;
 
-  m_toolWidget->selectedUIDs().clear();
-  emit drawablesChanged();
+  clearLigandSelection();
   Vector2f windowPos(e->localPos().x(), e->localPos().y());
   Vector3f atomPos = m_renderer->camera().unProject(windowPos);
   // center of inserted template
@@ -606,10 +619,11 @@ Vector3 rotateLigandCoords(Vector3 in, Vector3 centerVector, Vector3 outVector)
 Matrix3 applyKabsch(const std::vector<Vector3>& templatePoints,
                     const std::vector<Vector3>& moleculePoints)
 {
-  // The two sets should always match, but a mismatched template would
-  // otherwise read past the end of the shorter one.
-  size_t count = std::min(templatePoints.size(), moleculePoints.size());
-  if (count == 0)
+  // Callers must pair every template point with a molecule point. Anything
+  // else is a bad attachment mapping, so refuse to rotate rather than read
+  // past the end of the shorter set.
+  size_t count = templatePoints.size();
+  if (count == 0 || count != moleculePoints.size())
     return Matrix3::Identity();
 
   MatrixX TP(count, 3);
@@ -669,6 +683,7 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
       const QMimeData* mimeData(QApplication::clipboard()->mimeData());
 
       if (!mimeData) {
+        clearLigandSelection();
         return;
       }
 
@@ -693,16 +708,20 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
         pastedData = mimeData->text().toLatin1();
       }
 
-      if (pastedFormat == nullptr)
+      if (pastedFormat == nullptr) {
+        clearLigandSelection();
         return;
+      }
 
       // we have a format, so try to insert the new bits into the molecule
       bool success = pastedFormat->readString(
         std::string(pastedData.constData(), pastedData.size()),
         templateMolecule);
 
-      if (!success)
+      if (!success) {
+        clearLigandSelection();
         return;
+      }
 
     } else {
       QString path;
@@ -714,53 +733,38 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
       }
 
       QFile templ(path);
-      if (!templ.open(QFile::ReadOnly | QFile::Text))
+      if (!templ.open(QFile::ReadOnly | QFile::Text)) {
+        clearLigandSelection();
         return;
+      }
       QTextStream templateStream(&templ);
 
       CjsonFormat ff;
 
       if (!ff.readString(templateStream.readAll().toStdString(),
-                         templateMolecule))
+                         templateMolecule)) {
+        clearLigandSelection();
         return;
-    }
-
-    // Find dummy atom in template and get all necessary info
-    // for haptic ligands, we pick the dummy atom that's
-    // furthest from the centroid of the carbon atoms
-    Vector3 centroid(0.0, 0.0, 0.0);
-    unsigned carbonCount = 0;
-    for (size_t i = 0; i < templateMolecule.atomCount(); ++i) {
-      if (templateMolecule.atomicNumber(i) == 6) {
-        carbonCount++;
-        centroid += templateMolecule.atomPosition3d(i);
       }
     }
-    if (carbonCount > 1)
-      centroid = centroid / carbonCount;
 
-    size_t templateDummyIndex = 0;
-    std::vector<size_t> templateLigandIndices;
-    std::vector<size_t> templateLigandUIDs;
-    float maxDistance = 0.0;
-    for (size_t i = 0; i < templateMolecule.atomCount(); ++i) {
-      // in some ligands (e.g., haptic) we might have two dummy atoms
-      // so we only select the one furthest from the ligand centroid
-      if (templateMolecule.atomicNumber(i) == 0) {
-        Vector3 delta = templateMolecule.atomPosition3d(i) - centroid;
-        if (delta.squaredNorm() < maxDistance)
-          continue; // too close to the centroid
+    // Find the dummy atom in the template and get all necessary info
+    Index templateDummyIndex = templateAttachmentDummy(templateMolecule);
+    std::vector<Index> templateLigandIndices =
+      templateAttachmentPoints(templateMolecule, templateDummyIndex);
+    std::vector<Index> templateLigandUIDs;
+    templateLigandUIDs.reserve(templateLigandIndices.size());
+    for (Index index : templateLigandIndices)
+      templateLigandUIDs.push_back(templateMolecule.atomUniqueId(index));
 
-        maxDistance = delta.squaredNorm();
-        templateDummyIndex = i;
-        templateLigandIndices.clear();
-        templateLigandUIDs.clear();
-        for (const auto& bond : templateMolecule.bonds(i)) {
-          size_t newIndex = bond.getOtherAtom(i).index();
-          templateLigandIndices.push_back(newIndex);
-          templateLigandUIDs.push_back(templateMolecule.atomUniqueId(newIndex));
-        }
-      }
+    // The template has to offer exactly one attachment point per placeholder
+    // picked, or we would bond the wrong number of sites to the center (and
+    // have no way to align the two sets). Bail out before touching the
+    // molecule - this only happens for a custom ligand whose denticity does
+    // not match the type it was inserted under.
+    if (templateLigandIndices.size() != selectedUIDs.size()) {
+      clearLigandSelection();
+      return;
     }
 
     // Find center atom in our current molecule and get all necessary info
@@ -891,8 +895,7 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
     for (size_t index : templateNewLigandIndices)
       m_molecule->addBond(index + moleculeBaseIndex, moleculeCenterNewIndex);
 
-    selectedUIDs.clear();
-    emit drawablesChanged();
+    clearLigandSelection();
   }
 }
 

--- a/avogadro/qtplugins/templatetool/templatetool.h
+++ b/avogadro/qtplugins/templatetool/templatetool.h
@@ -77,6 +77,11 @@ private:
    */
   void reset();
 
+  /**
+   * Discard any pending ligand attachment points and refresh the display.
+   */
+  void clearLigandSelection();
+
   void emptyLeftClick(QMouseEvent* e);
   void atomLeftClick(QMouseEvent* e);
   void atomLeftClickCenter(QMouseEvent* e);

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
@@ -235,6 +235,15 @@ void TemplateToolWidget::setCurrentTab(int index)
   m_ui->tabWidget->setCurrentIndex(index);
 }
 
+void TemplateToolWidget::clearSelection()
+{
+  if (m_selectedUIDs.empty())
+    return;
+
+  m_selectedUIDs.clear();
+  emit selectionCleared();
+}
+
 void TemplateToolWidget::useCustomLigand(const QString& fileName)
 {
   m_ligandPath = fileName;
@@ -256,18 +265,14 @@ void TemplateToolWidget::useCustomLigand(const QString& fileName)
   m_ui->ligandComboBox->blockSignals(false);
 
   m_denticity = denticity;
-  m_selectedUIDs.clear();
+  clearSelection();
 }
 
 void TemplateToolWidget::tabChanged(int)
 {
   // A half-finished ligand can't carry over to another tab - the new tab has
   // its own denticity, so any pending attachment points are meaningless here.
-  if (m_selectedUIDs.empty())
-    return;
-
-  m_selectedUIDs.clear();
-  emit selectionCleared();
+  clearSelection();
 }
 
 void TemplateToolWidget::setGroup(const QString& groupName)
@@ -485,7 +490,7 @@ void TemplateToolWidget::typeChanged(int index)
   settings.beginGroup("templatetool");
   settings.setValue("ligandType", index);
 
-  m_selectedUIDs.clear();
+  clearSelection();
   m_denticity = denticityForType(index);
   m_ui->ligandComboBox->clear();
   m_ligands = QStringList();

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
@@ -47,7 +47,8 @@ enum LigandType
 
 TemplateToolWidget::TemplateToolWidget(QWidget* parent_)
   : QWidget(parent_), m_ui(new Ui::TemplateToolWidget),
-    m_fragmentDialog(nullptr), m_elementSelector(nullptr), m_currentElement(26)
+    m_fragmentDialog(nullptr), m_elementSelector(nullptr), m_currentElement(26),
+    m_denticity(1)
 {
   m_ui->setupUi(this);
 
@@ -211,7 +212,6 @@ void TemplateToolWidget::setGroup(const QString& groupName)
     m_ui->groupComboBox->blockSignals(true);
     m_ui->groupComboBox->setCurrentIndex(m_ui->groupComboBox->count() - 1);
     m_ui->groupComboBox->blockSignals(false);
-    m_denticity = 1;
     // Update the preview icon
     m_ui->groupPreview->setIcon(QIcon(":/icons/ligands/" + groupName + ".svg"));
   }
@@ -303,7 +303,6 @@ void TemplateToolWidget::groupChanged(int index)
   int i = m_ui->groupComboBox->currentIndex();
   const QString& groupName = m_groups[i];
   const QString& iconName = groupName;
-  m_denticity = 1;
 
   // check if it's "other"
   if (index == m_ui->groupComboBox->count() - 1) {
@@ -616,6 +615,11 @@ void TemplateToolWidget::saveElements()
 
 int TemplateToolWidget::denticity() const
 {
+  // Functional groups always attach through a single placeholder - m_denticity
+  // belongs to the ligand tab, so don't let it leak across.
+  if (currentTab() == TabType::FunctionalGroups)
+    return 1;
+
   return m_denticity;
 }
 

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.cpp
@@ -4,6 +4,7 @@
 ******************************************************************************/
 
 #include "templatetoolwidget.h"
+#include "templateattachment.h"
 #include "ui_templatetoolwidget.h"
 
 #include <avogadro/core/elements.h>
@@ -45,6 +46,46 @@ enum LigandType
   Clipboard = 6
 };
 
+namespace {
+// The denticity a ligand type implies. Custom ("Other...") ligands are
+// measured from their template instead, since the file decides.
+int denticityForType(int ligandType)
+{
+  switch (ligandType) {
+    case LigandType::Bidentate:
+      return 2;
+    case LigandType::Tridentate:
+      return 3;
+    case LigandType::Tetradentate:
+      return 4;
+    case LigandType::Hexadentate:
+      return 6;
+    default:
+      // monodentate, haptic (one dummy atom) and clipboard
+      return 1;
+  }
+}
+
+// The ligand type matching a measured denticity, or -1 when no type applies.
+// Monodentate and haptic templates both have a single attachment point, so
+// leave whichever of those the user picked alone.
+int typeForDenticity(int denticity)
+{
+  switch (denticity) {
+    case 2:
+      return LigandType::Bidentate;
+    case 3:
+      return LigandType::Tridentate;
+    case 4:
+      return LigandType::Tetradentate;
+    case 6:
+      return LigandType::Hexadentate;
+    default:
+      return -1;
+  }
+}
+} // namespace
+
 TemplateToolWidget::TemplateToolWidget(QWidget* parent_)
   : QWidget(parent_), m_ui(new Ui::TemplateToolWidget),
     m_fragmentDialog(nullptr), m_elementSelector(nullptr), m_currentElement(26),
@@ -83,6 +124,9 @@ TemplateToolWidget::TemplateToolWidget(QWidget* parent_)
            << "phenyl"
            << "phosphate"
            << "sulfonate" << tr("Other…");
+
+  connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), this,
+          SLOT(tabChanged(int)));
 
   connect(m_ui->elementComboBox, SIGNAL(currentIndexChanged(int)), this,
           SLOT(elementChanged(int)));
@@ -191,6 +235,41 @@ void TemplateToolWidget::setCurrentTab(int index)
   m_ui->tabWidget->setCurrentIndex(index);
 }
 
+void TemplateToolWidget::useCustomLigand(const QString& fileName)
+{
+  m_ligandPath = fileName;
+
+  // The file decides how many placeholders have to be picked, whichever type
+  // it was inserted under.
+  int denticity = templateDenticity(fileName);
+  if (denticity < 1)
+    denticity = 1;
+
+  // Show the type the template actually is. This repopulates the ligand list,
+  // so "Other..." has to be re-selected afterwards.
+  int ligandType = typeForDenticity(denticity);
+  if (ligandType >= 0 && ligandType != m_ui->typeComboBox->currentIndex())
+    m_ui->typeComboBox->setCurrentIndex(ligandType);
+
+  m_ui->ligandComboBox->blockSignals(true);
+  m_ui->ligandComboBox->setCurrentIndex(m_ui->ligandComboBox->count() - 1);
+  m_ui->ligandComboBox->blockSignals(false);
+
+  m_denticity = denticity;
+  m_selectedUIDs.clear();
+}
+
+void TemplateToolWidget::tabChanged(int)
+{
+  // A half-finished ligand can't carry over to another tab - the new tab has
+  // its own denticity, so any pending attachment points are meaningless here.
+  if (m_selectedUIDs.empty())
+    return;
+
+  m_selectedUIDs.clear();
+  emit selectionCleared();
+}
+
 void TemplateToolWidget::setGroup(const QString& groupName)
 {
   // Check if it's in the groups list (excluding "Other" at the end)
@@ -243,12 +322,8 @@ void TemplateToolWidget::setLigand(const QString& ligandName)
   if (index >= 0 && index < m_ligands.size() - 1) {
     m_ui->ligandComboBox->setCurrentIndex(index);
   } else {
-    // Not in list, set as custom ligand path
-    m_ligandPath = ":/templates/ligands/" + ligandName + ".cjson";
-    // Set to "Other" without triggering the dialog
-    m_ui->ligandComboBox->blockSignals(true);
-    m_ui->ligandComboBox->setCurrentIndex(m_ui->ligandComboBox->count() - 1);
-    m_ui->ligandComboBox->blockSignals(false);
+    // Not in list, so use it as a custom ligand ("Other...")
+    useCustomLigand(":/templates/ligands/" + ligandName + ".cjson");
     // Update the preview icon
     m_ui->ligandPreview->setIcon(
       QIcon(":/icons/ligands/" + ligandName + ".svg"));
@@ -373,6 +448,10 @@ void TemplateToolWidget::ligandChanged(int index)
     return;
   }
 
+  // A built-in ligand always matches the denticity of its type; a custom one
+  // may have left a measured value behind.
+  m_denticity = denticityForType(m_ui->typeComboBox->currentIndex());
+
   m_ui->ligandPreview->setIcon(QIcon(":/icons/ligands/" + iconName + ".svg"));
 }
 
@@ -384,7 +463,7 @@ void TemplateToolWidget::otherLigandInsert(const QString& fileName,
 
   // get the ligand name
   QString ligandName = m_fragmentDialog->fileName();
-  m_ligandPath = ligandName;
+  useCustomLigand(ligandName);
 
   m_fragmentDialog->hide();
   // it will be deleted later
@@ -407,6 +486,7 @@ void TemplateToolWidget::typeChanged(int index)
   settings.setValue("ligandType", index);
 
   m_selectedUIDs.clear();
+  m_denticity = denticityForType(index);
   m_ui->ligandComboBox->clear();
   m_ligands = QStringList();
   QStringList ligandNames;
@@ -425,7 +505,6 @@ void TemplateToolWidget::typeChanged(int index)
                 << "1-phosphine"
                 << "1-thiol"
                 << "1-other";
-      m_denticity = 1;
       break;
     case LigandType::Bidentate: // Bidentate
       ligandNames << "acetylacetonate"
@@ -435,13 +514,11 @@ void TemplateToolWidget::typeChanged(int index)
                 << "2-bipyridine"
                 << "2-ethylenediamine"
                 << "2-other";
-      m_denticity = 2;
       break;
     case LigandType::Tridentate: // Tridentate
       ligandNames << "terpyridine" << tr("Other…");
       m_ligands << "3-terpyridine"
                 << "3-other";
-      m_denticity = 3;
       break;
     case LigandType::Tetradentate: // Tetradentate
       ligandNames << "phthalocyanine"
@@ -451,13 +528,11 @@ void TemplateToolWidget::typeChanged(int index)
                 << "4-porphin"
                 << "4-salen"
                 << "4-other";
-      m_denticity = 4;
       break;
     case LigandType::Hexadentate: // Hexadentate
       ligandNames << "edta" << tr("Other…");
       m_ligands << "6-edta"
                 << "6-other";
-      m_denticity = 6;
       break;
     case LigandType::Haptic: // Haptic
       ligandNames << "η2-ethylene"
@@ -467,13 +542,11 @@ void TemplateToolWidget::typeChanged(int index)
                 << "eta5-cyclopentyl"
                 << "eta6-benzene"
                 << "eta-other";
-      m_denticity = 1;
       break;
     case LigandType::Clipboard: // Clipboard
       ligandNames << "clipboard";
       m_ligands = ligandNames;
       // technically, we should check the clipboard
-      m_denticity = 1;
       break;
   }
   m_ui->ligandComboBox->addItems(ligandNames);

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.h
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.h
@@ -73,6 +73,12 @@ private slots:
 
 private:
   /**
+   * Discard any pending attachment points and let the tool know, so the
+   * markers for them are removed from the display.
+   */
+  void clearSelection();
+
+  /**
    * Point the ligand tab at a custom template, matching the type combo to the
    * denticity measured from the file.
    */

--- a/avogadro/qtplugins/templatetool/templatetoolwidget.h
+++ b/avogadro/qtplugins/templatetool/templatetoolwidget.h
@@ -50,7 +50,13 @@ public:
   void setGroup(const QString& groupName);
   void setLigand(const QString& ligandName);
 
+signals:
+  /** Emitted when pending ligand attachment points are discarded. */
+  void selectionCleared();
+
 private slots:
+  void tabChanged(int index);
+
   void elementChanged(int index);
   void updateElementCombo();
   void addUserElement(unsigned char element);
@@ -66,6 +72,12 @@ private slots:
   void otherLigandInsert(const QString& fileName, bool crystal);
 
 private:
+  /**
+   * Point the ligand tab at a custom template, matching the type combo to the
+   * denticity measured from the file.
+   */
+  void useCustomLigand(const QString& fileName);
+
   void buildElements();
   void buildBondOrders();
   void saveElements();


### PR DESCRIPTION
Fix #2849 - make sure all atoms are unique
Also add a translucent selection and number marker to show clicks

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom ligand templates with automatic denticity detection and ligand-type selection.
  * Improved attachment-point mapping and visual markers for polydentate ligand placement.
  * Pending attachment selections can now be cleared when changing ligands, tabs, or insertion modes.

* **Bug Fixes**
  * Improved selection handling by ignoring duplicate clicks and removing invalid selections.
  * Ligand alignment and insertion now behave reliably with incomplete, empty, or mismatched attachment selections.
  * Functional Groups mode consistently uses the correct default denticity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->