### PR TITLE
Add support to avogadro.connect for introspection

### DIFF
--- a/python/avogadro/connect.py
+++ b/python/avogadro/connect.py
@@ -5,6 +5,7 @@
 ******************************************************************************/
 """
 
+import base64
 import json
 import os
 import socket
@@ -257,14 +258,90 @@ class connect:
         """
         return self.send("loadMolecule", {"content": content, "format": format})
 
-    def export_file(self, filename):
+    def version(self):
+        """
+        Report the versions Avogadro is running, for compatibility checks.
+
+        This is answered before the "no active window" check that every
+        other method requires, so it can be used to probe a starting
+        instance. A build old enough to have no ``version`` method raises
+        RPCError with code ``RPCError.METHOD_NOT_FOUND``; treat that as
+        ``rpcProtocol`` 1, the immediate-reply era before ``wait`` existed.
+
+        :returns: A dict with keys ``avogadroApp``, ``avogadroLibs``,
+            ``qt``, ``platform`` (one of "macos", "windows", "linux",
+            "bsd", "unknown"), and ``rpcProtocol`` (an int, 2 once a build
+            honours ``wait``).
+        """
+        response = self.send("version")
+        return response["result"]
+
+    def list_commands(self):
+        """
+        List every command Avogadro will answer, built-in and plugin alike.
+
+        :returns: A list of dicts, sorted by name, each with keys ``name``,
+            ``description``, ``kind`` ("builtin", "tool" or "extension"),
+            ``plugin`` (the owning plugin's name, empty for builtins),
+            ``async`` (currently always False), and ``schema`` (currently
+            always ``{}``).
+        """
+        response = self.send("listCommands")
+        return response["result"]
+
+    def molecule_info(self):
+        """
+        Summarize the active molecule: counts, formula, and what it has.
+
+        Every key is always present, even with no molecule open, in which
+        case the counts are 0 and the strings are empty.
+
+        :returns: A dict with keys ``atomCount``, ``bondCount``,
+            ``formula``, ``mass``, ``totalCharge``, ``spinMultiplicity``,
+            ``coordinateSetCount``, ``selectedAtomCount``, ``residueCount``,
+            ``hasResidues``, ``hasUnitCell``, ``hasCustomElements``,
+            ``hasBasisSet``, ``orbitalCount``, ``homoIndex`` (zero-based,
+            -1 with no basis set), ``cubeCount``, ``vibrationCount``, and
+            ``fileName`` (empty for a molecule loaded with load_molecule()).
+        """
+        response = self.send("moleculeInfo")
+        return response["result"]
+
+    def get_molecule(self, format="cjson"):
+        """
+        Read the active molecule back as text, without writing a file.
+
+        :param format: Any file format Avogadro can write, e.g. "xyz".
+            Defaults to "cjson".
+        :returns: The molecule's content as a string.
+        :raises RPCError: with code -1 for an unknown format, a write
+            failure, or no molecule open.
+        """
+        response = self.send("getMolecule", {"format": format})
+        return response["result"]["content"]
+
+    def export_file(self, filename, wait=True):
         """
         Write the active molecule to a file. The format is inferred from
         the file extension.
 
+        The write happens on a background thread, so without waiting this
+        call can return before the file exists on disk -- the bug the
+        completion protocol exists to fix. ``wait`` therefore defaults to
+        True here, unlike send() and command(), whose wait defaults stay
+        False.
+
         :param filename: Path to write.
+        :param wait: If True (the default), do not return until the write
+            has finished.
+        :returns: With wait=True, the dict of data the command reported
+            (currently just ``{"fileName": ...}``); with wait=False, the
+            raw response, as before.
         """
-        return self.send("exportFile", {"fileName": str(filename)})
+        response = self.send("exportFile", {"fileName": str(filename)}, wait=wait)
+        if wait:
+            return result_data(response)
+        return response
 
     def save_graphic(self, filename):
         """
@@ -274,6 +351,84 @@ class connect:
         :param filename: Path to write.
         """
         return self.send("saveGraphic", {"fileName": str(filename)})
+
+    def render_image(self, width=None, height=None, transparent=False, filename=None):
+        """
+        Render the current view, at any size, in or out of process memory.
+
+        Unlike save_graphic(), this can render larger or smaller than the
+        on-screen view, and can hand back the image bytes directly instead
+        of only writing a file.
+
+        :param width: Image width in pixels. Defaults to the current view
+            size. Clamped to the range [1, 8192].
+        :param height: Image height in pixels. Same default and clamping
+            as width.
+        :param transparent: If True, render with a transparent background.
+        :param filename: Path to write the PNG to. ".png" is appended if
+            the name has no extension, matching save_graphic(). If left
+            out, the image is returned inline instead of written to disk.
+        :returns: bytes of a PNG image when filename is not given;
+            True when it is (the file was written). No PIL dependency --
+            decode the bytes yourself if you want an image object, e.g.
+            with ``PIL.Image.open(io.BytesIO(data))``.
+        :raises RPCError: with code -1 for an unwritable path.
+        """
+        params = {}
+        if width is not None:
+            params["width"] = width
+        if height is not None:
+            params["height"] = height
+        if transparent:
+            params["transparentBackground"] = True
+        if filename is not None:
+            params["fileName"] = str(filename)
+
+        response = self.send("renderImage", params)
+        if filename is not None:
+            return True
+        return base64.b64decode(response["result"]["data"])
+
+    def list_display_types(self):
+        """
+        List the scene display types (ball-and-stick, wireframe, etc.)
+        and whether each is on, applicable, and configurable.
+
+        :returns: A list of dicts, each with keys ``name`` (the stable
+            identifier, e.g. "BallStick" -- pass this to
+            set_display_types(), not ``displayName``), ``displayName``
+            (translated for the interface language), ``enabled``,
+            ``applicable`` (false for e.g. a crystal-only type on a
+            molecule with no unit cell), and ``hasSettings``.
+        """
+        response = self.send("listDisplayTypes")
+        return response["result"]
+
+    def set_display_types(self, types):
+        """
+        Choose which scene display types are active.
+
+        :param types: Either a list of type names to turn on (e.g.
+            ``["BallStick", "VanDerWaals"]``), or a dict mapping names to
+            booleans, which can also turn types off (e.g.
+            ``{"BallStick": True, "Wireframe": False}``). A name matches
+            either a type's identifier or its translated display name;
+            prefer the identifier, since it does not change with the
+            interface language.
+        """
+        if isinstance(types, dict):
+            params = dict(types)
+        else:
+            params = {"types": list(types)}
+        return self.send("setRenderTypes", params)
+
+    def set_projection(self, kind):
+        """
+        Switch the camera projection.
+
+        :param kind: "perspective" or "orthographic".
+        """
+        return self.send("setProjection", {"type": kind})
 
     def ping(self):
         """

--- a/python/avogadro/connect.py
+++ b/python/avogadro/connect.py
@@ -430,6 +430,48 @@ class connect:
         """
         return self.send("setProjection", {"type": kind})
 
+    def get_camera(self):
+        """
+        Report the active view's camera.
+
+        :returns: A dict with keys ``distance`` (to the camera's own focus
+            point -- the number that matters for framing a molecule),
+            ``focus`` (a 3-element list), ``projection`` ("perspective" or
+            "orthographic"), ``orthographicScale``, and ``modelView`` (the
+            4x4 model view matrix as 16 floats in row-major order: element
+            ``[row * 4 + col]`` is ``modelView[row][col]``). Save this and
+            pass it to set_camera() to restore this exact view later.
+        :raises RPCError: with code -1 if there is no active view.
+        """
+        response = self.send("getCamera")
+        return response["result"]
+
+    def set_camera(self, model_view=None, projection=None, orthographic_scale=None):
+        """
+        Apply a saved camera view.
+
+        Give any combination of the three; anything left out is unchanged.
+
+        :param model_view: The 16-float row-major model view matrix from a
+            previous get_camera() call. Must be exactly 16 numbers.
+        :param projection: "perspective" or "orthographic".
+        :param orthographic_scale: The orthographic zoom factor.
+        :returns: The resulting camera state, the same shape get_camera()
+            returns.
+        :raises RPCError: with code -1 for a model_view that is not exactly
+            16 numbers, or if there is no active view.
+        """
+        params = {}
+        if model_view is not None:
+            params["modelView"] = list(model_view)
+        if projection is not None:
+            params["projection"] = projection
+        if orthographic_scale is not None:
+            params["orthographicScale"] = orthographic_scale
+
+        response = self.send("setCamera", params)
+        return response["result"]
+
     def ping(self):
         """
         Check that the server is alive.

--- a/python/avogadro/connect.py
+++ b/python/avogadro/connect.py
@@ -212,12 +212,17 @@ class connect:
             )
         return response
 
-    def command(self, name, wait=False, timeout=None, **params):
+    def command(self, name, /, wait=False, timeout=None, **params):
         """
         Run a command registered by a tool or extension plugin.
 
         Keyword arguments are passed through as the command options, e.g.
         ``avo.command("renderMO", orbital="homo", isovalue=0.02)``.
+
+        The command name is positional-only, so a command may have an
+        option of its own called ``name`` without colliding with it --
+        ``avo.command("fetchByName", name="caffeine")`` passes "caffeine"
+        through as the option. Only ``wait`` and ``timeout`` are reserved.
 
         :param name: The registered command name.
         :param wait: If True, do not return until the command has finished.

--- a/python/avogadro/connect.py
+++ b/python/avogadro/connect.py
@@ -258,6 +258,35 @@ class connect:
         """
         return self.send("loadMolecule", {"content": content, "format": format})
 
+    def fetch_by_name(self, name, wait=True, timeout=None):
+        """
+        Download a structure by name and load it, replacing the active
+        molecule.
+
+        The lookup queries the NIH Cactus resolver first, then retries
+        against PubChem's 3D endpoint if Cactus errors or returns 2D-only
+        coordinates. Like export_file(), this hands the work to the network
+        and would otherwise reply before it finishes, so ``wait`` defaults
+        to True here, unlike send() and command().
+
+        :param name: A common or IUPAC chemical name, e.g. "caffeine".
+        :param wait: If True (the default), do not return until the
+            structure has been downloaded and loaded.
+        :param timeout: Seconds to allow the command, when wait is True.
+        :returns: With wait=True, the dict of data the command reported --
+            ``name`` and ``source`` ("cactus" or "pubchem") always,
+            ``atomCount`` and ``formula`` when available; with wait=False,
+            the raw response.
+        :raises RPCError: with code -2 if name is empty, or if no match was
+            found in either database.
+        """
+        response = self.send(
+            "fetchByName", {"name": name}, wait=wait, timeout=timeout
+        )
+        if wait:
+            return result_data(response)
+        return response
+
     def version(self):
         """
         Report the versions Avogadro is running, for compatibility checks.

--- a/python/tests/_load_avogadro.py
+++ b/python/tests/_load_avogadro.py
@@ -1,0 +1,34 @@
+"""
+Import avogadro.connect for tests, without requiring a fully built wheel.
+
+``avogadro/__init__.py`` eagerly imports the compiled ``core`` and ``io``
+extension modules, so a plain ``import avogadro`` fails in a source
+checkout that has not been built (no C++ compiler run, no pybind11
+extensions present). ``connect.py`` itself has no avogadro-internal
+imports -- only the standard library -- so these tests do not need those
+extensions at all.
+
+load_connect_module() prefers a real, already-installed ``avogadro``
+package (e.g. in CI, after ``pip install .`` builds the wheel) and only
+falls back to loading ``connect.py`` through a minimal stand-in package
+when the real one cannot be imported. Either way, callers get back the
+same module object shape: ``.connect``, ``.RPCError``, ``.result_data``.
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+_AVOGADRO_DIR = Path(__file__).resolve().parent.parent / "avogadro"
+
+
+def load_connect_module():
+    if "avogadro" not in sys.modules:
+        try:
+            importlib.import_module("avogadro")
+        except ImportError:
+            stub = types.ModuleType("avogadro")
+            stub.__path__ = [str(_AVOGADRO_DIR)]
+            sys.modules["avogadro"] = stub
+    return importlib.import_module("avogadro.connect")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared pytest fixtures for testing avogadro.connect against a fake
+Avogadro RPC server (fake_rpc_server.FakeRPCServer).
+"""
+
+import pytest
+
+from _load_avogadro import load_connect_module
+from fake_rpc_server import FakeRPCServer
+
+connect = load_connect_module().connect
+
+
+@pytest.fixture
+def fake_server():
+    """A FakeRPCServer listening on its own throwaway socket name."""
+    with FakeRPCServer() as server:
+        yield server
+
+
+@pytest.fixture
+def avo(fake_server):
+    """A connect() instance already talking to fake_server."""
+    with connect(name=fake_server.name) as client:
+        yield client

--- a/python/tests/fake_rpc_server.py
+++ b/python/tests/fake_rpc_server.py
@@ -1,0 +1,369 @@
+"""
+A fake Avogadro RPC server, for testing ``avogadro.connect`` (and anything
+built on top of it) without a running Avogadro instance.
+
+It speaks the real wire protocol described in
+``two.avogadro.cc/source/develop/rpc.md``: a 4-byte big-endian length
+prefix followed by that many bytes of UTF-8 JSON-RPC 2.0, on a Unix domain
+socket named the way ``avogadro.connect.connect`` expects
+(``$TMPDIR/<name>``).
+
+Reuse from another package
+---------------------------
+
+This module has no dependency on ``avogadro`` itself -- only the standard
+library -- so another project (``avogadro-mcp`` is the intended consumer,
+per the MCP bridge plan) can use it as a test fixture by putting this
+file's directory on ``sys.path`` (e.g. a checked-out ``avogadrolibs``
+tree, ``.../avogadrolibs/python/tests``) and importing it directly::
+
+    import sys
+    sys.path.insert(0, "/path/to/avogadrolibs/python/tests")
+    from fake_rpc_server import FakeRPCServer
+
+    with FakeRPCServer() as server:
+        # point a client at server.name / server.path
+
+A pytest fixture wrapping it lives in ``conftest.py`` next to this file.
+
+Platform limitation
+--------------------
+
+Only the Unix domain socket transport is implemented, matching Linux,
+macOS and BSD. Windows Avogadro listens on a named pipe
+(``\\\\.\\pipe\\<name>``) instead; a named-pipe variant of this server
+would need the ``pywin32`` (or ``ctypes`` + the Win32 API) overlapped-IO
+calls and is not attempted here. Tests that use this module do not run on
+Windows as a result -- skip them there rather than trying to fake the
+pipe transport.
+"""
+
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import uuid
+import zlib
+
+
+def _png_chunk(tag, data):
+    """Build one PNG chunk: length + tag + data + CRC32."""
+    return (
+        struct.pack(">I", len(data))
+        + tag
+        + data
+        + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+    )
+
+
+def _make_tiny_png():
+    """
+    Build a minimal, valid 1x1 white PNG using only the standard library
+    (struct + zlib), so render_image() tests have real image bytes to
+    base64-decode and check, without shipping a binary fixture file.
+    """
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)  # 1x1, 8-bit RGB
+    raw = b"\x00" + b"\xff\xff\xff"  # filter-type byte + one white pixel
+    idat = zlib.compress(raw)
+    return (
+        signature
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", idat)
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+#: A real (if trivial) PNG, used to answer renderImage.
+TINY_PNG_BYTES = _make_tiny_png()
+
+
+def _default_render_image(params):
+    width = params.get("width", 1600)
+    height = params.get("height", 1200)
+    filename = params.get("fileName")
+    if filename:
+        if "." not in os.path.basename(filename):
+            filename = filename + ".png"
+        return {"width": width, "height": height, "fileName": filename}
+    import base64
+
+    return {
+        "width": width,
+        "height": height,
+        "format": "png",
+        "data": base64.b64encode(TINY_PNG_BYTES).decode("ascii"),
+    }
+
+
+def _default_get_molecule(params):
+    fmt = params.get("format", "cjson")
+    return {"format": fmt, "content": '{"chemical json": 1, "atoms": {}}'}
+
+
+def _default_export_file(params):
+    # Mirrors the real app: exportFile writes on a background thread, so
+    # without wait it answers immediately with True, and with wait it
+    # holds the reply for the "finished" shape carrying the results.
+    if params.get("wait"):
+        return {
+            "status": "finished",
+            "message": "Export finished",
+            "data": {"fileName": params.get("fileName")},
+        }
+    return True
+
+
+#: Canned results for every phase 1 method, per Appendix A of the MCP
+#: bridge plan. Each entry is either a plain value or a callable taking
+#: the request's params dict and returning the "result" payload.
+DEFAULT_RESPONSES = {
+    "internalPing": "pong",
+    "version": {
+        "avogadroApp": "1.103.0",
+        "avogadroLibs": "2.0.0",
+        "qt": "6.8.3",
+        "platform": "macos",
+        "rpcProtocol": 2,
+    },
+    "listCommands": [
+        {
+            "name": "openFile",
+            "description": "Read a file from disk and make it the active molecule.",
+            "kind": "builtin",
+            "plugin": "",
+            "async": False,
+            "schema": {},
+        },
+        {
+            "name": "renderMO",
+            "description": "Render a molecular orbital.",
+            "kind": "extension",
+            "plugin": "Surfaces",
+            "async": False,
+            "schema": {},
+        },
+    ],
+    "moleculeInfo": {
+        "atomCount": 24,
+        "bondCount": 25,
+        "formula": "C8H10N4O2",
+        "mass": 194.19,
+        "totalCharge": 0,
+        "spinMultiplicity": 1,
+        "coordinateSetCount": 0,
+        "selectedAtomCount": 0,
+        "residueCount": 0,
+        "hasResidues": False,
+        "hasUnitCell": False,
+        "hasCustomElements": False,
+        "hasBasisSet": False,
+        "orbitalCount": 0,
+        "homoIndex": -1,
+        "cubeCount": 0,
+        "vibrationCount": 0,
+        "fileName": "/path/to/caffeine.cml",
+    },
+    "getMolecule": _default_get_molecule,
+    "renderImage": _default_render_image,
+    "listDisplayTypes": [
+        {
+            "name": "BallStick",
+            "displayName": "Ball and Stick",
+            "enabled": True,
+            "applicable": True,
+            "hasSettings": True,
+        },
+        {
+            "name": "Wireframe",
+            "displayName": "Wireframe",
+            "enabled": False,
+            "applicable": True,
+            "hasSettings": False,
+        },
+    ],
+    "setRenderTypes": True,
+    "setProjection": True,
+    "openFile": True,
+    "loadMolecule": True,
+    "saveGraphic": True,
+    "exportFile": _default_export_file,
+    "kill": True,
+}
+
+
+class FakeRPCServer:
+    """
+    A background-thread Unix-socket server that answers JSON-RPC 2.0
+    requests framed the way Avogadro frames them.
+
+    Use it as a context manager, or call start()/stop() directly::
+
+        with FakeRPCServer() as server:
+            server.set_error("openFile", -1, "No such file.")
+            ...
+
+    Every request the server receives is recorded in ``self.requests``
+    (the parsed JSON-RPC objects, in order) so a test can assert on what
+    was sent, not just what came back.
+
+    :param name: The socket name, i.e. the file is
+        ``$TMPDIR/<name>``, matching what ``avogadro.connect.connect``
+        expects for its ``name`` argument. Defaults to a random name so
+        parallel test runs, and a real running Avogadro, never collide.
+    :param responses: Extra or overriding canned responses, merged over
+        DEFAULT_RESPONSES. Same shape: method name -> value or
+        callable(params) -> value.
+    """
+
+    def __init__(self, name=None, responses=None):
+        self.name = name or ("avogadro-test-%s" % uuid.uuid4().hex[:8])
+        self.path = os.path.join(tempfile.gettempdir(), self.name)
+        self._responses = dict(DEFAULT_RESPONSES)
+        if responses:
+            self._responses.update(responses)
+        self._overrides = {}
+        self.requests = []
+        self._socket = None
+        self._thread = None
+        self._stop = threading.Event()
+
+    def set_result(self, method, result):
+        """Answer the next (and all subsequent) calls to method with result."""
+        self._overrides[method] = ("result", result)
+
+    def set_error(self, method, code, message, data=None):
+        """
+        Answer calls to method with a JSON-RPC error instead of a result.
+
+        :param code: One of the RPCError codes, e.g. -1, -2, -3, -32601.
+        :param message: The error message text.
+        :param data: Optional extra error data.
+        """
+        self._overrides[method] = ("error", (code, message, data))
+
+    def clear_override(self, method):
+        """Go back to the default canned response for method."""
+        self._overrides.pop(method, None)
+
+    def start(self):
+        """Bind the socket and start answering requests in a background thread."""
+        if sys.platform.startswith("win"):
+            raise NotImplementedError(
+                "FakeRPCServer only implements the Unix domain socket "
+                "transport; there is no named-pipe variant yet."
+            )
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._socket.bind(self.path)
+        self._socket.listen(1)
+        self._socket.settimeout(0.5)
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self):
+        """Stop answering requests and remove the socket file."""
+        self._stop.set()
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+            self._socket = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+        return False
+
+    # -- internals ---------------------------------------------------
+
+    def _serve(self):
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            try:
+                self._handle_connection(conn)
+            finally:
+                conn.close()
+
+    def _handle_connection(self, conn):
+        conn.settimeout(5.0)
+        while not self._stop.is_set():
+            header = self._recv_exactly(conn, 4)
+            if header is None:
+                return
+            (size,) = struct.unpack(">I", header)
+            body = self._recv_exactly(conn, size)
+            if body is None:
+                return
+            request = json.loads(body.decode("utf-8"))
+            self.requests.append(request)
+            reply = self._build_reply(request)
+            payload = json.dumps(reply).encode("utf-8")
+            conn.sendall(struct.pack(">I", len(payload)) + payload)
+
+    @staticmethod
+    def _recv_exactly(conn, size):
+        """Read exactly size bytes, or None if the peer closes early."""
+        if size == 0:
+            return b""
+        chunks = []
+        remaining = size
+        while remaining > 0:
+            try:
+                chunk = conn.recv(remaining)
+            except (socket.timeout, OSError):
+                return None
+            if not chunk:
+                return None
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _build_reply(self, request):
+        method = request.get("method")
+        params = request.get("params") or {}
+        reply = {"jsonrpc": "2.0", "id": request.get("id")}
+
+        if method in self._overrides:
+            kind, payload = self._overrides[method]
+            if kind == "error":
+                code, message, data = payload
+                error = {"code": code, "message": message}
+                if data is not None:
+                    error["data"] = data
+                reply["error"] = error
+            else:
+                reply["result"] = payload
+            return reply
+
+        if method not in self._responses:
+            reply["error"] = {
+                "code": -32601,
+                "message": "Method not found",
+                "data": {"request": {"method": method, "params": params}},
+            }
+            return reply
+
+        responder = self._responses[method]
+        reply["result"] = responder(params) if callable(responder) else responder
+        return reply

--- a/python/tests/fake_rpc_server.py
+++ b/python/tests/fake_rpc_server.py
@@ -293,9 +293,17 @@ class FakeRPCServer:
     # -- internals ---------------------------------------------------
 
     def _serve(self):
+        # Bind the listening socket to a local first: stop() runs on another
+        # thread and clears self._socket right after setting the stop flag,
+        # so reading the attribute inside the loop can come back None between
+        # the flag check and the accept() call. Once stop() closes it, the
+        # accept below raises OSError and the thread returns as before.
+        server = self._socket
+        if server is None:
+            return
         while not self._stop.is_set():
             try:
-                conn, _ = self._socket.accept()
+                conn, _ = server.accept()
             except socket.timeout:
                 continue
             except OSError:

--- a/python/tests/test_connect_errors.py
+++ b/python/tests/test_connect_errors.py
@@ -1,0 +1,71 @@
+"""
+Tests that RPCError is raised with the right code/message/data for every
+documented failure, across a representative set of the new helpers plus
+the general send()/command() entry points.
+"""
+
+import pytest
+
+from _load_avogadro import load_connect_module
+
+_mod = load_connect_module()
+RPCError = _mod.RPCError
+
+
+def test_command_could_not_be_carried_out(avo, fake_server):
+    # -1: "could not be carried out" -- no molecule open, bad path, etc.
+    fake_server.set_error("getMolecule", -1, "No molecule is open.")
+    with pytest.raises(RPCError) as excinfo:
+        avo.get_molecule()
+    assert excinfo.value.code == -1
+    assert excinfo.value.message == "No molecule is open."
+
+
+def test_command_failed_or_timed_out(avo, fake_server):
+    fake_server.set_error(
+        "renderImage", RPCError.COMMAND_FAILED, "The command timed out."
+    )
+    with pytest.raises(RPCError) as excinfo:
+        avo.render_image()
+    assert excinfo.value.code == -2
+    assert excinfo.value.code == RPCError.COMMAND_FAILED
+
+
+def test_plugin_busy(avo, fake_server):
+    fake_server.set_error(
+        "exportFile",
+        RPCError.PLUGIN_BUSY,
+        "That plugin is already running a command.",
+    )
+    with pytest.raises(RPCError) as excinfo:
+        avo.export_file("/tmp/out.cml")
+    assert excinfo.value.code == -3
+    assert excinfo.value.code == RPCError.PLUGIN_BUSY
+
+
+def test_method_not_found(avo, fake_server):
+    # No override needed -- any method the fake server's table does not
+    # know about behaves like an older Avogadro build that predates it.
+    with pytest.raises(RPCError) as excinfo:
+        avo.send("aFutureMethodThisBuildDoesNotHave")
+    assert excinfo.value.code == -32601
+    assert excinfo.value.code == RPCError.METHOD_NOT_FOUND
+
+
+def test_version_method_not_found_means_protocol_1(avo, fake_server):
+    # Appendix A: a build old enough to lack `version` raises
+    # METHOD_NOT_FOUND, and callers are told to assume rpcProtocol 1.
+    fake_server.clear_override("version")
+    fake_server._responses.pop("version", None)
+    with pytest.raises(RPCError) as excinfo:
+        avo.version()
+    assert excinfo.value.code == RPCError.METHOD_NOT_FOUND
+
+
+def test_error_data_is_preserved(avo, fake_server):
+    fake_server.set_error(
+        "getMolecule", -1, "Unknown format.", data={"format": "bogus"}
+    )
+    with pytest.raises(RPCError) as excinfo:
+        avo.get_molecule(format="bogus")
+    assert excinfo.value.data == {"format": "bogus"}

--- a/python/tests/test_connect_helpers.py
+++ b/python/tests/test_connect_helpers.py
@@ -1,0 +1,115 @@
+"""
+Happy-path tests for the phase 1 introspection helpers on
+avogadro.connect.connect, against the fake RPC server.
+"""
+
+from _load_avogadro import load_connect_module
+
+_mod = load_connect_module()
+result_data = _mod.result_data
+
+
+def test_version(avo):
+    info = avo.version()
+    assert info == {
+        "avogadroApp": "1.103.0",
+        "avogadroLibs": "2.0.0",
+        "qt": "6.8.3",
+        "platform": "macos",
+        "rpcProtocol": 2,
+    }
+
+
+def test_list_commands(avo):
+    commands = avo.list_commands()
+    assert isinstance(commands, list)
+    names = {entry["name"] for entry in commands}
+    assert "openFile" in names
+    assert "renderMO" in names
+    for entry in commands:
+        assert set(entry) == {
+            "name",
+            "description",
+            "kind",
+            "plugin",
+            "async",
+            "schema",
+        }
+        assert entry["kind"] in ("builtin", "tool", "extension")
+
+
+def test_molecule_info(avo):
+    info = avo.molecule_info()
+    assert info["atomCount"] == 24
+    assert info["formula"] == "C8H10N4O2"
+    assert info["homoIndex"] == -1
+    assert info["hasResidues"] is False
+
+
+def test_get_molecule_default_format(avo, fake_server):
+    content = avo.get_molecule()
+    assert content == '{"chemical json": 1, "atoms": {}}'
+    request = fake_server.requests[-1]
+    assert request["method"] == "getMolecule"
+    # Default format is applied by the server when the client omits it,
+    # but connect.get_molecule() always sends one explicitly.
+    assert request["params"]["format"] == "cjson"
+
+
+def test_get_molecule_explicit_format(avo, fake_server):
+    avo.get_molecule(format="xyz")
+    request = fake_server.requests[-1]
+    assert request["params"]["format"] == "xyz"
+
+
+def test_list_display_types(avo):
+    types_ = avo.list_display_types()
+    names = {entry["name"] for entry in types_}
+    assert names == {"BallStick", "Wireframe"}
+    ball_stick = next(t for t in types_ if t["name"] == "BallStick")
+    assert ball_stick["enabled"] is True
+    assert ball_stick["applicable"] is True
+    assert ball_stick["hasSettings"] is True
+
+
+def test_set_display_types_with_list(avo, fake_server):
+    avo.set_display_types(["BallStick", "VanDerWaals"])
+    request = fake_server.requests[-1]
+    assert request["method"] == "setRenderTypes"
+    assert request["params"] == {"types": ["BallStick", "VanDerWaals"]}
+
+
+def test_set_display_types_with_dict(avo, fake_server):
+    avo.set_display_types({"BallStick": True, "Wireframe": False})
+    request = fake_server.requests[-1]
+    assert request["params"] == {"BallStick": True, "Wireframe": False}
+
+
+def test_set_projection(avo, fake_server):
+    avo.set_projection("orthographic")
+    request = fake_server.requests[-1]
+    assert request["method"] == "setProjection"
+    assert request["params"] == {"type": "orthographic"}
+
+
+def test_export_file_waits_by_default(avo, fake_server):
+    data = avo.export_file("/tmp/out.cml")
+    assert data == {"fileName": "/tmp/out.cml"}
+    request = fake_server.requests[-1]
+    assert request["method"] == "exportFile"
+    assert request["params"]["fileName"] == "/tmp/out.cml"
+    assert request["params"]["wait"] is True
+
+
+def test_export_file_wait_false_returns_raw_response(avo, fake_server):
+    response = avo.export_file("/tmp/out.cml", wait=False)
+    assert response["result"] is True
+    request = fake_server.requests[-1]
+    assert "wait" not in request["params"]
+
+
+def test_export_file_wait_true_uses_result_data(avo, fake_server):
+    # export_file() with wait=True should agree with what a caller doing
+    # this by hand through send()/result_data() would see.
+    response = avo.send("exportFile", {"fileName": "/tmp/x.cml"}, wait=True)
+    assert result_data(response) == {"fileName": "/tmp/x.cml"}

--- a/python/tests/test_framing.py
+++ b/python/tests/test_framing.py
@@ -1,0 +1,120 @@
+"""
+Tests for the length-prefix wire framing itself -- the part most likely
+to be subtly wrong, per the MCP bridge plan. A reply larger than what a
+single recv() call returns must still be read correctly.
+
+Two angles are covered:
+
+* A unit test that feeds connect._read_exactly()/._read() a hostile
+  transport that only ever hands back a few bytes per call, regardless
+  of how much was asked for. This is deterministic -- it does not depend
+  on OS socket buffer sizes, which vary by platform and are not under
+  test control.
+* An end-to-end test through a real Unix domain socket and the fake
+  server, with a payload large enough (multiple MB) that it is for all
+  practical purposes certain to arrive across more than one recv() on
+  every platform this runs on, as a realistic check that the two halves
+  agree with each other.
+"""
+
+import json
+import struct
+
+from _load_avogadro import load_connect_module
+
+_mod = load_connect_module()
+connect = _mod.connect
+
+
+class _ChunkedSocket:
+    """
+    A minimal socket stand-in that hands back only a few bytes per call,
+    no matter how much the caller asked for. A read loop that assumes one
+    recv() returns everything it asked for will read truncated or garbled
+    data against this.
+    """
+
+    def __init__(self, data, chunk_size=3):
+        self._data = data
+        self._chunk_size = chunk_size
+        self._pos = 0
+        self.recv_calls = 0
+
+    def recv(self, size):
+        self.recv_calls += 1
+        if self._pos >= len(self._data):
+            return b""
+        end = min(self._pos + min(size, self._chunk_size), len(self._data))
+        chunk = self._data[self._pos : end]
+        self._pos = end
+        return chunk
+
+    def settimeout(self, *_args, **_kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+def _make_client_with_socket(sock):
+    """A connect instance wired to a fake socket, bypassing __init__ (and
+    therefore the real network connection it would otherwise make)."""
+    client = connect.__new__(connect)
+    client._windows = False
+    client.sock = sock
+    return client
+
+
+def test_read_exactly_survives_many_short_reads():
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"blob": "x" * 5000}}
+    body = json.dumps(payload).encode("utf-8")
+    packet = struct.pack(">I", len(body)) + body
+
+    sock = _ChunkedSocket(packet, chunk_size=7)
+    client = _make_client_with_socket(sock)
+
+    response = client._read()
+
+    assert response == payload
+    # Sanity: this really did require multiple recv() calls, i.e. the
+    # test is actually exercising the loop and not a lucky single read.
+    assert sock.recv_calls > len(packet) / 7
+
+
+def test_read_exactly_handles_reads_that_split_the_length_header():
+    # The 4-byte length header itself can arrive split across recv()
+    # calls -- a chunk size smaller than 4 forces that.
+    payload = {"jsonrpc": "2.0", "id": 2, "result": True}
+    body = json.dumps(payload).encode("utf-8")
+    packet = struct.pack(">I", len(body)) + body
+
+    sock = _ChunkedSocket(packet, chunk_size=1)
+    client = _make_client_with_socket(sock)
+
+    response = client._read()
+
+    assert response == payload
+
+
+def test_large_reply_over_a_real_socket(avo, fake_server):
+    # A multi-megabyte listCommands reply, round-tripped through the real
+    # Unix domain socket connect() actually uses, and the fake server's
+    # real send loop -- not just the unit-level mock above.
+    big_commands = [
+        {
+            "name": "command%05d" % i,
+            "description": "Test command number %d." % i,
+            "kind": "extension",
+            "plugin": "FakePlugin",
+            "async": False,
+            "schema": {},
+        }
+        for i in range(20000)
+    ]
+    fake_server.set_result("listCommands", big_commands)
+
+    commands = avo.list_commands()
+
+    assert len(commands) == len(big_commands)
+    assert commands[0]["name"] == "command00000"
+    assert commands[-1]["name"] == "command19999"

--- a/python/tests/test_render_image.py
+++ b/python/tests/test_render_image.py
@@ -1,0 +1,51 @@
+"""
+Tests for connect.render_image(), which has two reply shapes: inline
+base64-encoded PNG bytes when no filename is given, and a small dict
+reporting where the file was written when one is.
+"""
+
+import base64
+
+from fake_rpc_server import TINY_PNG_BYTES
+
+
+def test_render_image_inline_returns_real_png_bytes(avo, fake_server):
+    data = avo.render_image()
+    assert isinstance(data, bytes)
+    # The fake server's canned reply is a real (if trivial) PNG; check the
+    # base64 round-trip landed on the exact same bytes, and that it is a
+    # real PNG (starts with the PNG signature), not just opaque data.
+    assert data == TINY_PNG_BYTES
+    assert data[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_render_image_inline_request_shape(avo, fake_server):
+    avo.render_image(width=800, height=600, transparent=True)
+    request = fake_server.requests[-1]
+    assert request["method"] == "renderImage"
+    assert request["params"] == {
+        "width": 800,
+        "height": 600,
+        "transparentBackground": True,
+    }
+
+
+def test_render_image_omits_unset_params(avo, fake_server):
+    avo.render_image()
+    request = fake_server.requests[-1]
+    assert request["params"] == {}
+
+
+def test_render_image_with_filename_returns_true(avo, fake_server):
+    result = avo.render_image(filename="/tmp/homo.png")
+    assert result is True
+    request = fake_server.requests[-1]
+    assert request["params"]["fileName"] == "/tmp/homo.png"
+
+
+def test_render_image_base64_matches_server_encoding(avo):
+    # Belt and braces: re-derive what the server sent and compare, rather
+    # than only trusting the shared TINY_PNG_BYTES constant.
+    expected = base64.b64encode(TINY_PNG_BYTES)
+    data = avo.render_image()
+    assert base64.b64encode(data) == expected


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Python connection API with molecule retrieval and information tools.
  * Added version and available-command discovery.
  * Added image rendering with configurable dimensions, transparency, and file output.
  * Added display-type, projection, and camera controls.
  * Added support for waiting for export results and retrieving command response data.
  * Improved command handling when commands use a `name` option.
* **Bug Fixes**
  * Improved reliability when receiving large responses or data split across multiple network reads.
  * Added clearer handling and propagation of remote operation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->