### PR TITLE
Normalize QSettings key casing in label and cartoons plugins

### DIFF
--- a/avogadro/qtplugins/cartoons/cartoons.cpp
+++ b/avogadro/qtplugins/cartoons/cartoons.cpp
@@ -175,7 +175,13 @@ struct LayerCartoon : Core::LayerData
     showTube = settings.value("cartoon/tube", false).toBool();
     showRibbon = settings.value("cartoon/ribbon", false).toBool();
     showRope = settings.value("cartoon/rope", false).toBool();
-    showSimpleCartoon = settings.value("cartoon/simplecartoon", false).toBool();
+    // Read the current key, falling back to the pre-2.0 spelling; the
+    // read/write spellings previously diverged so this setting never
+    // persisted. (fallback can be dropped after a release or two)
+    showSimpleCartoon = settings
+                          .value("cartoon/simpleCartoon",
+                                 settings.value("cartoon/simplecartoon", false))
+                          .toBool();
   }
 
   LayerCartoon(std::string settings)

--- a/avogadro/qtplugins/label/label.cpp
+++ b/avogadro/qtplugins/label/label.cpp
@@ -46,7 +46,8 @@ typedef Array<Molecule::BondType> NeighborListType;
 
 namespace {
 TextLabel3D* createLabel(const std::string& text, const Vector3f& pos,
-                         float radius, const Vector3ub& color, float scale = 1.0f)
+                         float radius, const Vector3ub& color,
+                         float scale = 1.0f)
 {
   Rendering::TextProperties tprop;
   tprop.setAlign(Rendering::TextProperties::HCenter,
@@ -92,14 +93,31 @@ struct LayerLabel : Core::LayerData
   {
     widget = nullptr;
     QSettings settings;
+    // Read the current key, falling back to the pre-2.0 spelling.
+    // (fallback can be dropped after a release or two)
     atomOptions =
-      settings.value("label/atomoptions", LabelOptions::Name).toInt();
+      settings
+        .value("label/atomOptions",
+               settings.value("label/atomoptions", LabelOptions::Name))
+        .toInt();
     residueOptions =
-      settings.value("label/residueoptions", LabelOptions::None).toInt();
+      settings
+        .value("label/residueOptions",
+               settings.value("label/residueoptions", LabelOptions::None))
+        .toInt();
     bondOptions =
-      settings.value("label/bondoptions", LabelOptions::None).toInt();
-    radiusScalar = settings.value("label/radiusscalar", 0.5).toDouble();
-    labelScale = settings.value("label/labelscale", 1.0).toDouble();
+      settings
+        .value("label/bondOptions",
+               settings.value("label/bondoptions", LabelOptions::None))
+        .toInt();
+    radiusScalar =
+      settings
+        .value("label/radiusScalar", settings.value("label/radiusscalar", 0.5))
+        .toDouble();
+    labelScale =
+      settings
+        .value("label/labelScale", settings.value("label/labelscale", 1.0))
+        .toDouble();
 
     auto q_color =
       settings.value("label/color", QColor(Qt::white)).value<QColor>();
@@ -325,7 +343,8 @@ void Label::processResidue(const Core::Molecule& molecule,
     if (interface->residueOptions & LayerLabel::LabelOptions::Custom) {
       text += (text == "" ? "" : " / ") + customLabel;
     }
-    TextLabel3D* residueLabel = createLabel(text, pos, radius, color, interface->labelScale);
+    TextLabel3D* residueLabel =
+      createLabel(text, pos, radius, color, interface->labelScale);
     geometry->addDrawable(residueLabel);
   }
 }
@@ -425,8 +444,8 @@ void Label::processAtom(const Core::Molecule& molecule,
       float radius = static_cast<float>(Elements::radiusVDW(atomicNumber)) *
                      interface->radiusScalar;
 
-      TextLabel3D* atomLabel =
-        createLabel(text, pos, radius, contrastColor(color), interface->labelScale);
+      TextLabel3D* atomLabel = createLabel(
+        text, pos, radius, contrastColor(color), interface->labelScale);
       geometry->addDrawable(atomLabel);
     }
   }
@@ -482,7 +501,8 @@ void Label::processBond(const Core::Molecule& molecule,
       (atom1.position3d().cast<float>() + atom2.position3d().cast<float>()) /
       2.0f;
 
-    TextLabel3D* bondLabel = createLabel(text.str(), pos, radius, color, interface1->labelScale);
+    TextLabel3D* bondLabel =
+      createLabel(text.str(), pos, radius, color, interface1->labelScale);
     geometry->addDrawable(bondLabel);
   }
 }
@@ -511,7 +531,7 @@ void Label::atomLabelType(int index)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("label/atomoptions", interface->atomOptions);
+  settings.setValue("label/atomOptions", interface->atomOptions);
 }
 
 void Label::bondLabelType(int index)
@@ -524,7 +544,7 @@ void Label::bondLabelType(int index)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("label/bondoptions", interface->bondOptions);
+  settings.setValue("label/bondOptions", interface->bondOptions);
 }
 
 void Label::residueLabelType(int index)
@@ -537,7 +557,7 @@ void Label::residueLabelType(int index)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("label/residueoptions", interface->residueOptions);
+  settings.setValue("label/residueOptions", interface->residueOptions);
 }
 
 void Label::setRadiusScalar(double radius)
@@ -547,7 +567,7 @@ void Label::setRadiusScalar(double radius)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("label/radiusscalar", interface->radiusScalar);
+  settings.setValue("label/radiusScalar", interface->radiusScalar);
 }
 
 void Label::setLabelScale(double scale)
@@ -557,7 +577,7 @@ void Label::setLabelScale(double scale)
   emit drawablesChanged();
 
   QSettings settings;
-  settings.setValue("label/labelscale", interface->labelScale);
+  settings.setValue("label/labelScale", interface->labelScale);
 }
 
 QWidget* Label::setupWidget()


### PR DESCRIPTION
Rename five lowercase key parts in label.cpp to camelCase (atomOptions, bondOptions, residueOptions, labelScale, radiusScalar) and fix a bug in cartoons.cpp where the "simple cartoon" toggle was read from "cartoon/simplecartoon" but written to "cartoon/simpleCartoon" -- the two spellings never matched, so the setting silently failed to persist across restarts.

Every renamed/normalized key falls back to reading its old spelling so existing users' settings are not lost; writes go to the new key only. Prefixes (label/, cartoon/) are left untouched, since renaming them would migrate settings for no benefit.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
