### PR TITLE
Fix zoomScene delta sign to match its documentation

### DIFF
--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -68,7 +68,11 @@ void Navigator::registerCommands()
 {
   emit registerCommand("rotateScene",
                        tr("Rotate the scene along the x, y, or z axes."));
-  emit registerCommand("zoomScene", tr("Zoom the scene."));
+  emit registerCommand(
+    "zoomScene",
+    tr("Zoom the scene. Positive delta moves toward the molecule, negative "
+       "away. One unit of delta is roughly a 2% change in the camera's "
+       "distance to the focal point."));
   emit registerCommand("translateScene", tr("Translate the scene."));
 }
 
@@ -87,7 +91,12 @@ bool Navigator::handleCommand(const QString& command,
     m_glWidget->requestUpdate();
   } else if (command == "zoomScene") {
     float d = options.value("delta").toFloat();
-    zoom(m_renderer->camera().focus(), d);
+    // zoom() itself treats positive d as moving away from the focus point
+    // (used as-is by the mouse wheel / keyboard handlers below, which must
+    // keep their existing feel). The zoomScene command is documented the
+    // other way around -- positive delta moves toward the molecule -- so
+    // negate here, at the command boundary only.
+    zoom(m_renderer->camera().focus(), -d);
     m_glWidget->requestUpdate();
   } else if (command == "translateScene") {
     float x = options.value("x").toFloat();


### PR DESCRIPTION
Naively, positive zoomScene() command delta should zoom in and move towards the molecule, and negative zoomScene delta should move away.

Previously, just passed straight through to zoom() which handled the mouse wheel.

Also document the unit in the registered command description: ZOOM_SPEED is 0.02, so one unit of delta is roughly a 2% change in the camera's distance to the focal point.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
