### PR TITLE
Fix potential crash from uninitialized OB member variables

### DIFF
--- a/avogadro/qtplugins/forcefield/obenergy.cpp
+++ b/avogadro/qtplugins/forcefield/obenergy.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QDir>
 
+#include <iostream>
 #include <memory>
 
 using namespace OpenBabel;
@@ -55,7 +56,17 @@ public:
       return false;
 
     m_forceField.reset(plugin->MakeNewInstance());
-    return m_forceField != nullptr;
+    if (m_forceField == nullptr)
+      return false;
+
+    // OBForceField leaves _loglvl and _logos uninitialized: no constructor
+    // sets them, and the plugin singleton only escaped that because static
+    // storage zeroed it. A heap clone gets whatever the allocator hands back,
+    // so a garbage _loglvl enables logging and a garbage _logos is then
+    // dereferenced (OBFFLog only checks it against null). Pin both.
+    m_forceField->SetLogLevel(OBFF_LOGLVL_NONE);
+    m_forceField->SetLogFile(&std::clog);
+    return true;
   }
 };
 


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
