### PR TITLE
Add an idealBondLength method to correct covalent radii sum

### DIFF
--- a/avogadro/core/atomutilities.cpp
+++ b/avogadro/core/atomutilities.cpp
@@ -5,6 +5,9 @@
 
 #include "atomutilities.h"
 
+#include <avogadro/core/elements.h>
+
+#include <algorithm>
 #include <cmath>
 #include <vector>
 
@@ -221,6 +224,189 @@ Vector3 AtomUtilities::generateNewBondVector(
     }
   }
   return newPos;
+}
+
+namespace {
+
+/**
+ * A measured length for one element pair and bond order, used where the sum of
+ * covalent radii is a poor estimate.
+ */
+struct IdealBondLength
+{
+  unsigned char atomicNumber1; //!< always <= atomicNumber2
+  unsigned char atomicNumber2;
+  unsigned char order;
+  double length; //!< in Angstroms
+};
+
+/** Pack a bond into a sortable key. Atomic numbers need 8 bits, order 4. */
+constexpr unsigned int bondKey(unsigned char atomicNumber1,
+                               unsigned char atomicNumber2, unsigned char order)
+{
+  return (static_cast<unsigned int>(atomicNumber1) << 12) |
+         (static_cast<unsigned int>(atomicNumber2) << 4) |
+         static_cast<unsigned int>(order);
+}
+
+/**
+ * Bonds whose measured length differs from the covalent radii estimate by more
+ * than ~1.5%, plus the common organic bonds, which are pinned so that editing
+ * a hydrocarbon reproduces textbook geometry exactly.
+ *
+ * Single and multiple bond references are averages over the Cambridge
+ * Structural Database (Allen et al., J. Chem. Soc. Perkin Trans. II, 1987,
+ * S1-S19) where one exists, otherwise gas phase microwave or electron
+ * diffraction values for the parent molecule (CRC Handbook, 97th ed.).
+ *
+ * Sorted by (atomicNumber1, atomicNumber2, order); keep it that way.
+ */
+const IdealBondLength ideal_bond_lengths[] = {
+  { 1, 1, 1, 0.741 },  // H-H   H2 (radii: 0.640)
+  { 1, 5, 1, 1.190 },  // H-B   B2H6 terminal (radii: 1.170)
+  { 1, 6, 1, 1.090 },  // H-C   CH4 / CSD sp3 (radii: 1.070)
+  { 1, 7, 1, 1.012 },  // H-N   NH3 (radii: 1.030)
+  { 1, 8, 1, 0.958 },  // H-O   H2O (radii: 0.950)
+  { 1, 9, 1, 0.917 },  // H-F   HF (radii: 0.960)
+  { 1, 16, 1, 1.341 }, // H-S   H2S (radii: 1.350)
+  { 1, 17, 1, 1.275 }, // H-Cl  HCl (radii: 1.310)
+  { 1, 35, 1, 1.414 }, // H-Br  HBr (radii: 1.460)
+  { 1, 53, 1, 1.609 }, // H-I   HI (radii: 1.650)
+
+  { 5, 5, 1, 1.750 },  // B-B   B2Cl4 (radii: 1.700)
+  { 5, 8, 1, 1.370 },  // B-O   borates (radii: 1.480)
+  { 5, 9, 1, 1.307 },  // B-F   BF3 (radii: 1.490)
+  { 5, 17, 1, 1.742 }, // B-Cl  BCl3 (radii: 1.840)
+
+  { 6, 6, 1, 1.540 },  // C-C   ethane 1.535 / diamond 1.544 (radii: 1.500)
+  { 6, 6, 2, 1.331 },  // C=C   CSD alkene (radii: 1.312)
+  { 6, 6, 3, 1.200 },  // C#C   acetylene 1.203 / CSD 1.181 (radii: 1.185)
+  { 6, 7, 1, 1.469 },  // C-N   CSD sp3 (radii: 1.460)
+  { 6, 7, 2, 1.279 },  // C=N   CSD imine (radii: 1.277)
+  { 6, 7, 3, 1.140 },  // C#N   nitrile (radii: 1.153)
+  { 6, 8, 1, 1.426 },  // C-O   CSD sp3 (radii: 1.380)
+  { 6, 8, 2, 1.220 },  // C=O   CSD ketone (radii: 1.208)
+  { 6, 8, 3, 1.128 },  // C#O   CO (radii: 1.090)
+  { 6, 14, 1, 1.863 }, // C-Si  CSD (radii: 1.910)
+  { 6, 16, 1, 1.819 }, // C-S   CSD sp3 (radii: 1.780)
+  { 6, 16, 2, 1.650 }, // C=S   CSD thioketone (radii: 1.594)
+  { 6, 17, 1, 1.790 }, // C-Cl  CSD sp3 (radii: 1.740)
+  { 6, 34, 1, 1.970 }, // C-Se  CSD (radii: 1.910)
+  { 6, 34, 2, 1.770 }, // C=Se  selenoketone (radii: 1.735)
+  { 6, 35, 1, 1.966 }, // C-Br  CSD sp3 (radii: 1.890)
+  { 6, 53, 1, 2.162 }, // C-I   CSD sp3 (radii: 2.080)
+
+  { 7, 7, 1, 1.449 },  // N-N   hydrazine (radii: 1.420)
+  { 7, 7, 2, 1.240 },  // N=N   CSD azo (radii: 1.242)
+  { 7, 7, 3, 1.098 },  // N#N   N2 (radii: 1.122)
+  { 7, 8, 1, 1.440 },  // N-O   hydroxylamine/CSD (radii: 1.340)
+  { 7, 8, 2, 1.220 },  // N=O   CSD nitro/nitroso (radii: 1.172)
+  { 7, 14, 1, 1.720 }, // N-Si  CSD (radii: 1.870)
+  { 7, 15, 1, 1.650 }, // N-P   CSD (radii: 1.820)
+  { 7, 15, 2, 1.580 }, // N=P   phosphazene (radii: 1.631)
+  { 7, 16, 1, 1.700 }, // N-S   CSD (radii: 1.740)
+  { 7, 17, 1, 1.750 }, // N-Cl  NCl3 (radii: 1.700)
+
+  { 8, 8, 1, 1.475 },  // O-O   H2O2 (radii: 1.260)
+  { 8, 8, 2, 1.208 },  // O=O   O2 (radii: 1.103)
+  { 8, 9, 1, 1.420 },  // O-F   OF2 1.405 (radii: 1.270)
+  { 8, 14, 1, 1.630 }, // O-Si  silicates (radii: 1.790)
+  { 8, 15, 1, 1.600 }, // O-P   P-OH (radii: 1.740)
+  { 8, 15, 2, 1.480 }, // O=P   phosphine oxide (radii: 1.561)
+  { 8, 16, 1, 1.570 }, // O-S   S-OH (radii: 1.660)
+  { 8, 16, 2, 1.440 }, // O=S   sulfone (radii: 1.489)
+  { 8, 17, 1, 1.690 }, // O-Cl  HOCl (radii: 1.620)
+  { 8, 17, 2, 1.430 }, // O=Cl  perchlorate 1.44 (radii: 1.452)
+
+  { 9, 9, 1, 1.412 },  // F-F   F2 (radii: 1.280)
+  { 9, 14, 1, 1.570 }, // F-Si  SiF4 1.554 (radii: 1.800)
+  { 9, 15, 1, 1.570 }, // F-P   PF3 (radii: 1.750)
+  { 9, 16, 1, 1.564 }, // F-S   SF6 (radii: 1.670)
+
+  { 14, 14, 2, 2.160 }, // Si=Si disilene (radii: 2.111)
+  { 14, 17, 1, 2.019 }, // Si-Cl SiCl4 (radii: 2.150)
+
+  { 15, 17, 1, 2.043 }, // P-Cl  PCl3 (radii: 2.100)
+};
+
+/** @return the period (row) of the periodic table @a atomicNumber sits in. */
+unsigned char elementPeriod(unsigned char atomicNumber)
+{
+  if (atomicNumber <= 2)
+    return 1;
+  if (atomicNumber <= 10)
+    return 2;
+  if (atomicNumber <= 18)
+    return 3;
+  if (atomicNumber <= 36)
+    return 4;
+  if (atomicNumber <= 54)
+    return 5;
+  if (atomicNumber <= 86)
+    return 6;
+  return 7;
+}
+
+/**
+ * @return the fraction of its single bond covalent radius that @a atomicNumber
+ * contributes to a bond of order @a order.
+ *
+ * Multiple bond contraction weakens going down a group, so no single factor
+ * fits both rows: C=C needs 0.89 while Si=Si needs 0.93. These are a
+ * least-squares fit, per period, to the measured lengths above.
+ */
+double multipleBondScale(unsigned char atomicNumber, unsigned char order)
+{
+  if (order < 2)
+    return 1.0;
+
+  const unsigned char period = elementPeriod(atomicNumber);
+  if (order == 2) {
+    if (period <= 2)
+      return 0.875;
+    return (period == 3) ? 0.910 : 0.930;
+  }
+  if (period <= 2)
+    return 0.790;
+  return (period == 3) ? 0.845 : 0.870;
+}
+
+} // namespace
+
+Real AtomUtilities::idealBondLength(unsigned char atomicNumber1,
+                                    unsigned char atomicNumber2,
+                                    unsigned char bondOrder)
+{
+  // Aromatic, dative and other orders outside 1-3 have no contraction to
+  // apply, so fall back to the single bond length.
+  if (bondOrder < 1 || bondOrder > 3)
+    bondOrder = 1;
+
+  // The table only stores each pair once, in ascending atomic number. Order
+  // the pair once here so the result cannot depend on which way round the
+  // caller passed the two atoms.
+  const unsigned char lighter = std::min(atomicNumber1, atomicNumber2);
+  const unsigned char heavier = std::max(atomicNumber1, atomicNumber2);
+
+  const unsigned int key = bondKey(lighter, heavier, bondOrder);
+
+  const IdealBondLength* begin = std::begin(ideal_bond_lengths);
+  const IdealBondLength* end = std::end(ideal_bond_lengths);
+  const IdealBondLength* match = std::lower_bound(
+    begin, end, key, [](const IdealBondLength& bond, unsigned int value) {
+      return bondKey(bond.atomicNumber1, bond.atomicNumber2, bond.order) <
+             value;
+    });
+
+  if (match != end &&
+      bondKey(match->atomicNumber1, match->atomicNumber2, match->order) == key)
+    return match->length;
+
+  // Otherwise sum the covalent radii, contracted for double and triple bonds.
+  return Elements::radiusCovalent(lighter) *
+           multipleBondScale(lighter, bondOrder) +
+         Elements::radiusCovalent(heavier) *
+           multipleBondScale(heavier, bondOrder);
 }
 
 } // namespace Avogadro::Core

--- a/avogadro/core/atomutilities.h
+++ b/avogadro/core/atomutilities.h
@@ -33,6 +33,24 @@ public:
     const Atom& atom, const std::vector<Vector3>& currentVectors,
     AtomHybridization hybridization);
 
+  /**
+   * @return the ideal length in Angstroms of a bond of order @a bondOrder
+   * between elements @a atomicNumber1 and @a atomicNumber2.
+   *
+   * The default is the sum of the Pyykko covalent radii, scaled down for
+   * double and triple bonds. That estimate is within a few percent for most
+   * element pairs, but it is systematically wrong for strongly polar bonds
+   * (Si-F, B-F, P-O) and for bonds between lone-pair rich atoms (O-O, F-F),
+   * so a table of measured lengths overrides it for common bonds.
+   *
+   * Intended for building and editing geometries, not for structure
+   * validation: the returned value is a single representative length and
+   * ignores hybridization, formal charge, and neighboring substituents.
+   */
+  static Real idealBondLength(unsigned char atomicNumber1,
+                              unsigned char atomicNumber2,
+                              unsigned char bondOrder = 1);
+
 private:
   AtomUtilities();  // Not implemented
   ~AtomUtilities(); // Not implemented

--- a/avogadro/qtgui/hydrogentools.cpp
+++ b/avogadro/qtgui/hydrogentools.cpp
@@ -64,10 +64,8 @@ inline unsigned int lookupValency(const RWAtom& atom,
 
 inline float hydrogenBondDistance(unsigned char otherAtomicNumber)
 {
-  static double hCovRadius(Avogadro::Core::Elements::radiusCovalent(1));
-  double covRadius =
-    Avogadro::Core::Elements::radiusCovalent(otherAtomicNumber);
-  return static_cast<float>(hCovRadius + covRadius);
+  return static_cast<float>(Avogadro::Core::AtomUtilities::idealBondLength(
+    Avogadro::Core::Hydrogen, otherAtomicNumber));
 }
 
 } // namespace

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -8,6 +8,7 @@
 #include "editortoolwidget.h"
 
 #include <avogadro/core/atom.h>
+#include <avogadro/core/atomutilities.h>
 #include <avogadro/core/bond.h>
 #include <avogadro/core/contrastcolor.h>
 #include <avogadro/core/elements.h>
@@ -41,6 +42,7 @@
 
 #include <QDebug>
 
+#include <cmath>
 #include <limits>
 
 namespace {
@@ -396,15 +398,8 @@ void Editor::atomLeftClick(QMouseEvent* e)
       if (bond.isValid()) {
         RWAtom atom2 = bond.getOtherAtom(atom);
 
-        m_bondDistance = Elements::radiusCovalent(atomicNumber) +
-                         Elements::radiusCovalent(atom2.atomicNumber());
-
-        // tweak the bond distance if we have a double or triple bond
-        if (bond.order() == 2) {
-          m_bondDistance *= 0.87; // e.g. C=C vs C-C
-        } else if (bond.order() == 3) {
-          m_bondDistance *= 0.78; // e.g. C#C vs C-C
-        }
+        m_bondDistance = Core::AtomUtilities::idealBondLength(
+          atomicNumber, atom2.atomicNumber(), bond.order());
 
         Vector3 bondVector = atom.position3d() - atom2.position3d();
         bondVector.normalize();
@@ -438,15 +433,8 @@ void Editor::bondLeftClick(QMouseEvent* e)
   RWAtom atom2 = bond.atom2();
 
   // Estimate the adjusted bond length
-  Real distance = Elements::radiusCovalent(atom1.atomicNumber()) +
-                  Elements::radiusCovalent(atom2.atomicNumber());
-
-  // tweak the bond distance if we have a double or triple bond
-  if (bond.order() == 2) {
-    distance *= 0.87; // e.g. C=C vs C-C
-  } else if (bond.order() == 3) {
-    distance *= 0.78; // e.g. C#C vs C-C
-  }
+  Real distance = Core::AtomUtilities::idealBondLength(
+    atom1.atomicNumber(), atom2.atomicNumber(), bond.order());
 
   // check if at least one of the atoms either has only one bond
   // or all the other bonds are hydrogens
@@ -579,20 +567,22 @@ void Editor::bondRightClick(QMouseEvent* e)
 
 int expectedBondOrder(RWAtom atom1, RWAtom atom2)
 {
-  Vector3 bondVector = atom1.position3d() - atom2.position3d();
-  double bondDistance = bondVector.norm();
-  double radiiSum;
-  radiiSum = Elements::radiusCovalent(atom1.atomicNumber()) +
-             Elements::radiusCovalent(atom2.atomicNumber());
-  double ratio = bondDistance / radiiSum;
+  double bondDistance = (atom1.position3d() - atom2.position3d()).norm();
 
-  int bondOrder;
-  if (ratio > 1.0)
-    bondOrder = 1;
-  else if (ratio > 0.91 && ratio < 1.0)
-    bondOrder = 2;
-  else
-    bondOrder = 3;
+  // Pick the order whose ideal length is closest to the distance drawn, so the
+  // cutoffs sit midway between the single, double and triple lengths for this
+  // particular element pair.
+  int bondOrder = 1;
+  double closest = -1.0;
+  for (unsigned char order = 1; order <= 3; ++order) {
+    double difference = std::fabs(
+      bondDistance - Core::AtomUtilities::idealBondLength(
+                       atom1.atomicNumber(), atom2.atomicNumber(), order));
+    if (closest < 0.0 || difference < closest) {
+      closest = difference;
+      bondOrder = order;
+    }
+  }
 
   return bondOrder;
 }

--- a/avogadro/qtplugins/templatetool/templatetool.cpp
+++ b/avogadro/qtplugins/templatetool/templatetool.cpp
@@ -9,6 +9,7 @@
 #include "templatetoolwidget.h"
 
 #include <avogadro/core/atom.h>
+#include <avogadro/core/atomutilities.h>
 #include <avogadro/core/bond.h>
 #include <avogadro/core/elements.h>
 #include <avogadro/core/molecule.h>
@@ -792,10 +793,8 @@ void TemplateTool::atomLeftClick(QMouseEvent*)
         unsigned char ligandAtomicNumber =
           templateMolecule.atomicNumber(templateLigandIndices[i]);
         ligandAtomicNumber = (ligandAtomicNumber == 0) ? 6 : ligandAtomicNumber;
-        // Estimate as the sum of covalent radii
-        double bondDistance = Elements::radiusCovalent(ligandAtomicNumber) +
-                              Elements::radiusCovalent(
-                                m_molecule->atomicNumber(moleculeCenterIndex));
+        double bondDistance = Core::AtomUtilities::idealBondLength(
+          ligandAtomicNumber, m_molecule->atomicNumber(moleculeCenterIndex));
         Vector3 inVector =
           templateMolecule.atomPosition3d(templateDummyIndex) -
           templateMolecule.atomPosition3d(templateLigandIndices[i]);
@@ -980,8 +979,8 @@ void TemplateTool::atomLeftClickCenter(QMouseEvent* e)
 
   // Place the new metal at a reasonable bond distance from the anchor,
   // keeping the original H direction so the geometry doesn't jump.
-  double bondDist = Elements::radiusCovalent(newAtomic) +
-                    Elements::radiusCovalent(anchorAtomic);
+  double bondDist =
+    Core::AtomUtilities::idealBondLength(newAtomic, anchorAtomic);
   Vector3 hDir = hPos - anchorPos;
   if (hDir.norm() < 1e-9)
     hDir = Vector3(1.0, 0.0, 0.0);

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests
   Array
   Atom
   AtomTyper
+  AtomUtilities
   BasisSet
   Bond
   CoordinateBlockGenerator

--- a/tests/core/atomutilitiestest.cpp
+++ b/tests/core/atomutilitiestest.cpp
@@ -1,0 +1,124 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/atom.h>
+#include <avogadro/core/atomutilities.h>
+#include <avogadro/core/elements.h>
+
+using Avogadro::Core::AtomUtilities;
+using Avogadro::Core::Elements;
+
+namespace {
+// The table is quoted to three decimals, so match to within half of the last
+// digit rather than exactly.
+const double tol = 0.0005;
+} // namespace
+
+TEST(AtomUtilitiesTest, idealBondLengthCommonOrganic)
+{
+  // The bonds users draw constantly should reproduce textbook geometry, not
+  // the sum of covalent radii (which gives 1.500 and 1.070 for the first two).
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 6, 1), 1.540, tol); // C-C
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 1, 1), 1.090, tol); // C-H
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 7, 1), 1.469, tol); // C-N
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 8, 1), 1.426, tol); // C-O
+  EXPECT_NEAR(AtomUtilities::idealBondLength(7, 1, 1), 1.012, tol); // N-H
+  EXPECT_NEAR(AtomUtilities::idealBondLength(8, 1, 1), 0.958, tol); // O-H
+
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 6, 2), 1.331, tol); // C=C
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 8, 2), 1.220, tol); // C=O
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 7, 2), 1.279, tol); // C=N
+
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 6, 3), 1.200, tol); // C#C
+  EXPECT_NEAR(AtomUtilities::idealBondLength(6, 7, 3), 1.140, tol); // C#N
+}
+
+TEST(AtomUtilitiesTest, idealBondLengthPolarAndLonePairBonds)
+{
+  // The cases the covalent radii sum gets worst: strongly polar bonds are much
+  // shorter than the sum, lone-pair rich bonds much longer.
+  EXPECT_NEAR(AtomUtilities::idealBondLength(14, 9, 1), 1.570, tol); // Si-F
+  EXPECT_NEAR(AtomUtilities::idealBondLength(5, 9, 1), 1.307, tol);  // B-F
+  EXPECT_NEAR(AtomUtilities::idealBondLength(15, 9, 1), 1.570, tol); // P-F
+  EXPECT_NEAR(AtomUtilities::idealBondLength(8, 14, 1), 1.630, tol); // O-Si
+
+  EXPECT_NEAR(AtomUtilities::idealBondLength(8, 8, 1), 1.475, tol); // O-O
+  EXPECT_NEAR(AtomUtilities::idealBondLength(9, 9, 1), 1.412, tol); // F-F
+  EXPECT_NEAR(AtomUtilities::idealBondLength(1, 1, 1), 0.741, tol); // H-H
+  EXPECT_NEAR(AtomUtilities::idealBondLength(7, 8, 1), 1.440, tol); // N-O
+}
+
+TEST(AtomUtilitiesTest, idealBondLengthFallsBackToCovalentRadii)
+{
+  // An untabulated single bond is exactly the sum of the covalent radii.
+  for (auto pair : { std::make_pair(6, 5), std::make_pair(16, 17),
+                     std::make_pair(26, 8), std::make_pair(92, 17) }) {
+    EXPECT_NEAR(AtomUtilities::idealBondLength(pair.first, pair.second, 1),
+                Elements::radiusCovalent(pair.first) +
+                  Elements::radiusCovalent(pair.second),
+                1e-9);
+  }
+}
+
+TEST(AtomUtilitiesTest, idealBondLengthMultipleBondsContract)
+{
+  // Multiple bonds are shorter than single bonds, for tabulated pairs and for
+  // pairs that fall through to the covalent radii.
+  for (auto pair : { std::make_pair(6, 6), std::make_pair(7, 7),
+                     std::make_pair(16, 16), std::make_pair(26, 8) }) {
+    const double single =
+      AtomUtilities::idealBondLength(pair.first, pair.second, 1);
+    const double dbl =
+      AtomUtilities::idealBondLength(pair.first, pair.second, 2);
+    const double triple =
+      AtomUtilities::idealBondLength(pair.first, pair.second, 3);
+    EXPECT_LT(dbl, single);
+    EXPECT_LT(triple, dbl);
+  }
+
+  // Contraction is weaker for heavier elements, so a single scale factor
+  // cannot fit both rows: Si=Si must not shrink as much as C=C.
+  const double cRatio = AtomUtilities::idealBondLength(6, 6, 2) /
+                        AtomUtilities::idealBondLength(6, 6, 1);
+  const double siRatio = AtomUtilities::idealBondLength(14, 14, 2) /
+                         AtomUtilities::idealBondLength(14, 14, 1);
+  EXPECT_GT(siRatio, cRatio);
+}
+
+TEST(AtomUtilitiesTest, idealBondLengthArgumentOrderAndBadOrders)
+{
+  // Swapping the two atoms must give a bit-identical answer.
+  for (unsigned char z1 = 1; z1 < 40; ++z1) {
+    for (unsigned char z2 = 1; z2 < 40; ++z2) {
+      for (unsigned char order = 1; order <= 3; ++order) {
+        EXPECT_DOUBLE_EQ(AtomUtilities::idealBondLength(z1, z2, order),
+                         AtomUtilities::idealBondLength(z2, z1, order));
+      }
+    }
+  }
+
+  // Orders outside 1-3 (aromatic, dative, unset) fall back to a single bond.
+  const double single = AtomUtilities::idealBondLength(6, 6, 1);
+  EXPECT_DOUBLE_EQ(AtomUtilities::idealBondLength(6, 6, 0), single);
+  EXPECT_DOUBLE_EQ(AtomUtilities::idealBondLength(6, 6, 4), single);
+  EXPECT_DOUBLE_EQ(AtomUtilities::idealBondLength(6, 6, 255), single);
+}
+
+TEST(AtomUtilitiesTest, idealBondLengthHandlesEveryElement)
+{
+  // Nothing in range may return a non-positive or absurd length, and the
+  // lookup must stay in bounds for custom/invalid atomic numbers.
+  for (unsigned int z1 = 1; z1 < 119; ++z1) {
+    for (unsigned int z2 = 1; z2 < 119; ++z2) {
+      const double length = AtomUtilities::idealBondLength(
+        static_cast<unsigned char>(z1), static_cast<unsigned char>(z2), 1);
+      EXPECT_GT(length, 0.0);
+      EXPECT_LT(length, 6.0);
+    }
+  }
+  EXPECT_GT(AtomUtilities::idealBondLength(255, 6, 1), 0.0);
+}


### PR DESCRIPTION
- Checked through a range of common CSD bond lengths
- Fixed up C-C and C-H, etc.
- Adjusted double and triple bond ratios for 3rd period

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ideal bond-length calculations using measured values and element-specific covalent radii.
  - Improved bond-length estimates for hydrogen bonds and metal–ligand bonds.
- **Improvements**
  - Bond creation and editing now use more accurate distances when changing elements or bond orders.
  - Automatic bond-order detection now selects the bond order that best matches the measured distance.
- **Tests**
  - Added comprehensive validation for common, multiple, polar, and unsupported bond combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->