### PR TITLE
Add shared camera controls for all tools / modes

### DIFF
--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -16,6 +16,7 @@
 #include <avogadro/rendering/camera.h>
 
 #include <QAction>
+#include <QtCore/QSettings>
 #include <QtCore/QTimer>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
@@ -34,6 +35,12 @@ GLWidget::GLWidget(QWidget* p)
   connect(&m_scenePlugins, &QtGui::ScenePluginModel::pluginConfigChanged, this,
           &GLWidget::updateScene);
   m_renderer.setTextRenderStrategy(new QtTextRenderStrategy);
+
+  QSettings settings;
+  m_navigationModifier = static_cast<Qt::KeyboardModifiers>(
+    settings
+      .value("glwidget/navigationModifier", static_cast<int>(Qt::AltModifier))
+      .toInt());
 }
 
 GLWidget::~GLWidget() {}
@@ -252,6 +259,44 @@ void GLWidget::paintGL()
   m_renderer.render();
 }
 
+Qt::KeyboardModifiers GLWidget::navigationModifier() const
+{
+  return m_navigationModifier;
+}
+
+void GLWidget::setNavigationModifier(Qt::KeyboardModifiers modifier)
+{
+  m_navigationModifier = modifier;
+  QSettings settings;
+  settings.setValue("glwidget/navigationModifier", static_cast<int>(modifier));
+}
+
+bool GLWidget::isNavigationMouseGesture(const QMouseEvent* event) const
+{
+  return m_defaultTool != nullptr && m_navigationModifier != Qt::NoModifier &&
+         (event->modifiers() & m_navigationModifier);
+}
+
+bool GLWidget::isNavigationKeyGesture(const QKeyEvent* event) const
+{
+  if (m_defaultTool == nullptr)
+    return false;
+
+  Qt::KeyboardModifiers mods = event->modifiers();
+  if (!(mods & Qt::ControlModifier) || (mods & Qt::ShiftModifier))
+    return false;
+
+  switch (event->key()) {
+    case Qt::Key_Left:
+    case Qt::Key_Right:
+    case Qt::Key_Up:
+    case Qt::Key_Down:
+      return true;
+    default:
+      return false;
+  }
+}
+
 void GLWidget::mouseDoubleClickEvent(QMouseEvent* e)
 {
   e->ignore();
@@ -270,7 +315,12 @@ void GLWidget::mousePressEvent(QMouseEvent* e)
 {
   e->ignore();
 
-  if (m_activeTool)
+  // Latch the navigation gesture for the duration of the drag: once a press
+  // starts the camera navigating, keep it there through move and release
+  // even if the user releases the modifier key mid-drag.
+  m_navigationDrag = isNavigationMouseGesture(e);
+
+  if (m_activeTool && !m_navigationDrag)
     m_activeTool->mousePressEvent(e);
 
   if (m_defaultTool && !e->isAccepted())
@@ -284,7 +334,7 @@ void GLWidget::mouseMoveEvent(QMouseEvent* e)
 {
   e->ignore();
 
-  if (m_activeTool)
+  if (m_activeTool && !m_navigationDrag)
     m_activeTool->mouseMoveEvent(e);
 
   if (m_defaultTool && !e->isAccepted())
@@ -298,7 +348,7 @@ void GLWidget::mouseReleaseEvent(QMouseEvent* e)
 {
   e->ignore();
 
-  if (m_activeTool)
+  if (m_activeTool && !m_navigationDrag)
     m_activeTool->mouseReleaseEvent(e);
 
   if (m_defaultTool && !e->isAccepted())
@@ -306,6 +356,10 @@ void GLWidget::mouseReleaseEvent(QMouseEvent* e)
 
   if (!e->isAccepted())
     QOpenGLWidget::mouseReleaseEvent(e);
+
+  // Release the latch now that the drag sequence this press started has
+  // finished being dispatched.
+  m_navigationDrag = false;
 }
 
 void GLWidget::wheelEvent(QWheelEvent* e)
@@ -326,7 +380,7 @@ void GLWidget::keyPressEvent(QKeyEvent* e)
 {
   e->ignore();
 
-  if (m_activeTool)
+  if (m_activeTool && !isNavigationKeyGesture(e))
     m_activeTool->keyPressEvent(e);
 
   if (m_defaultTool && !e->isAccepted())
@@ -340,7 +394,7 @@ void GLWidget::keyReleaseEvent(QKeyEvent* e)
 {
   e->ignore();
 
-  if (m_activeTool)
+  if (m_activeTool && !isNavigationKeyGesture(e))
     m_activeTool->keyReleaseEvent(e);
 
   if (m_defaultTool && !e->isAccepted())

--- a/avogadro/qtopengl/glwidget.cpp
+++ b/avogadro/qtopengl/glwidget.cpp
@@ -273,8 +273,11 @@ void GLWidget::setNavigationModifier(Qt::KeyboardModifiers modifier)
 
 bool GLWidget::isNavigationMouseGesture(const QMouseEvent* event) const
 {
+  // Compare the whole mask: m_navigationModifier may hold a combination, and a
+  // bare bitwise and would match when only one of the configured modifiers is
+  // held.
   return m_defaultTool != nullptr && m_navigationModifier != Qt::NoModifier &&
-         (event->modifiers() & m_navigationModifier);
+         (event->modifiers() & m_navigationModifier) == m_navigationModifier;
 }
 
 bool GLWidget::isNavigationKeyGesture(const QKeyEvent* event) const

--- a/avogadro/qtopengl/glwidget.h
+++ b/avogadro/qtopengl/glwidget.h
@@ -106,6 +106,16 @@ public:
    */
   QString error() const { return m_renderer.error().c_str(); }
 
+  /**
+   * @brief Modifier reserved for camera navigation.
+   *
+   * A mouse gesture carrying this modifier is routed to the default
+   * (navigation) tool regardless of which tool is currently active.
+   * Defaults to Qt::AltModifier and is persisted in QSettings.
+   */
+  Qt::KeyboardModifiers navigationModifier() const;
+  void setNavigationModifier(Qt::KeyboardModifiers modifier);
+
 signals:
   void rendererInvalid();
 
@@ -196,6 +206,9 @@ protected:
   /** @} */
 
 private:
+  bool isNavigationMouseGesture(const QMouseEvent* event) const;
+  bool isNavigationKeyGesture(const QKeyEvent* event) const;
+
   QPointer<QtGui::Molecule> m_molecule;
   QList<QtGui::ToolPlugin*> m_tools;
   QtGui::ToolPlugin* m_activeTool;
@@ -205,6 +218,9 @@ private:
   QtGui::ScenePluginModel m_scenePlugins;
 
   QTimer* m_renderTimer;
+
+  Qt::KeyboardModifiers m_navigationModifier;
+  bool m_navigationDrag = false;
 };
 
 } // namespace QtOpenGL

--- a/avogadro/qtplugins/editor/editor.cpp
+++ b/avogadro/qtplugins/editor/editor.cpp
@@ -35,6 +35,7 @@
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
+#include <QtWidgets/QApplication>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QWidget>
 
@@ -137,20 +138,12 @@ QUndoCommand* Editor::mousePressEvent(QMouseEvent* e)
         return nullptr;
     }
   } else if (m_pressedButtons & Qt::RightButton) {
+    // Just record what was hit. The actual deletion is deferred to
+    // mouseReleaseEvent() so that a right-drag can be told apart from a
+    // right-click: a drag is reserved for camera navigation, so the event
+    // must stay ignored here to let the default Navigator tool see the
+    // press and start panning.
     m_clickedObject = m_renderer->hit(e->pos().x(), e->pos().y());
-
-    switch (m_clickedObject.type) {
-      case Rendering::AtomType:
-        m_molecule->beginMergeMode(tr("Remove Atom"));
-        atomRightClick(e);
-        return nullptr;
-      case Rendering::BondType:
-        m_molecule->beginMergeMode(tr("Remove Bond"));
-        bondRightClick(e);
-        return nullptr;
-      default:
-        break;
-    }
   }
 
   return nullptr;
@@ -171,7 +164,6 @@ QUndoCommand* Editor::mouseReleaseEvent(QMouseEvent* e)
 
   switch (e->button()) {
     case Qt::LeftButton:
-    case Qt::RightButton:
       reset();
       e->accept();
       m_molecule->endMergeMode();
@@ -181,6 +173,40 @@ QUndoCommand* Editor::mouseReleaseEvent(QMouseEvent* e)
                               Molecule::Added | Molecule::Removed |
                               Molecule::Modified);
       break;
+    case Qt::RightButton: {
+      // Only delete on release if this was a click, not a drag: a
+      // right-drag is reserved for camera navigation, so the deletion that
+      // used to happen unconditionally on press is deferred here.
+      bool isClick = (e->pos() - m_clickPosition).manhattanLength() <
+                     QApplication::startDragDistance();
+      if (isClick) {
+        switch (m_clickedObject.type) {
+          case Rendering::AtomType:
+            m_molecule->beginMergeMode(tr("Remove Atom"));
+            atomRightClick(e);
+            m_molecule->endMergeMode();
+            break;
+          case Rendering::BondType:
+            m_molecule->beginMergeMode(tr("Remove Bond"));
+            bondRightClick(e);
+            m_molecule->endMergeMode();
+            break;
+          default:
+            break;
+        }
+        // Let's cover all possible changes - the undo stack won't update
+        // without this
+        m_molecule->emitChanged(Molecule::Atoms | Molecule::Bonds |
+                                Molecule::Added | Molecule::Removed |
+                                Molecule::Modified);
+      }
+      reset();
+      // atomRightClick()/bondRightClick() accept the event internally;
+      // ignore it again so the release still reaches the default Navigator
+      // tool, which needs to reset its own internal action state machine.
+      e->ignore();
+      break;
+    }
     default:
       break;
   }

--- a/avogadro/qtplugins/manipulator/manipulator.cpp
+++ b/avogadro/qtplugins/manipulator/manipulator.cpp
@@ -57,7 +57,7 @@ Manipulator::Manipulator(QObject* parent_)
        "Right Mouse:\tClick and drag to rotate atoms\n\n"
        "Arrow Keys:\tTranslate atoms\n"
        "Shift+Arrows:\tRotate around X/Y axes\n"
-       "Ctrl+Left/Right:\tRotate around Z axis\n"
+       "Ctrl+Shift+Left/Right:\tRotate around Z axis\n"
        "Alt+<key>:\tLarger steps")
       .arg(shortcut));
   setIcon();
@@ -192,10 +192,10 @@ QUndoCommand* Manipulator::keyPressEvent(QKeyEvent* e)
     case Qt::Key_A:
       if (mods == Qt::NoModifier || mods == Qt::KeypadModifier)
         translate(Vector3(-transStep, 0.0, 0.0), moveSelected);
+      else if ((mods & Qt::ControlModifier) && (mods & Qt::ShiftModifier))
+        axisRotate(Vector3(0.0, 0.0, -rotStep), centroid, moveSelected);
       else if (mods & Qt::ShiftModifier)
         axisRotate(Vector3(0.0, -rotStep, 0.0), centroid, moveSelected);
-      else if (mods & Qt::ControlModifier)
-        axisRotate(Vector3(0.0, 0.0, -rotStep), centroid, moveSelected);
       e->accept();
       break;
 
@@ -204,10 +204,10 @@ QUndoCommand* Manipulator::keyPressEvent(QKeyEvent* e)
     case Qt::Key_D:
       if (mods == Qt::NoModifier || mods == Qt::KeypadModifier)
         translate(Vector3(+transStep, 0.0, 0.0), moveSelected);
+      else if ((mods & Qt::ControlModifier) && (mods & Qt::ShiftModifier))
+        axisRotate(Vector3(0.0, 0.0, +rotStep), centroid, moveSelected);
       else if (mods & Qt::ShiftModifier)
         axisRotate(Vector3(0.0, +rotStep, 0.0), centroid, moveSelected);
-      else if (mods & Qt::ControlModifier)
-        axisRotate(Vector3(0.0, 0.0, +rotStep), centroid, moveSelected);
       e->accept();
       break;
 

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -32,7 +32,8 @@ namespace Avogadro::QtPlugins {
 
 const float ZOOM_SPEED = 0.02f;
 const float ROTATION_SPEED = 0.005f;
-const float TRACKBALL_SPAN = 1.0f; // XY molecule rotations when trackball crossed
+const float TRACKBALL_SPAN =
+  1.0f; // XY molecule rotations when trackball crossed
 
 Navigator::Navigator(QObject* parent_)
   : QtGui::ToolPlugin(parent_), m_activateAction(new QAction(this)),
@@ -46,7 +47,9 @@ Navigator::Navigator(QObject* parent_)
     tr("Navigation Tool\t(%1)\n\n"
        "Left Mouse:\tClick and drag to rotate the view.\n"
        "Middle Mouse:\tClick and drag to zoom in or out.\n"
-       "Right Mouse:\tClick and drag to move the view.")
+       "Right Mouse:\tClick and drag to move the view.\n\n"
+       "Alt(Option)+Drag:\tRotate/zoom/pan from within any tool.\n"
+       "Alt(Option)+Left:\tUses the virtual trackball.")
       .arg(shortcut));
   setIcon();
   QSettings settings;
@@ -168,6 +171,9 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
 {
   switch (m_currentAction) {
     case RotTrackball: {
+      if (!m_glWidget)
+        break;
+
       QPoint delta = e->pos() - m_lastMousePosition;
 
       double w = m_glWidget->width(); // double for type consistency in max
@@ -193,12 +199,10 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
       if (distSquaredCurrent <= trackballSquaredRadius) {
         // like in Rotation but speed normalized
         // undo *ROTATION_SPEED which will happen in rotate()
-        double speedCorrection = (1.0 / ROTATION_SPEED) * TRACKBALL_SPAN
-                                  * 3.14159265358979 / trackballRadius;
-        rotate(m_renderer->camera().focus(),
-               delta.y() * speedCorrection,
-               delta.x() * speedCorrection,
-               0);
+        double speedCorrection = (1.0 / ROTATION_SPEED) * TRACKBALL_SPAN *
+                                 3.14159265358979 / trackballRadius;
+        rotate(m_renderer->camera().focus(), delta.y() * speedCorrection,
+               delta.x() * speedCorrection, 0);
       } else {
         // Calculate angle between current and previous ticks
         double x1 = prevVec.x();

--- a/avogadro/qtplugins/templatetool/templatetool.cpp
+++ b/avogadro/qtplugins/templatetool/templatetool.cpp
@@ -159,15 +159,12 @@ QUndoCommand* TemplateTool::mousePressEvent(QMouseEvent* e)
         break;
     }
   } else if (m_pressedButtons & Qt::RightButton) {
+    // Just record what was hit. The actual deletion is deferred to
+    // mouseReleaseEvent() so that a right-drag can be told apart from a
+    // right-click: a drag is reserved for camera navigation, so the event
+    // must stay ignored here to let the default Navigator tool see the
+    // press and start panning.
     m_clickedObject = m_renderer->hit(e->pos().x(), e->pos().y());
-
-    switch (m_clickedObject.type) {
-      case Rendering::AtomType:
-        atomRightClick(e);
-        return nullptr;
-      default:
-        break;
-    }
   }
 
   return nullptr;
@@ -189,10 +186,24 @@ QUndoCommand* TemplateTool::mouseReleaseEvent(QMouseEvent* e)
 
   switch (e->button()) {
     case Qt::LeftButton:
-    case Qt::RightButton:
       reset();
       e->accept();
       break;
+    case Qt::RightButton: {
+      // Only delete on release if this was a click, not a drag: a
+      // right-drag is reserved for camera navigation, so the deletion that
+      // used to happen unconditionally on press is deferred here.
+      bool isClick = (e->pos() - m_clickPosition).manhattanLength() <
+                     QApplication::startDragDistance();
+      if (isClick && m_clickedObject.type == Rendering::AtomType)
+        atomRightClick(e);
+      reset();
+      // atomRightClick() accepts the event internally; ignore it again so
+      // the release still reaches the default Navigator tool, which needs
+      // to reset its own internal action state machine.
+      e->ignore();
+      break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
- Alt drag for rotate, zoom, etc.
- Control + arrows for pan

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable camera-navigation gestures, including mouse and keyboard controls.
  - Right-dragging in editing tools now supports camera navigation without accidental atom or bond deletion.
  - Right-click deletion occurs only when the pointer release qualifies as a click.
  - Added navigation guidance to the Navigator tool’s tooltip.

- **Improvements**
  - Z-axis rotation shortcuts now use Ctrl+Shift+Left/Right, avoiding conflicts with navigation controls.
  - Improved safety when navigating if the associated 3D view is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->