### PR TITLE
Insert the modelView and camera projection matrix into CJSON

### DIFF
--- a/avogadro/qtgui/interfacescript.cpp
+++ b/avogadro/qtgui/interfacescript.cpp
@@ -28,6 +28,21 @@ namespace Avogadro::QtGui {
 using QtGui::GenericHighlighter;
 using QtGui::PythonScript;
 
+// Serialize a 4x4 matrix as nested rows, matching what CjsonFormat writes for
+// a Variant::Matrix, so a script sees one shape whether the CJSON came from a
+// file or from the live camera.
+static QJsonArray matrixToJson(const Matrix4f& matrix)
+{
+  QJsonArray rows;
+  for (int i = 0; i < 4; ++i) {
+    QJsonArray row;
+    for (int j = 0; j < 4; ++j)
+      row.append(static_cast<double>(matrix(i, j)));
+    rows.append(row);
+  }
+  return rows;
+}
+
 // Strip any leading non-JSON output (e.g. deprecation warnings printed to
 // stdout by third-party libraries). Find the first '{' or '['.
 static void stripLeadingNonJson(QByteArray& data)
@@ -177,6 +192,27 @@ void InterfaceScript::reset()
   m_files.clear();
   m_fileHighlighters.clear();
   m_highlightStyles.clear();
+}
+
+void InterfaceScript::setCamera(const Matrix4f& modelView,
+                                const Matrix4f& projection)
+{
+  m_modelView = modelView;
+  m_projection = projection;
+  m_hasCamera = true;
+}
+
+void InterfaceScript::insertCamera(QJsonObject& cjson) const
+{
+  if (!m_hasCamera)
+    return;
+
+  // Overwrite rather than merge: the molecule may carry matrices from the file
+  // it was read from, and the live camera is what the user is looking at.
+  QJsonObject properties = cjson.value(QStringLiteral("properties")).toObject();
+  properties.insert(QStringLiteral("modelView"), matrixToJson(m_modelView));
+  properties.insert(QStringLiteral("projection"), matrixToJson(m_projection));
+  cjson.insert(QStringLiteral("properties"), properties);
 }
 
 bool InterfaceScript::runCommand(const QJsonObject& options_,
@@ -689,7 +725,9 @@ bool InterfaceScript::insertMolecule(QJsonObject& json,
     return false;
   }
 
-  json.insert("cjson", doc.object());
+  QJsonObject cjson = doc.object();
+  insertCamera(cjson);
+  json.insert("cjson", cjson);
 
   return true;
 }

--- a/avogadro/qtgui/interfacescript.h
+++ b/avogadro/qtgui/interfacescript.h
@@ -11,6 +11,7 @@
 #include "avogadroqtguiexport.h"
 
 #include <avogadro/core/avogadrocore.h>
+#include <avogadro/core/matrix.h>
 
 #include <QRegularExpression>
 #include <QtCore/QJsonObject>
@@ -629,6 +630,22 @@ public:
   bool runCommand(const QJsonObject& options_, Core::Molecule* mol);
 
   /**
+   * Supply the current view camera, so that the CJSON handed to the script
+   * carries the orientation the user is actually looking at.
+   *
+   * The matrices are written to the CJSON as \c properties.modelView and
+   * \c properties.projection, the same keys CjsonFormat uses, and they
+   * override any stale matrices the molecule kept from the file it was read
+   * from. Without this, a script only ever sees the camera as of the last
+   * save.
+   *
+   * @param modelView The camera's world-to-eye transform.
+   * @param projection The camera's projection matrix. Its (3, 3) element is 0
+   * for a perspective camera and 1 for an orthographic one.
+   */
+  void setCamera(const Matrix4f& modelView, const Matrix4f& projection);
+
+  /**
    * Finish processing an aynchronous command script
    */
   bool processCommand(Core::Molecule* mol);
@@ -761,6 +778,7 @@ private:
                      const QByteArray& scriptStdin = QByteArray()) const;
   QString processErrorString(const QProcess& proc) const;
   bool insertMolecule(QJsonObject& json, const Core::Molecule& mol) const;
+  void insertCamera(QJsonObject& cjson) const;
 
   // File extension of requested molecule format
   mutable QString m_moleculeExtension;
@@ -776,6 +794,11 @@ private:
   QMap<QString, QtGui::GenericHighlighter*> m_fileHighlighters;
 
   mutable QMap<QString, QtGui::GenericHighlighter*> m_highlightStyles;
+
+  // The view camera, when the caller has one to offer.
+  bool m_hasCamera = false;
+  Matrix4f m_modelView;
+  Matrix4f m_projection;
 };
 
 inline bool InterfaceScript::isValid() const

--- a/avogadro/qtplugins/commandscripts/CMakeLists.txt
+++ b/avogadro/qtplugins/commandscripts/CMakeLists.txt
@@ -11,7 +11,8 @@ avogadro_plugin(commands
   "${command_srcs}"
 )
 
-target_link_libraries(commands PRIVATE Avogadro::IO Avogadro::QtGui)
+target_link_libraries(commands PRIVATE Avogadro::IO Avogadro::QtGui
+  Avogadro::Rendering)
 
 # We no longer bundle scripts because they should be downloaded separately.
 # This also helps base translations.

--- a/avogadro/qtplugins/commandscripts/command.cpp
+++ b/avogadro/qtplugins/commandscripts/command.cpp
@@ -15,6 +15,8 @@
 #include <avogadro/qtgui/pythonscript.h>
 #include <avogadro/qtgui/utilities.h>
 
+#include <avogadro/rendering/camera.h>
+
 #include <QAction>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QDialogButtonBox>
@@ -326,6 +328,13 @@ void Command::menuActivated()
   m_currentDialog->exec();
 }
 
+void Command::setCamera(Rendering::Camera* camera)
+{
+  // MainWindow hands out the renderer's own camera, so this pointer keeps
+  // tracking the view as the user rotates it.
+  m_camera = camera;
+}
+
 void Command::run()
 {
   if (m_currentDialog)
@@ -383,6 +392,14 @@ void Command::run()
     m_progress->setAutoReset(false);
     connect(m_progress, &QProgressDialog::canceled, this,
             &Command::cancelCommand);
+
+    // Give the script the view the user is actually looking at. The molecule
+    // only carries a camera if it was read from, or written to, a file, so
+    // without this a script would see a stale orientation or none at all.
+    if (m_camera != nullptr) {
+      m_currentScript->setCamera(m_camera->modelView().matrix(),
+                                 m_camera->projection().matrix());
+    }
 
     // Snapshot so processFinished() can detect if the molecule was closed
     // or swapped before the async script returned.

--- a/avogadro/qtplugins/commandscripts/command.h
+++ b/avogadro/qtplugins/commandscripts/command.h
@@ -24,6 +24,10 @@ namespace Io {
 class FileFormat;
 }
 
+namespace Rendering {
+class Camera;
+}
+
 namespace QtGui {
 class InterfaceScript;
 class InterfaceWidget;
@@ -56,6 +60,8 @@ public:
   QStringList menuPath(QAction*) const override;
 
   void setMolecule(QtGui::Molecule* mol) override;
+
+  void setCamera(Rendering::Camera* camera) override;
 
 public slots:
   /**
@@ -116,6 +122,8 @@ private:
 
   QList<QAction*> m_actions;
   QtGui::Molecule* m_molecule;
+  // The active view's camera, owned by the renderer; null until a view exists.
+  Rendering::Camera* m_camera = nullptr;
   // Launch-time molecule for the async script; QPointer detects deletion.
   QPointer<QtGui::Molecule> m_runningMolecule;
   // keyed on script file path or package feature key


### PR DESCRIPTION
Currently, the view and projection are handled by avogadroapp Which means scripts can't access from CJSON

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command scripts now receive the active camera’s model-view and projection settings.
  - Script-generated molecular content reflects the current 3D view, including camera orientation and perspective.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->