### PR TITLE
Fix a bug when dragging a window to a new monitor

### DIFF
--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -20,7 +20,6 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
-#include <QtGui/QWindow>
 #include <QtWidgets/QApplication>
 
 namespace Avogadro::QtOpenGL {
@@ -234,13 +233,22 @@ void GLWidget::initializeGL()
 
 void GLWidget::resizeGL(int width_, int height_)
 {
-  float pixelRatio = window()->windowHandle()->devicePixelRatio();
-  m_renderer.setPixelRatio(pixelRatio);
+  // Qt hands us the widget size in logical pixels.
+  m_pixelRatio = static_cast<float>(devicePixelRatioF());
+  m_renderer.setPixelRatio(m_pixelRatio);
   m_renderer.resize(width_, height_);
 }
 
 void GLWidget::paintGL()
 {
+  // Moving the window to a screen with a different scale factor changes the
+  // device pixel ratio without changing the widget size in logical pixels, so
+  // resizeGL() is not necessarily called. Resize here to keep the offscreen
+  // buffers in step with the framebuffer Qt has recreated for the new screen.
+  auto pixelRatio = static_cast<float>(devicePixelRatioF());
+  if (pixelRatio != m_pixelRatio)
+    resizeGL(width(), height());
+
   m_renderer.render();
 }
 

--- a/avogadro/qtopengl/glwidget.h
+++ b/avogadro/qtopengl/glwidget.h
@@ -201,6 +201,7 @@ private:
   QtGui::ToolPlugin* m_activeTool;
   QtGui::ToolPlugin* m_defaultTool;
   Rendering::GLRenderer m_renderer;
+  float m_pixelRatio = 0.0f;
   QtGui::ScenePluginModel m_scenePlugins;
 
   QTimer* m_renderTimer;

--- a/avogadro/rendering/glrenderer.cpp
+++ b/avogadro/rendering/glrenderer.cpp
@@ -25,8 +25,8 @@ namespace Avogadro::Rendering {
 using Core::Array;
 
 GLRenderer::GLRenderer()
-  : m_valid(false), m_textRenderStrategy(nullptr), m_center(Vector3f::Zero()),
-    m_radius(20.0)
+  : m_valid(false), m_pixelRatio(1.0f), m_textRenderStrategy(nullptr),
+    m_center(Vector3f::Zero()), m_radius(20.0)
 #ifdef _3DCONNEXION
     ,
     m_drawIcon(false), m_iconData(nullptr), m_iconWidth(0u), m_iconHeight(0u),
@@ -76,7 +76,10 @@ void GLRenderer::resize(int width, int height)
     return;
 
   // m_volume.resize(width, height);
-  glViewport(0, 0, static_cast<GLint>(width), static_cast<GLint>(height));
+  // The viewport is in device pixels, while the cameras work in logical pixels
+  // as they are used to project and unproject Qt mouse coordinates.
+  glViewport(0, 0, static_cast<GLsizei>(width * m_pixelRatio),
+             static_cast<GLsizei>(height * m_pixelRatio));
   m_camera.setViewport(width, height);
   m_overlayCamera.setViewport(width, height);
   m_solidPipeline.resize(width, height);
@@ -84,6 +87,7 @@ void GLRenderer::resize(int width, int height)
 
 void GLRenderer::setPixelRatio(float ratio)
 {
+  m_pixelRatio = ratio;
   m_solidPipeline.setPixelRatio(ratio);
 }
 

--- a/avogadro/rendering/glrenderer.h
+++ b/avogadro/rendering/glrenderer.h
@@ -101,7 +101,6 @@ public:
   const SolidPipeline& solidPipeline() const { return m_solidPipeline; }
   SolidPipeline& solidPipeline() { return m_solidPipeline; }
 
-
   const VolumeGeometry& volume() const { return m_volume; }
   VolumeGeometry& volume() { return m_volume; }
   /**
@@ -149,6 +148,7 @@ private:
                                const Frustrum& frustrum) const;
 
   bool m_valid;
+  float m_pixelRatio;
   std::string m_error;
   Camera m_camera;
   Camera m_overlayCamera;

--- a/avogadro/rendering/solidpipeline.cpp
+++ b/avogadro/rendering/solidpipeline.cpp
@@ -47,6 +47,7 @@ public:
   }
 
   GLuint defaultFBO;
+  GLint defaultViewport[4] = { 0, 0, 0, 0 };
   GLuint renderFBO;
   GLuint renderTexture;
   GLuint depthTexture;
@@ -138,9 +139,17 @@ void SolidPipeline::initialize()
 void SolidPipeline::begin()
 {
   glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&d->defaultFBO);
+  glGetIntegerv(GL_VIEWPORT, d->defaultViewport);
   glBindFramebuffer(GL_FRAMEBUFFER, d->renderFBO);
   GLenum drawBuffersList[1] = { GL_COLOR_ATTACHMENT0 };
   glDrawBuffers(1, drawBuffersList);
+
+  // The offscreen buffers are sized independently of the default framebuffer,
+  // so the viewport must be set to match them rather than inherited. They can
+  // disagree whenever the device pixel ratio changes without a resize, such as
+  // when the window is dragged to a monitor with a different scale factor.
+  glViewport(0, 0, static_cast<GLsizei>(m_width),
+             static_cast<GLsizei>(m_height));
 
   GLfloat tmp[5];
   glGetFloatv(GL_COLOR_CLEAR_VALUE, tmp);
@@ -165,6 +174,8 @@ void SolidPipeline::end()
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDrawBuffer(GL_BACK);
   }
+  glViewport(d->defaultViewport[0], d->defaultViewport[1],
+             d->defaultViewport[2], d->defaultViewport[3]);
   d->attachStage(d->firstStageShaders, "inRGBTex", d->renderTexture,
                  "inDepthTex", d->depthTexture, m_width, m_height);
   d->firstStageShaders.setUniformValue("inAoEnabled",


### PR DESCRIPTION
Resolution changes and the viewport doesn't update Thanks to Wes Transue for the bug report
Credit to Claude Opus 5.0 for the OpenGL / Qt analysis

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering on high-DPI displays by correctly accounting for device pixel ratios.
  * Fixed viewport handling when resizing the application or moving its window between screens.
  * Improved offscreen rendering stability by preserving and restoring the display viewport correctly.
* **Compatibility**
  * Cameras continue using logical dimensions while rendering is scaled appropriately to physical display pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->