### PR TITLE
[skip ci] Add a warning if the build attempts to sign on Mac

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -140,9 +140,24 @@ jobs:
             security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
             security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-            # import certificate to keychain
+            # import the certificate *and* its private key to the keychain
             security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+            # let codesign use the private key without an interactive prompt
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH > /dev/null
             security list-keychain -d user -s $KEYCHAIN_PATH
+
+            # Fail here, with a useful message, rather than deep inside the
+            # packaging step where the only clue is
+            # "The specified item could not be found in the keychain."
+            echo "Code signing identities in the build keychain:"
+            security find-identity -v -p codesigning $KEYCHAIN_PATH || true
+            if ! security find-identity -v -p codesigning $KEYCHAIN_PATH | grep -qF "${CODESIGN_IDENTITY}"; then
+              echo "::error::No valid codesigning identity matching CODESIGN_ID was found."
+              echo "BUILD_CERTIFICATE_BASE64 must be a .p12 exported from Keychain Access"
+              echo "under 'My Certificates' (i.e. the certificate *and* its private key),"
+              echo "and the certificate must not have expired."
+              exit 1
+            fi
           fi # certificate exists
         fi # password exists
 


### PR DESCRIPTION
Mac signing cert wasn't changed properly, leading to an error

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
