### PR TITLE
Add some more bullet-proof code for installing packages

### DIFF
--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -171,6 +171,33 @@ static QString findPixiExecutable()
   return pixiDir.isEmpty() ? QString() : pixiDir + '/' + pixiName;
 }
 
+bool PackageManager::hasPixiManifest(const QString& packageDir)
+{
+  if (packageDir.isEmpty())
+    return false;
+
+  // A standalone pixi.toml is a workspace in its own right.
+  if (QFileInfo::exists(packageDir + QStringLiteral("/pixi.toml")))
+    return true;
+
+  QFile tomlFile(packageDir + QStringLiteral("/pyproject.toml"));
+  if (!tomlFile.open(QIODevice::ReadOnly))
+    return false;
+  const QByteArray content = tomlFile.readAll();
+
+  bool ok = false;
+  const QVariantMap root =
+    parseTomlString(std::string_view(content.constData(), content.size()), &ok);
+  if (!ok)
+    return false;
+
+  return !root.value(QStringLiteral("tool"))
+            .toMap()
+            .value(QStringLiteral("pixi"))
+            .toMap()
+            .isEmpty();
+}
+
 QString PackageManager::pixiScriptPath(const QString& packageDir,
                                        const QString& command)
 {
@@ -439,6 +466,38 @@ static PackageCommands readScriptCommands(const QString& packageDir)
                               tomlPath);
 }
 
+// Compare two package names the way Python does (PEP 503): case-insensitively,
+// with any run of "-", "_" and "." equivalent. An exact comparison would be
+// wrong in both directions here — QSettings folds key case on Windows and
+// macOS, and a package is free to respell "avogadro_x" as "avogadro-x" without
+// becoming a different package.
+static QString normalizedPackageName(const QString& name)
+{
+  static const QRegularExpression separators(QStringLiteral("[-_.]+"));
+  return QString(name).replace(separators, QStringLiteral("-")).toLower();
+}
+
+// The [project.name] declared by the pyproject.toml in @p packageDir, or an
+// empty string if it cannot be read.
+static QString readPackageName(const QString& packageDir)
+{
+  QFile tomlFile(packageDir + QStringLiteral("/pyproject.toml"));
+  if (!tomlFile.open(QIODevice::ReadOnly))
+    return {};
+  const QByteArray content = tomlFile.readAll();
+
+  bool ok = false;
+  const QVariantMap root =
+    parseTomlString(std::string_view(content.constData(), content.size()), &ok);
+  if (!ok)
+    return {};
+
+  return root.value(QStringLiteral("project"))
+    .toMap()
+    .value(QStringLiteral("name"))
+    .toString();
+}
+
 bool PackageManager::removeSupersededVenv(const QString& packageDir,
                                           const QString& command)
 {
@@ -500,18 +559,130 @@ static void runSetupScript(const QString& packageDir, const QString& setupCmd,
   }
 }
 
+// Install @p packageDir with pixi. Returns true only if the package's command
+// can afterwards be run from its pixi environment.
+static bool installWithPixi(const QString& packageDir,
+                            const PackageCommands& commands,
+                            const QString& pixiExe, int timeoutMs)
+{
+  // Without a workspace of its own, pixi would install an ancestor's
+  // environment and report success, leaving this package unrunnable.
+  if (!PackageManager::hasPixiManifest(packageDir)) {
+    qWarning() << "PackageManager:" << packageDir
+               << "declares no pixi workspace, installing with pip instead";
+    return false;
+  }
+
+  // If a copied package includes a non-executable .pixi environment,
+  // pixi install fails querying its interpreter. Remove it and recreate.
+  const QString pixiDir = packageDir + QStringLiteral("/.pixi");
+  if (hasNonExecutablePixiPython(packageDir)) {
+    if (!QDir(pixiDir).removeRecursively()) {
+      qWarning() << "Could not remove invalid .pixi directory in" << packageDir;
+    }
+  }
+
+  QProcess installProc;
+  installProc.setWorkingDirectory(packageDir);
+  installProc.start(pixiExe, { QStringLiteral("install") });
+  if (!installProc.waitForFinished(timeoutMs)) {
+    qWarning() << "pixi install timed out for" << packageDir;
+    installProc.kill();
+    return false;
+  }
+  if (installProc.exitCode() != 0) {
+    qWarning() << "pixi install failed for" << packageDir << ":"
+               << QString::fromUtf8(installProc.readAllStandardError());
+    return false;
+  }
+
+  // Exit code 0 is not proof that this package was installed, so check that
+  // the command actually landed in the environment before relying on it.
+  if (!commands.command.isEmpty() &&
+      PackageManager::pixiScriptPath(packageDir, commands.command).isEmpty()) {
+    qWarning() << "pixi install reported success but did not provide"
+               << commands.command << "in" << packageDir;
+    return false;
+  }
+
+  // A package set up before pixi was available was pip-installed into .venv.
+  // Now that pixi has taken over, drop that tree.
+  PackageManager::removeSupersededVenv(packageDir, commands.command);
+
+  // Run the *-setup script if one is declared (e.g. to download ML model
+  // weights).
+  runSetupScript(packageDir, commands.setupCommand, pixiExe, true, timeoutMs);
+  return true;
+}
+
+// Install @p packageDir with pip into a fresh .venv. Returns true only if the
+// package's command can afterwards be run from that environment.
+static bool installWithPip(const QString& packageDir,
+                           const PackageCommands& commands,
+                           const QString& pythonExe, int timeoutMs)
+{
+  // Step 1: create a venv
+  QProcess venvProc;
+  venvProc.setWorkingDirectory(packageDir);
+  venvProc.start(pythonExe, { QStringLiteral("-m"), QStringLiteral("venv"),
+                              QStringLiteral(".venv") });
+  if (!venvProc.waitForFinished(timeoutMs)) {
+    qWarning() << "venv creation timed out for" << packageDir;
+    venvProc.kill();
+    return false;
+  }
+  if (venvProc.exitCode() != 0) {
+    qWarning() << "venv creation failed for" << packageDir << ":"
+               << venvProc.readAllStandardError();
+    return false;
+  }
+
+  // Step 2: pip install . using the venv's pip
+#ifdef Q_OS_WIN
+  QString venvPip = packageDir + QStringLiteral("/.venv/Scripts/pip.exe");
+#else
+  QString venvPip = packageDir + QStringLiteral("/.venv/bin/pip");
+#endif
+  QProcess installProc;
+  installProc.setWorkingDirectory(packageDir);
+  installProc.start(venvPip,
+                    { QStringLiteral("install"), QStringLiteral(".") });
+  if (!installProc.waitForFinished(timeoutMs)) {
+    qWarning() << "pip install timed out for" << packageDir;
+    installProc.kill();
+    return false;
+  }
+  if (installProc.exitCode() != 0) {
+    qWarning() << "pip install failed for" << packageDir << ":"
+               << installProc.readAllStandardError();
+    return false;
+  }
+
+  // Exit code 0 is not proof that this package was installed, so check that
+  // the command actually landed in the environment before relying on it.
+  if (!commands.command.isEmpty() &&
+      PackageManager::venvScriptPath(packageDir, commands.command).isEmpty()) {
+    qWarning() << "pip install reported success but did not provide"
+               << commands.command << "in" << packageDir;
+    return false;
+  }
+
+  // Run the *-setup script if one is declared.
+  runSetupScript(packageDir, commands.setupCommand, QString(), false,
+                 timeoutMs);
+  return true;
+}
+
 void PackageManager::installPackages(const QStringList& packageDirs)
 {
-  QString pixiExe = findPixiExecutable();
+  const QString pixiExe = findPixiExecutable();
   QString pythonExe;
-  if (pixiExe.isEmpty()) {
-    // Paths come back in the order the names were given, so the first hit is
-    // the most preferred interpreter.
-    const QStringList pythons =
-      Utilities::findExecutablePaths(pythonExecutableNames());
-    if (!pythons.isEmpty())
-      pythonExe = pythons.constFirst();
-  }
+  // Paths come back in the order the names were given, so the first hit is
+  // the most preferred interpreter.
+  const QStringList pythons =
+    Utilities::findExecutablePaths(pythonExecutableNames());
+  if (!pythons.isEmpty())
+    pythonExe = pythons.constFirst();
 
   // Pre-read entry-point names on the main thread so the install thread
   // doesn't need to re-parse pyproject.toml (parsePackage() reads it again
@@ -523,88 +694,24 @@ void PackageManager::installPackages(const QStringList& packageDirs)
     QThread::create([pixiExe, pythonExe, packageDirs, packageCommands]() {
       constexpr int installTimeoutMs = 10 * 60 * 1000; // 10 minutes
       for (const QString& packageDir : packageDirs) {
-        if (pixiExe.isEmpty() && pythonExe.isEmpty())
-          continue; // TODO - give a warning to the user that they need pixi
+        const PackageCommands commands = packageCommands.value(packageDir);
+        bool installed = false;
 
         if (!pixiExe.isEmpty()) {
-          // If a copied package includes a non-executable .pixi environment,
-          // pixi install fails querying its interpreter. Remove it and
-          // recreate.
-          const QString pixiDir = packageDir + QStringLiteral("/.pixi");
-          if (hasNonExecutablePixiPython(packageDir)) {
-            if (!QDir(pixiDir).removeRecursively()) {
-              qWarning() << "Could not remove invalid .pixi directory in"
-                         << packageDir;
-            }
-          }
+          installed =
+            installWithPixi(packageDir, commands, pixiExe, installTimeoutMs);
+        }
 
-          // Pixi install
-          QProcess installProc;
-          installProc.setWorkingDirectory(packageDir);
-          installProc.start(pixiExe, { QStringLiteral("install") });
-          if (!installProc.waitForFinished(installTimeoutMs)) {
-            qWarning() << "pixi install timed out for" << packageDir;
-            installProc.kill();
-            continue;
-          }
-          if (installProc.exitCode() != 0) {
-            qWarning() << "pixi install failed for" << packageDir << ":"
-                       << QString::fromUtf8(installProc.readAllStandardError());
-          } else {
-            // A package set up before pixi was available was pip-installed
-            // into .venv. Now that pixi has taken over, drop that tree.
-            removeSupersededVenv(packageDir,
-                                 packageCommands.value(packageDir).command);
+        // pixi is preferred, but it cannot install a package that declares no
+        // workspace of its own, and an install that leaves the command
+        // missing is no install at all. Either way pip can still do it.
+        if (!installed && !pythonExe.isEmpty()) {
+          installed =
+            installWithPip(packageDir, commands, pythonExe, installTimeoutMs);
+        }
 
-            // Run the *-setup script if one is declared (e.g. to download ML
-            // model weights).
-            runSetupScript(packageDir,
-                           packageCommands.value(packageDir).setupCommand,
-                           pixiExe, true, installTimeoutMs);
-          }
-        } else {
-          // Step 1: create a venv
-          QProcess venvProc;
-          venvProc.setWorkingDirectory(packageDir);
-          venvProc.start(pythonExe,
-                         { QStringLiteral("-m"), QStringLiteral("venv"),
-                           QStringLiteral(".venv") });
-          if (!venvProc.waitForFinished(installTimeoutMs)) {
-            qWarning() << "venv creation timed out for" << packageDir;
-            venvProc.kill();
-            continue;
-          }
-          if (venvProc.exitCode() != 0) {
-            qWarning() << "venv creation failed for" << packageDir << ":"
-                       << venvProc.readAllStandardError();
-            continue;
-          }
-
-        // Step 2: pip install . using the venv's pip
-#ifdef Q_OS_WIN
-          QString venvPip =
-            packageDir + QStringLiteral("/.venv/Scripts/pip.exe");
-#else
-          QString venvPip = packageDir + QStringLiteral("/.venv/bin/pip");
-#endif
-          QProcess installProc;
-          installProc.setWorkingDirectory(packageDir);
-          installProc.start(venvPip,
-                            { QStringLiteral("install"), QStringLiteral(".") });
-          if (!installProc.waitForFinished(installTimeoutMs)) {
-            qWarning() << "pip install timed out for" << packageDir;
-            installProc.kill();
-            continue;
-          }
-          if (installProc.exitCode() != 0) {
-            qWarning() << "pip install failed for" << packageDir << ":"
-                       << installProc.readAllStandardError();
-          } else {
-            // Run the *-setup script if one is declared.
-            runSetupScript(packageDir,
-                           packageCommands.value(packageDir).setupCommand,
-                           QStringLiteral(), false, installTimeoutMs);
-          }
+        if (!installed) {
+          qWarning() << "PackageManager: could not install" << packageDir;
         }
       }
     });
@@ -669,9 +776,12 @@ bool PackageManager::unregisterPackage(const QString& packageName)
 // or may have been built with a backend we no longer prefer: a package
 // pip-installed into .venv predates pixi being available on this machine, and
 // "pixi run --as-is" will not create the pixi environment on demand. Both are
-// repaired by installing again.
+// repaired by installing again — except that a package declaring no pixi
+// workspace of its own can never be moved off .venv, so pixi being merely
+// present must not be treated as a reason to reinstall it: that would re-offer
+// the install on every launch, for ever.
 static bool environmentNeedsInstall(const QString& packageDir,
-                                    const QString& command, bool pixiAvailable,
+                                    const QString& command, bool pixiUsable,
                                     bool canInstall)
 {
   // Nothing to install with, or nothing to install — don't ask every launch.
@@ -684,8 +794,9 @@ static bool environmentNeedsInstall(const QString& packageDir,
   if (PackageManager::venvScriptPath(packageDir, command).isEmpty())
     return true; // no usable environment at all
 
-  // A working .venv, but pixi has been installed since it was created.
-  return pixiAvailable;
+  // A working .venv, but pixi has been installed since it was created and can
+  // install this package.
+  return pixiUsable;
 }
 
 QStringList PackageManager::scanDirectory(const QString& directoryPath)
@@ -703,8 +814,7 @@ QStringList PackageManager::scanDirectory(const QString& directoryPath)
 
   // Whether we could repair a package with a missing or outdated environment.
   const bool pixiAvailable = !findPixiExecutable().isEmpty();
-  const bool canInstall =
-    pixiAvailable ||
+  const bool pythonAvailable =
     !Utilities::findExecutablePaths(pythonExecutableNames()).isEmpty();
 
   const QStringList subdirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
@@ -725,22 +835,32 @@ QStringList PackageManager::scanDirectory(const QString& directoryPath)
         .toHex();
     tomlFile.close();
 
-    // Check if we already have this package with the same hash
-    // We need to find the package name — check all registered packages
+    // pixi can only install a package that brings its own workspace.
+    const bool pixiUsable = pixiAvailable && hasPixiManifest(packageDir);
+    const bool canInstall = pixiUsable || pythonAvailable;
+
+    // Several cache entries can name the same directory: a package renamed
+    // upstream leaves its old name behind, with the hash of a pyproject.toml
+    // that will never be seen again. Check them all rather than stopping at
+    // the first, or that stale entry alone would keep the package looking
+    // out of date on every launch.
     bool needsRegistration = true;
     const QStringList known = registeredPackages();
     for (const QString& name : known) {
-      PackageInfo info = packageInfo(name);
-      if (QDir(info.directory) == QDir(packageDir)) {
-        // Same directory — check the cached hash
-        QSettings settings;
-        QString prefix = QStringLiteral("plugins/") + name + '/';
-        QByteArray cachedHash =
-          settings.value(prefix + "tomlHash").toByteArray();
-        if (cachedHash == currentHash) {
-          needsRegistration = environmentNeedsInstall(
-            packageDir, info.command, pixiAvailable, canInstall);
-        }
+      const PackageInfo info = packageInfo(name);
+      if (QDir(info.directory) != QDir(packageDir))
+        continue;
+
+      QSettings settings;
+      const QString prefix = QStringLiteral("plugins/") + name + '/';
+      const QByteArray cachedHash =
+        settings.value(prefix + "tomlHash").toByteArray();
+      if (cachedHash != currentHash)
+        continue;
+
+      if (!environmentNeedsInstall(packageDir, info.command, pixiUsable,
+                                   canInstall)) {
+        needsRegistration = false;
         break;
       }
     }
@@ -1005,6 +1125,17 @@ bool PackageManager::loadFromCache(const QString& packageName,
   // Verify the package directory still exists and has a pyproject.toml
   QFileInfo pyproject(info.directory + QLatin1String("/pyproject.toml"));
   if (!pyproject.isFile()) {
+    removeFromCache(packageName);
+    return false;
+  }
+
+  // A package renamed upstream leaves its old entry behind: the directory and
+  // its pyproject.toml are still there, but they now describe a different
+  // package. Replaying it would register features that can never run.
+  const QString declaredName =
+    normalizedPackageName(readPackageName(info.directory));
+  if (!declaredName.isEmpty() &&
+      declaredName != normalizedPackageName(packageName)) {
     removeFromCache(packageName);
     return false;
   }

--- a/avogadro/qtgui/packagemanager.cpp
+++ b/avogadro/qtgui/packagemanager.cpp
@@ -477,9 +477,9 @@ static QString normalizedPackageName(const QString& name)
   return QString(name).replace(separators, QStringLiteral("-")).toLower();
 }
 
-// The [project.name] declared by the pyproject.toml in @p packageDir, or an
-// empty string if it cannot be read.
-static QString readPackageName(const QString& packageDir)
+// The [project] table of the pyproject.toml in @p packageDir, empty if the
+// file cannot be read or parsed.
+static QVariantMap readProjectTable(const QString& packageDir)
 {
   QFile tomlFile(packageDir + QStringLiteral("/pyproject.toml"));
   if (!tomlFile.open(QIODevice::ReadOnly))
@@ -492,9 +492,22 @@ static QString readPackageName(const QString& packageDir)
   if (!ok)
     return {};
 
-  return root.value(QStringLiteral("project"))
-    .toMap()
-    .value(QStringLiteral("name"))
+  return root.value(QStringLiteral("project")).toMap();
+}
+
+// The [project.name] declared by the pyproject.toml in @p packageDir, or an
+// empty string if it cannot be read.
+static QString readPackageName(const QString& packageDir)
+{
+  return readProjectTable(packageDir).value(QStringLiteral("name")).toString();
+}
+
+QString PackageManager::packageVersion(const QString& packageDir)
+{
+  if (packageDir.isEmpty())
+    return {};
+  return readProjectTable(packageDir)
+    .value(QStringLiteral("version"))
     .toString();
 }
 

--- a/avogadro/qtgui/packagemanager.h
+++ b/avogadro/qtgui/packagemanager.h
@@ -82,6 +82,19 @@ public:
   // --- Installed environments ---
 
   /**
+   * Whether @p packageDir declares a pixi workspace of its own: a pixi.toml,
+   * or a pyproject.toml with a non-empty @c [tool.pixi] table.
+   *
+   * pixi finds its manifest by walking up from the directory it is run in, so
+   * a package that declares none is not merely unsupported — pixi silently
+   * operates on an ancestor's workspace instead. @c "pixi install" then
+   * reports success having installed something else entirely, and the
+   * package's own command is nowhere on PATH ("command not found", exit 127).
+   * Such a package has to be installed with pip into @c .venv.
+   */
+  static bool hasPixiManifest(const QString& packageDir);
+
+  /**
    * Absolute path to @p command as installed in the pixi environment of
    * @p packageDir (@c .pixi/envs/default), or an empty string if the package
    * has no pixi environment with that command in it.

--- a/avogadro/qtgui/packagemanager.h
+++ b/avogadro/qtgui/packagemanager.h
@@ -79,6 +79,12 @@ public:
   static void mergeOptionsFromFile(QJsonObject& opts,
                                    const QString& userOptionsPath);
 
+  /**
+   * The @c [project.version] declared by the pyproject.toml in @p packageDir,
+   * or an empty string if it cannot be read.
+   */
+  static QString packageVersion(const QString& packageDir);
+
   // --- Installed environments ---
 
   /**

--- a/tests/qtgui/packagemanagertest.cpp
+++ b/tests/qtgui/packagemanagertest.cpp
@@ -1086,7 +1086,10 @@ TEST_F(PackageManagerTest, scanDirectoryRescansPackageWithMissingEnvironment)
 TEST_F(PackageManagerTest, scanDirectoryRescansVenvPackageOncePixiIsAvailable)
 {
   const QString scanDir = m_packageDir + "/scan";
-  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  // Only a package that brings its own pixi workspace can be migrated to one.
+  const QString pkgDir = createScannablePackage(
+    scanDir, sampleToml() + "\n[tool.pixi.workspace]\n"
+                            "channels = [\"conda-forge\"]\n");
   ASSERT_FALSE(pkgDir.isEmpty());
 
   auto* pm = PackageManager::instance();
@@ -1098,6 +1101,26 @@ TEST_F(PackageManagerTest, scanDirectoryRescansVenvPackageOncePixiIsAvailable)
   // order to migrate it to pixi — and only if pixi is actually here now.
   EXPECT_EQ(pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()),
             pixiIsInstalled());
+}
+
+TEST_F(PackageManagerTest, scanDirectoryKeepsVenvPackageThatCannotUsePixi)
+{
+  const QString scanDir = m_packageDir + "/scan";
+  // sampleToml() declares no [tool.pixi] table, so pixi would install some
+  // ancestor's workspace rather than this package.
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  auto* pm = PackageManager::instance();
+  ASSERT_TRUE(pm->registerPackage(pkgDir));
+  ASSERT_TRUE(
+    createConsoleScript(pkgDir + venvBinDir(), "avogadro-test-plugin"));
+
+  // The .venv is the only environment this package can ever have, so pixi
+  // turning up is no reason to reinstall it. Asking anyway would put the
+  // install prompt up on every single launch, for ever.
+  EXPECT_FALSE(
+    pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()));
 }
 
 // ---------------------------------------------------------------------------
@@ -1213,4 +1236,133 @@ TEST_F(PackageManagerTest, resolveCommandLineEmptyWithoutAnyEnvironment)
 
   EXPECT_TRUE(commandLine.program.isEmpty());
   EXPECT_TRUE(commandLine.prefixArgs.isEmpty());
+}
+
+// ---------------------------------------------------------------------------
+// hasPixiManifest()
+//
+// pixi finds its manifest by walking up from the directory it is run in, so a
+// package declaring none is not merely unsupported: "pixi install" silently
+// installs some ancestor's workspace instead and reports success.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, hasPixiManifestFalseWithoutPixiTable)
+{
+  // sampleToml() has a [tool.avogadro] table but no [tool.pixi].
+  EXPECT_FALSE(PackageManager::hasPixiManifest(m_packageDir));
+}
+
+TEST_F(PackageManagerTest, hasPixiManifestTrueWithPixiWorkspaceTable)
+{
+  const QString pkgDir = m_packageDir + "/with-workspace";
+  ASSERT_TRUE(QDir().mkpath(pkgDir));
+  ASSERT_FALSE(writeTextFile(pkgDir + "/pyproject.toml",
+                             "[tool.pixi.workspace]\n"
+                             "channels = [\"conda-forge\"]\n")
+                 .isEmpty());
+
+  EXPECT_TRUE(PackageManager::hasPixiManifest(pkgDir));
+}
+
+TEST_F(PackageManagerTest, hasPixiManifestTrueWithBarePixiToml)
+{
+  const QString pkgDir = m_packageDir + "/with-pixi-toml";
+  ASSERT_TRUE(QDir().mkpath(pkgDir));
+  // The pyproject.toml alone declares no [tool.pixi] table; the standalone
+  // pixi.toml beside it is what makes this directory a workspace.
+  ASSERT_FALSE(
+    writeTextFile(pkgDir + "/pyproject.toml", sampleToml()).isEmpty());
+  ASSERT_FALSE(writeTextFile(pkgDir + "/pixi.toml", "[workspace]\n").isEmpty());
+
+  EXPECT_TRUE(PackageManager::hasPixiManifest(pkgDir));
+}
+
+TEST_F(PackageManagerTest, hasPixiManifestFalseWithoutAnyManifest)
+{
+  const QString pkgDir = m_packageDir + "/no-manifest";
+  ASSERT_TRUE(QDir().mkpath(pkgDir));
+
+  EXPECT_FALSE(PackageManager::hasPixiManifest(pkgDir));
+}
+
+// ---------------------------------------------------------------------------
+// scanDirectory() with a stale entry from a renamed package
+//
+// A package renamed upstream leaves its old cache entry behind, pointing at
+// the same directory but carrying the hash of a pyproject.toml that will
+// never be seen again. That stale entry must not shadow a healthy, current
+// one that also names the directory.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, scanDirectoryIgnoresStaleEntryForSameDirectory)
+{
+  const QString scanDir = m_packageDir + "/scan";
+  const QString pkgDir = createScannablePackage(scanDir, sampleToml());
+  ASSERT_FALSE(pkgDir.isEmpty());
+
+  auto* pm = PackageManager::instance();
+  ASSERT_TRUE(pm->registerPackage(pkgDir));
+  ASSERT_TRUE(
+    createConsoleScript(pkgDir + pixiBinDir(), "avogadro-test-plugin"));
+
+  // A stale entry left behind by the package's old name: same directory, but
+  // a hash the current pyproject.toml will never match again.
+  {
+    QSettings settings;
+    settings.setValue("plugins/old-test-plugin/directory",
+                      pm->packageInfo("test-plugin").directory);
+    settings.setValue("plugins/old-test-plugin/command", "avogadro-old-name");
+    settings.setValue("plugins/old-test-plugin/tomlHash",
+                      QByteArray("deadbeef"));
+    settings.sync();
+  }
+
+  // The healthy "test-plugin" entry (unchanged hash, command installed) is
+  // enough on its own to say nothing needs to happen here.
+  EXPECT_FALSE(
+    pm->scanDirectory(scanDir).contains(QDir(pkgDir).absolutePath()));
+
+  QSettings settings;
+  settings.beginGroup("plugins");
+  settings.remove("old-test-plugin");
+  settings.endGroup();
+  settings.sync();
+}
+
+// ---------------------------------------------------------------------------
+// loadFromCache() / loadRegisteredPackages() pruning a renamed package
+//
+// A package renamed upstream (avogenerators: avogadro-avogenerators ->
+// avogadro-generators) leaves its old cache entry behind. The directory and
+// its pyproject.toml still exist, but the file now describes a different
+// package, so replaying that entry would register features for a name that
+// no longer exists.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, loadRegisteredPackagesPrunesRenamedEntry)
+{
+  // m_packageDir's pyproject.toml (sampleToml()) declares
+  // [project.name] = "test-plugin", so a cache entry under any other name is
+  // stale.
+  {
+    QSettings settings;
+    settings.setValue("plugins/old-name/directory", m_packageDir);
+    settings.setValue("plugins/old-name/command", "avogadro-old-name");
+    settings.setValue("plugins/old-name/version", "0.0");
+    settings.sync();
+  }
+  ASSERT_TRUE(
+    PackageManager::instance()->registeredPackages().contains("old-name"));
+
+  PackageManager::instance()->loadRegisteredPackages();
+
+  EXPECT_FALSE(
+    PackageManager::instance()->registeredPackages().contains("old-name"));
+
+  // In case the assertion above failed and left the entry behind.
+  QSettings settings;
+  settings.beginGroup("plugins");
+  settings.remove("old-name");
+  settings.endGroup();
+  settings.sync();
 }

--- a/tests/qtgui/packagemanagertest.cpp
+++ b/tests/qtgui/packagemanagertest.cpp
@@ -14,6 +14,7 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QSettings>
 #include <QtCore/QTemporaryDir>
+#include <QtCore/QVersionNumber>
 #include <QtCore/QVariantMap>
 
 #include <QSignalSpy>
@@ -1236,6 +1237,43 @@ TEST_F(PackageManagerTest, resolveCommandLineEmptyWithoutAnyEnvironment)
 
   EXPECT_TRUE(commandLine.program.isEmpty());
   EXPECT_TRUE(commandLine.prefixArgs.isEmpty());
+}
+
+// ---------------------------------------------------------------------------
+// packageVersion()
+//
+// MainWindow decides whether to refresh its bundled copy of a package by
+// comparing versions, never content: the plugin downloader installs over the
+// very same directory, so a package the user has updated themselves must not
+// be reverted to the bundled copy on the next launch.
+// ---------------------------------------------------------------------------
+
+TEST_F(PackageManagerTest, packageVersionReadsProjectVersion)
+{
+  EXPECT_EQ(PackageManager::packageVersion(m_packageDir), "1.2.3");
+}
+
+TEST_F(PackageManagerTest, packageVersionEmptyWithoutAPackage)
+{
+  const QString pkgDir = m_packageDir + "/no-manifest";
+  ASSERT_TRUE(QDir().mkpath(pkgDir));
+
+  EXPECT_TRUE(PackageManager::packageVersion(pkgDir).isEmpty());
+  EXPECT_TRUE(PackageManager::packageVersion(QString()).isEmpty());
+}
+
+TEST_F(PackageManagerTest, packageVersionOrdersAnAddedSegmentAsNewer)
+{
+  // The real case this was written for: avogenerators shipped "2.0" before it
+  // declared a pixi workspace and "2.0.0" after, so the repaired package has
+  // to compare as newer than the copy already sitting in the user's plugin
+  // directory.
+  EXPECT_GT(QVersionNumber::fromString(QStringLiteral("2.0.0")),
+            QVersionNumber::fromString(QStringLiteral("2.0")));
+
+  // ... while a package the user has updated past the bundled one does not.
+  EXPECT_GT(QVersionNumber::fromString(QStringLiteral("2.1.0")),
+            QVersionNumber::fromString(QStringLiteral("2.0.0")));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- check for a proper manifest
- check for a working pixi env after installing
- check for updated packages (e.g., updating avogenerators)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Package installation now supports packages with their own Pixi workspace configuration.
  - Packages without Pixi configuration can be installed using pip with an automatically selected Python environment.
  - Package metadata, including declared versions, is detected more reliably.

- **Bug Fixes**
  - Improved fallback behavior when Pixi installation is unavailable or unsuccessful.
  - Stale or renamed cached packages are now rejected and cleaned up.
  - Packages without Pixi configuration are no longer unnecessarily rescanned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->