### PR TITLE
Some fixes for the 'generic output' fail on Windows

### DIFF
--- a/avogadro/qtplugins/openbabel/obprocess.cpp
+++ b/avogadro/qtplugins/openbabel/obprocess.cpp
@@ -145,7 +145,11 @@ void OBProcess::queryReadFormatsPrepare()
   int pos = 0;
   while ((match = parser.match(output, pos)).hasMatch()) {
     QString extension = match.captured(1);
-    QString description = match.captured(2);
+    // obabel writes its format list in text mode, so on Windows every line
+    // ends "\r\n" and the description captures the carriage return. That CR
+    // then rides along into the format name and identifier, breaking both the
+    // display strings and any comparison against them.
+    QString description = match.captured(2).trimmed();
     result.insertMulti(description, extension);
     pos = match.capturedEnd(0);
   }
@@ -171,7 +175,11 @@ void OBProcess::queryWriteFormatsPrepare()
   int pos = 0;
   while ((match = parser.match(output, pos)).hasMatch()) {
     QString extension = match.captured(1);
-    QString description = match.captured(2);
+    // obabel writes its format list in text mode, so on Windows every line
+    // ends "\r\n" and the description captures the carriage return. That CR
+    // then rides along into the format name and identifier, breaking both the
+    // display strings and any comparison against them.
+    QString description = match.captured(2).trimmed();
 
     // skip some formats that we want to ignore
     if (extension == "png" || extension == "svg" || extension == "paint" ||
@@ -280,7 +288,9 @@ void OBProcess::queryForceFieldsPrepare()
   int pos = 0;
   while ((match = parser.match(output, pos)).hasMatch()) {
     QString key = match.captured(1);
-    QString desc = match.captured(2);
+    // Trimmed for the same reason as the format descriptions above: obabel's
+    // text-mode output leaves a carriage return on every line under Windows.
+    QString desc = match.captured(2).trimmed();
     result.insertMulti(key, desc);
     pos = match.capturedEnd(0);
   }
@@ -320,7 +330,9 @@ void OBProcess::queryChargesPrepare()
   int pos = 0;
   while ((match = parser.match(output, pos)).hasMatch()) {
     QString key = match.captured(1);
-    QString desc = match.captured(2);
+    // Trimmed for the same reason as the format descriptions above: obabel's
+    // text-mode output leaves a carriage return on every line under Windows.
+    QString desc = match.captured(2).trimmed();
     result.insertMulti(key, desc);
     pos = match.capturedEnd(0);
   }

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -39,8 +39,16 @@ bool startsWith(const std::string& text, const std::string& prefix)
  */
 std::string lowerExtension(const std::string& fileName)
 {
+  // Only a dot in the last path component names an extension. Searching the
+  // whole path would read "C:\work.v1\gaussian-output" as the extension
+  // "v1\gaussian-output"; both separators are checked because a Windows path
+  // can use either.
+  const std::string::size_type separator = fileName.find_last_of("/\\");
+  const std::string::size_type start =
+    (separator == std::string::npos) ? 0 : separator + 1;
+
   const std::string::size_type dot = fileName.find_last_of('.');
-  if (dot == std::string::npos || dot + 1 >= fileName.size())
+  if (dot == std::string::npos || dot < start || dot + 1 >= fileName.size())
     return std::string();
 
   std::string extension = fileName.substr(dot + 1);

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -164,7 +164,7 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
     for (const FileFormat* candidate : candidates) {
       if (candidate->name() == "cclib") { // avogadro-cclib plugin
         reader = candidate->newInstance();
-        detected = "the cclib plugin";
+        detected = "cclib plugin";
         break;
       }
     }
@@ -219,14 +219,9 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
     std::ostringstream error;
     error << "Could not determine the program used to generate this output "
              "file.\n"
-          << "Scanned " << lineCount << " line" << (lineCount == 1 ? "" : "s")
-          << " for the built-in GAMESS-US, Molden, NWChem, ORCA and xtb "
-             "signatures without a match.\n"
           << "No fallback reader is registered for \"." << extension
           << "\" files: neither the cclib plugin nor an Open Babel format "
              "was found.\n"
-          << "Formats registered for \"." << extension
-          << "\": " << identifierList(candidates) << "\n"
           << "Install the cclib plugin, or check that Open Babel is available, "
              "then reopen the file.";
     appendError(error.str());

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -59,24 +59,6 @@ std::string lowerExtension(const std::string& fileName)
   return extension;
 }
 
-/**
- * A comma-separated list of the identifiers in @a formats, for the failure
- * message: knowing which readers were even registered is the difference
- * between "this file is unsupported" and "your plugins did not load".
- */
-std::string identifierList(const std::vector<const FileFormat*>& formats)
-{
-  std::string list;
-  for (const FileFormat* format : formats) {
-    if (format == nullptr)
-      continue;
-    if (!list.empty())
-      list += ", ";
-    list += format->identifier();
-  }
-  return list.empty() ? std::string("(none)") : list;
-}
-
 } // namespace
 
 GenericOutput::GenericOutput() {}
@@ -111,9 +93,7 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
   std::string detected;
 
   std::string line;
-  size_t lineCount = 0;
   while (std::getline(in, line)) {
-    ++lineCount;
     if (line.find("Northwest Computational Chemistry Package") !=
         std::string::npos) {
       // NWChem

--- a/avogadro/quantumio/genericoutput.cpp
+++ b/avogadro/quantumio/genericoutput.cpp
@@ -14,9 +14,62 @@
 #include "nwchemlog.h"
 #include "orca.h"
 
-#include <iostream>
+#include <algorithm>
+#include <cctype>
+#include <sstream>
 
 namespace Avogadro::QuantumIO {
+
+namespace {
+
+using Io::FileFormat;
+
+bool startsWith(const std::string& text, const std::string& prefix)
+{
+  return text.size() >= prefix.size() &&
+         text.compare(0, prefix.size(), prefix) == 0;
+}
+
+/**
+ * The lower-cased extension of @a fileName, without the dot, or an empty
+ * string if there is none. Delegates are looked up by extension, and ".log"
+ * and ".out" do not map to the same set of formats, so the real extension
+ * matters. Windows users routinely have ".LOG" and ".OUT" files, and the
+ * format map is keyed on lower case.
+ */
+std::string lowerExtension(const std::string& fileName)
+{
+  const std::string::size_type dot = fileName.find_last_of('.');
+  if (dot == std::string::npos || dot + 1 >= fileName.size())
+    return std::string();
+
+  std::string extension = fileName.substr(dot + 1);
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char character) {
+                   return static_cast<char>(std::tolower(character));
+                 });
+  return extension;
+}
+
+/**
+ * A comma-separated list of the identifiers in @a formats, for the failure
+ * message: knowing which readers were even registered is the difference
+ * between "this file is unsupported" and "your plugins did not load".
+ */
+std::string identifierList(const std::vector<const FileFormat*>& formats)
+{
+  std::string list;
+  for (const FileFormat* format : formats) {
+    if (format == nullptr)
+      continue;
+    if (!list.empty())
+      list += ", ";
+    list += format->identifier();
+  }
+  return list.empty() ? std::string("(none)") : list;
+}
+
+} // namespace
 
 GenericOutput::GenericOutput() {}
 
@@ -46,49 +99,93 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
 {
   // check the stream line-by-line until we see the program name
   FileFormat* reader = nullptr;
+  // How the reader was chosen, so the error message can say what actually ran.
+  std::string detected;
 
   std::string line;
+  size_t lineCount = 0;
   while (std::getline(in, line)) {
+    ++lineCount;
     if (line.find("Northwest Computational Chemistry Package") !=
         std::string::npos) {
       // NWChem
       reader = new NWChemLog;
+      detected = "NWChem";
       break;
     } else if (line.find("GAMESS VERSION") != std::string::npos) {
       // GAMESS-US .. don't know if we can read Firefly or GAMESS-UK
       reader = new GAMESSUSOutput;
+      detected = "GAMESS-US";
       break;
     } else if (line.find("[Molden Format]") != std::string::npos) {
       // molden with .out extension
       reader = new MoldenFile;
+      detected = "Molden";
       break;
     } else if (line.find("O   R   C   A") != std::string::npos) {
       // ORCA reader
       reader = new ORCAOutput;
+      detected = "ORCA";
       break;
     } else if (line.find("xtb:") != std::string::npos) {
       // xtb reader
       reader = new Io::XyzFormat;
+      detected = "xtb";
       break;
     }
   }
 
+  // Look the fallbacks up under the extension actually being read: the
+  // sniffing above has already failed, so the delegate is chosen purely by
+  // extension, and Gaussian ".log" files are not registered under "out".
+  std::string extension = lowerExtension(fileName());
+  if (extension.empty())
+    extension = "out";
+
   // if we didn't find a program name, check for cclib or OpenBabel
-  // prefer cclib if it's available
+  std::vector<const FileFormat*> candidates;
   if (reader == nullptr) {
     // check what output is available
-    std::vector<const FileFormat*> readers =
-      Io::FileFormatManager::instance().fileFormatsFromFileExtension(
-        "out", FileFormat::File | FileFormat::Read);
+    candidates = Io::FileFormatManager::instance().fileFormatsFromFileExtension(
+      extension, FileFormat::File | FileFormat::Read);
 
-    // loop through readers to check for "cclib" or "Open Babel"
-    for (const FileFormat* r : readers) {
-      if (r->identifier().compare(0, 9, "OpenBabel") == 0) {
-        reader = r->newInstance();
+    // cclib recognizes more programs than the Open Babel readers do, so give
+    // it first refusal. Two passes, rather than one loop that stops at either:
+    // a single pass takes whichever happened to be registered first, which is
+    // Open Babel as often as not.
+    for (const FileFormat* candidate : candidates) {
+      if (candidate->name() == "cclib") { // avogadro-cclib plugin
+        reader = candidate->newInstance();
+        detected = "the cclib plugin";
         break;
-      } else if (r->name() == "cclib") { // avogadro-cclib plugin
-        reader = r->newInstance();
-        break;
+      }
+    }
+
+    if (reader == nullptr) {
+      // Open Babel's own "Generic Output file format" sniffs the file the
+      // same way this reader does and covers Gaussian, Q-Chem, MOPAC, PWSCF
+      // and more. Every other Open Babel format registered for this extension
+      // is tied to one program, so picking one of those at random hands the
+      // file to the wrong parser. Matched loosely, since the identifier is
+      // built from whatever description the installed obabel prints.
+      for (const FileFormat* candidate : candidates) {
+        const std::string candidateIdentifier = candidate->identifier();
+        if (startsWith(candidateIdentifier, "OpenBabel") &&
+            candidateIdentifier.find("Generic Output") != std::string::npos) {
+          reader = candidate->newInstance();
+          detected = "Open Babel";
+          break;
+        }
+      }
+    }
+
+    if (reader == nullptr) {
+      for (const FileFormat* candidate : candidates) {
+        if (startsWith(candidate->identifier(), "OpenBabel")) {
+          reader = candidate->newInstance();
+          detected = "Open Babel";
+          break;
+        }
       }
     }
   }
@@ -110,16 +207,53 @@ bool GenericOutput::read(std::istream& in, Core::Molecule& molecule)
   in.seekg(0, std::ios::beg);
   in.clear();
 
-  if (reader) {
-    bool success = reader->readFile(fileName(), molecule);
-    delete reader;
-    return success;
-  } else {
-    appendError(
-      "Could not determine the program used to generate this output file.");
+  if (reader == nullptr) {
+    std::ostringstream error;
+    error << "Could not determine the program used to generate this output "
+             "file.\n"
+          << "Scanned " << lineCount << " line" << (lineCount == 1 ? "" : "s")
+          << " for the built-in GAMESS-US, Molden, NWChem, ORCA and xtb "
+             "signatures without a match.\n"
+          << "No fallback reader is registered for \"." << extension
+          << "\" files: neither the cclib plugin nor an Open Babel format "
+             "was found.\n"
+          << "Formats registered for \"." << extension
+          << "\": " << identifierList(candidates) << "\n"
+          << "Install the cclib plugin, or check that Open Babel is available, "
+             "then reopen the file.";
+    appendError(error.str());
+    return false;
+  }
+
+  // Every delegate reads from the file rather than the stream, so a stream or
+  // string read has nothing to hand it. Say so instead of failing silently in
+  // FileFormat::open().
+  if (fileName().empty()) {
+    appendError("Detected " + detected + " (" + identifier +
+                "), but that reader needs a file path and this output was "
+                "read from a stream.");
     delete reader;
     return false;
   }
+
+  const bool success = reader->readFile(fileName(), molecule);
+  if (!success) {
+    std::ostringstream error;
+    error << "Detected " << detected << ", but reading \"" << fileName()
+          << "\" with \"" << identifier << "\" failed.";
+    appendError(error.str());
+
+    // Whatever the delegate itself has to say is the most specific
+    // information available - pass it through rather than dropping it.
+    const std::string readerError = reader->error();
+    if (!readerError.empty())
+      appendError(readerError, false);
+    else
+      appendError("The reader did not report a reason.", false);
+  }
+
+  delete reader;
+  return success;
 }
 
 } // namespace Avogadro::QuantumIO

--- a/tests/quantumio/CMakeLists.txt
+++ b/tests/quantumio/CMakeLists.txt
@@ -3,6 +3,7 @@ set(tests
   cube
   fchk
   gaussiansettools
+  genericoutput
   molden
   mopacaux
   nwchemlog
@@ -53,6 +54,9 @@ foreach(TestName ${tests})
   elseif(TestName STREQUAL "gaussiansettools")
     add_test(NAME "QuantumIo-gaussiansettools"
       COMMAND AvogadroQuantumIOTests "--gtest_filter=GaussianSetToolsTest.*")
+  elseif(TestName STREQUAL "genericoutput")
+    add_test(NAME "QuantumIo-genericoutput"
+      COMMAND AvogadroQuantumIOTests "--gtest_filter=GenericOutputTest.*")
   elseif(TestName STREQUAL "molden")
     add_test(NAME "QuantumIo-molden"
       COMMAND AvogadroQuantumIOTests "--gtest_filter=MoldenTest.*")

--- a/tests/quantumio/genericoutputtest.cpp
+++ b/tests/quantumio/genericoutputtest.cpp
@@ -50,12 +50,14 @@ bool contains(const std::string& haystack, const std::string& needle)
 } // namespace
 
 // A file nothing recognizes used to fail with one sentence that named neither
-// the file, the readers that were tried, nor the ones that were missing, which
-// left "cannot open Gaussian output" bug reports with nothing to go on.
+// the file nor the readers that were missing, which left "cannot open Gaussian
+// output" bug reports with nothing to go on. Both fallbacks have to be named:
+// which one is absent is what tells a user whether to install the cclib plugin
+// or to go looking for Open Babel.
 //
 // The fixture is deliberately ".LOG": the format map is keyed on lower case,
 // and Windows users routinely have upper-case extensions.
-TEST(GenericOutputTest, unrecognizedOutputSaysWhatWasTried)
+TEST(GenericOutputTest, unrecognizedOutputNamesTheMissingFallbacks)
 {
   TemporaryFile fixture("genericoutput-unrecognized.LOG",
                         "Entering Link 1\nsome program we do not know\n");
@@ -65,11 +67,7 @@ TEST(GenericOutputTest, unrecognizedOutputSaysWhatWasTried)
   EXPECT_FALSE(reader.readFile(fixture.name(), molecule));
 
   const std::string error = reader.error();
-  // The built-in signatures that were checked...
-  EXPECT_TRUE(contains(error, "GAMESS-US"));
-  EXPECT_TRUE(contains(error, "NWChem"));
-  EXPECT_TRUE(contains(error, "ORCA"));
-  // ...and the fallbacks that were not available.
+  // The fallbacks that were not available.
   EXPECT_TRUE(contains(error, "cclib"));
   EXPECT_TRUE(contains(error, "Open Babel"));
   // The delegate is looked up by the real extension, not a hard-coded "out",

--- a/tests/quantumio/genericoutputtest.cpp
+++ b/tests/quantumio/genericoutputtest.cpp
@@ -52,9 +52,12 @@ bool contains(const std::string& haystack, const std::string& needle)
 // A file nothing recognizes used to fail with one sentence that named neither
 // the file, the readers that were tried, nor the ones that were missing, which
 // left "cannot open Gaussian output" bug reports with nothing to go on.
+//
+// The fixture is deliberately ".LOG": the format map is keyed on lower case,
+// and Windows users routinely have upper-case extensions.
 TEST(GenericOutputTest, unrecognizedOutputSaysWhatWasTried)
 {
-  TemporaryFile fixture("genericoutput-unrecognized.log",
+  TemporaryFile fixture("genericoutput-unrecognized.LOG",
                         "Entering Link 1\nsome program we do not know\n");
 
   GenericOutput reader;
@@ -69,7 +72,8 @@ TEST(GenericOutputTest, unrecognizedOutputSaysWhatWasTried)
   // ...and the fallbacks that were not available.
   EXPECT_TRUE(contains(error, "cclib"));
   EXPECT_TRUE(contains(error, "Open Babel"));
-  // The delegate is looked up by the real extension, not a hard-coded "out".
+  // The delegate is looked up by the real extension, not a hard-coded "out",
+  // and the extension is folded to lower case before the lookup.
   EXPECT_TRUE(contains(error, "\".log\""));
 }
 

--- a/tests/quantumio/genericoutputtest.cpp
+++ b/tests/quantumio/genericoutputtest.cpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "quantumiotests.h"
+
+#include <gtest/gtest.h>
+
+#include <avogadro/core/molecule.h>
+
+#include <avogadro/quantumio/genericoutput.h>
+#include <avogadro/quantumio/orca.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+using Avogadro::Core::Molecule;
+using Avogadro::QuantumIO::GenericOutput;
+using Avogadro::QuantumIO::ORCAOutput;
+
+namespace {
+
+// The reader picks its delegate from the file name's extension, so the
+// fixtures have to be real files with real extensions rather than strings.
+class TemporaryFile
+{
+public:
+  TemporaryFile(const std::string& name, const std::string& contents)
+    : m_name(name)
+  {
+    std::ofstream file(m_name.c_str());
+    file << contents;
+  }
+
+  ~TemporaryFile() { std::remove(m_name.c_str()); }
+
+  const std::string& name() const { return m_name; }
+
+private:
+  std::string m_name;
+};
+
+bool contains(const std::string& haystack, const std::string& needle)
+{
+  return haystack.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+// A file nothing recognizes used to fail with one sentence that named neither
+// the file, the readers that were tried, nor the ones that were missing, which
+// left "cannot open Gaussian output" bug reports with nothing to go on.
+TEST(GenericOutputTest, unrecognizedOutputSaysWhatWasTried)
+{
+  TemporaryFile fixture("genericoutput-unrecognized.log",
+                        "Entering Link 1\nsome program we do not know\n");
+
+  GenericOutput reader;
+  Molecule molecule;
+  EXPECT_FALSE(reader.readFile(fixture.name(), molecule));
+
+  const std::string error = reader.error();
+  // The built-in signatures that were checked...
+  EXPECT_TRUE(contains(error, "GAMESS-US"));
+  EXPECT_TRUE(contains(error, "NWChem"));
+  EXPECT_TRUE(contains(error, "ORCA"));
+  // ...and the fallbacks that were not available.
+  EXPECT_TRUE(contains(error, "cclib"));
+  EXPECT_TRUE(contains(error, "Open Babel"));
+  // The delegate is looked up by the real extension, not a hard-coded "out".
+  EXPECT_TRUE(contains(error, "\".log\""));
+}
+
+// When a delegate is found but fails, its own diagnosis is the most specific
+// thing available: it used to be discarded, leaving the dialog empty.
+TEST(GenericOutputTest, delegateErrorIsPropagated)
+{
+  TemporaryFile fixture("genericoutput-truncated-orca.out",
+                        "           * O   R   C   A *\n\ntruncated\n");
+
+  ORCAOutput orca;
+  Molecule orcaMolecule;
+  ASSERT_FALSE(orca.readFile(fixture.name(), orcaMolecule));
+  const std::string orcaError = orca.error();
+  ASSERT_FALSE(orcaError.empty());
+
+  GenericOutput reader;
+  Molecule molecule;
+  EXPECT_FALSE(reader.readFile(fixture.name(), molecule));
+
+  const std::string error = reader.error();
+  // Which reader ran, on which file, and what it said.
+  EXPECT_TRUE(contains(error, "ORCA"));
+  EXPECT_TRUE(contains(error, fixture.name()));
+  EXPECT_TRUE(contains(error, orcaError));
+  EXPECT_EQ(reader.identifier(), std::string("Avogadro: Orca"));
+}
+
+// A file that does parse must stay silent - the new messages are only built on
+// the failure paths.
+TEST(GenericOutputTest, recognizedOutputReadsWithoutError)
+{
+  GenericOutput reader;
+  Molecule molecule;
+  ASSERT_TRUE(
+    reader.readFile(AVOGADRO_DATA "/data/nwchem/auh2o.out", molecule));
+  EXPECT_EQ(reader.error(), std::string());
+  EXPECT_EQ(reader.identifier(), std::string("Avogadro: NWChem"));
+  EXPECT_EQ(molecule.atomCount(), 7);
+}


### PR DESCRIPTION
Should fix #2787

I won't merge until someone can test the branch for a full fix

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quantum chemistry output-file detection and reader selection, including support for file extensions and preference for compatible readers.
  - Added clearer error messages when files are unrecognized, no file path is available, or parsing fails.
  - Fixed stray carriage returns in Open Babel format, force-field, and charge descriptions, improving display and comparisons on Windows.

- **Tests**
  - Added coverage for successful parsing, reader selection, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->