### PR TITLE
For now, use Open Babel as higher priority than cclib

### DIFF
--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -81,12 +81,12 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
       Io::FileFormatManager::instance().fileFormatsFromFileExtension(
         "out", FileFormat::File | FileFormat::Read);
 
-    // loop through writers to check for "cclib" or "Open Babel"
+    // loop through readers to check for "cclib" or "Open Babel"
     for (const FileFormat* r : readers) {
-      if (r->name() == "cclib") {
+      if (r->identifier().compare(0, 9, "OpenBabel") == 0) {
         reader = r->newInstance();
         break;
-      } else if (r->identifier().compare(0, 9, "OpenBabel") == 0) {
+      } else if (r->name() == "cclib") { // avogadro-cclib plugin
         reader = r->newInstance();
         break;
       }


### PR DESCRIPTION
The cclib plugin can offer more formats, but is currently failing (I'll revisit after cclib-2.0 is released)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
