### PR TITLE
Fix bug with underflow on reading a Q-Chem cube file

### DIFF
--- a/avogadro/core/utilities.h
+++ b/avogadro/core/utilities.h
@@ -185,6 +185,33 @@ inline std::optional<double> lexicalCast(const std::string& inputString)
 }
 
 /**
+ * @brief Cast the inputString to a float, tolerating out of range exponents.
+ *
+ * The stream extractor for float rejects a merely subnormal result, because
+ * strtof reports underflow as ERANGE. Quantum chemistry codes routinely write
+ * the decaying tail of a density or an orbital with exponents past FLT_MIN
+ * (e.g. "1.505124610E-39"), so the generic template above would discard a
+ * value that is effectively zero. Delegate to the double overload, which
+ * already separates a range error from a genuine parse failure, then narrow --
+ * clamping so that a magnitude beyond float cannot become an infinity.
+ */
+template <>
+inline std::optional<float> lexicalCast(const std::string& inputString)
+{
+  const std::optional<double> value = lexicalCast<double>(inputString);
+  if (!value)
+    return std::nullopt;
+
+  constexpr double floatMax =
+    static_cast<double>(std::numeric_limits<float>::max());
+  if (*value > floatMax)
+    return std::numeric_limits<float>::max();
+  if (*value < -floatMax)
+    return std::numeric_limits<float>::lowest();
+  return static_cast<float>(*value);
+}
+
+/**
  * @brief Cast the inputString to the specified type.
  * @param inputString String to cast to the specified type.
  * @param ok Set to true on success, and false if the string could not be

--- a/avogadro/quantumio/gaussiancube.cpp
+++ b/avogadro/quantumio/gaussiancube.cpp
@@ -9,9 +9,13 @@
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/utilities.h>
 
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <string>
 
 namespace Avogadro::QuantumIO {
 
@@ -37,6 +41,58 @@ bool hasMinimumRemainingBytes(std::istream& in, size_t minBytes)
 
   const size_t remaining = static_cast<size_t>(end - pos);
   return remaining >= minBytes;
+}
+
+/**
+ * Read one grid value into the float a Core::Cube stores.
+ *
+ * Extracting straight into a float discards valid files: strtof reports an
+ * underflow to subnormal as ERANGE, and the extractor turns that into failbit
+ * even though the value parsed correctly. Codes such as Q-Chem write the
+ * decaying tail of a density with exponents past FLT_MIN ("1.505124610E-39"),
+ * which would abort the read a handful of values from the end.
+ *
+ * Parse the token with strtod instead, which lets a range error be told apart
+ * from a genuine parse failure. Core::lexicalCast<double> applies the same
+ * rule, but builds an istringstream per value -- far too costly for a loop
+ * that runs once per grid point -- so the range handling is repeated here.
+ * Keep the two consistent.
+ */
+bool readCubeValue(std::istream& in, std::string& token, float& value)
+{
+  if (!(in >> token))
+    return false;
+
+  const char* first = token.c_str();
+  char* last = nullptr;
+  errno = 0;
+  double parsed = std::strtod(first, &last);
+
+  // Reject anything that is not a number, or that stopped short of the end of
+  // the token ("1.5abc", the "*******" some codes emit on overflow).
+  if (last != first + token.size())
+    return false;
+
+  if (errno == ERANGE) {
+    // Underflow leaves a zero or subnormal result, which is what we want. Only
+    // an overflow needs clamping, so that later arithmetic cannot see it.
+    if (std::isinf(parsed))
+      parsed = (parsed > 0.0) ? std::numeric_limits<double>::max()
+                              : std::numeric_limits<double>::lowest();
+  } else if (!std::isfinite(parsed)) {
+    // The literals "nan" and "inf" parse cleanly but have no meaning on a grid.
+    return false;
+  }
+
+  constexpr double floatMax =
+    static_cast<double>(std::numeric_limits<float>::max());
+  if (parsed > floatMax)
+    parsed = floatMax;
+  else if (parsed < -floatMax)
+    parsed = -floatMax;
+
+  value = static_cast<float>(parsed);
+  return true;
 }
 } // namespace
 
@@ -233,8 +289,9 @@ bool GaussianCube::read(std::istream& in, Core::Molecule& molecule)
     }
     if (values->size() != valueCount)
       values->resize(valueCount);
+    std::string token;
     for (size_t index = 0; index < valueCount; ++index) {
-      if (!(in >> (*values)[index])) {
+      if (!readCubeValue(in, token, (*values)[index])) {
         appendError("Invalid cube data.");
         return false;
       }

--- a/tests/core/utilitiestest.cpp
+++ b/tests/core/utilitiestest.cpp
@@ -7,6 +7,8 @@
 
 #include <avogadro/core/utilities.h>
 
+#include <limits>
+
 using Avogadro::Core::contains;
 using Avogadro::Core::lexicalCast;
 using Avogadro::Core::split;
@@ -68,6 +70,38 @@ TEST(UtilitiesTest, lexicalCastOutOfRange)
   EXPECT_EQ(lexicalCast<double>("-inf"), std::nullopt);
   EXPECT_EQ(lexicalCast<double>("infinity"), std::nullopt);
   EXPECT_EQ(lexicalCast<double>(""), std::nullopt);
+}
+
+TEST(UtilitiesTest, lexicalCastFloatOutOfRange)
+{
+  // The float extractor rejects a merely subnormal result, because strtof
+  // reports underflow as ERANGE. Quantum chemistry codes write the decaying
+  // tail of a density well past FLT_MIN, so these must still be read.
+  EXPECT_NE(lexicalCast<float>("9.293354777E-39"), std::nullopt);
+  EXPECT_NEAR(lexicalCast<float>("9.293354777E-39").value_or(-1.0f),
+              9.293354777e-39f, 1.0e-40f);
+  EXPECT_NEAR(lexicalCast<float>("1.505124610E-39").value_or(-1.0f),
+              1.505124610e-39f, 1.0e-40f);
+
+  // Below even a subnormal float, or below double, is effectively zero.
+  EXPECT_EQ(lexicalCast<float>("1.0E-60"), 0.0f);
+  EXPECT_EQ(lexicalCast<float>("2.61793E-500"), 0.0f);
+
+  // Overflow is clamped rather than becoming an infinity, including a value
+  // that is in range for double but not for float.
+  EXPECT_EQ(lexicalCast<float>("1.0E+300"), std::numeric_limits<float>::max());
+  EXPECT_EQ(lexicalCast<float>("-1.0E+300"),
+            std::numeric_limits<float>::lowest());
+  EXPECT_EQ(lexicalCast<float>("1.0E+500"), std::numeric_limits<float>::max());
+
+  // Ordinary values are unaffected.
+  EXPECT_FLOAT_EQ(lexicalCast<float>("1.000000000").value_or(0.0f), 1.0f);
+
+  // Values that are not numbers still fail.
+  EXPECT_EQ(lexicalCast<float>("five"), std::nullopt);
+  EXPECT_EQ(lexicalCast<float>("nan"), std::nullopt);
+  EXPECT_EQ(lexicalCast<float>("inf"), std::nullopt);
+  EXPECT_EQ(lexicalCast<float>(""), std::nullopt);
 }
 
 TEST(UtilitiesTest, lexicalCastCheck)

--- a/tests/quantumio/cubetest.cpp
+++ b/tests/quantumio/cubetest.cpp
@@ -8,14 +8,18 @@
 #include <gtest/gtest.h>
 
 #include <avogadro/core/atom.h>
+#include <avogadro/core/cube.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/vector.h>
 
 #include <avogadro/quantumio/gaussiancube.h>
 
+#include <cmath>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
+#include <vector>
 
 using Avogadro::Vector3;
 using Avogadro::Core::Atom;
@@ -58,6 +62,90 @@ TEST(GaussianCubeTest, oversizedCubeRejected)
 
   EXPECT_FALSE(cube.readString(out.str(), molecule));
   EXPECT_NE(cube.error(), std::string());
+}
+
+// Builds a minimal but complete one atom cube whose grid holds @p values.
+static std::string makeCube(const std::vector<std::string>& values)
+{
+  std::ostringstream out;
+  out << "Comment line\n";
+  out << "Second comment line\n";
+  out << "    1    0.000000    0.000000    0.000000\n";
+  out << "    " << values.size() << "    0.100000    0.000000    0.000000\n";
+  out << "    1    0.000000    0.100000    0.000000\n";
+  out << "    1    0.000000    0.000000    0.100000\n";
+  out << "    1    1.000000    0.000000    0.000000    0.000000\n";
+  for (const auto& value : values)
+    out << "  " << value << "\n";
+  return out.str();
+}
+
+// Regression test: values below FLT_MIN must not abort the read.
+//
+// Core::Cube stores float, and the stream extractor for float sets failbit
+// when strtof reports ERANGE -- which includes a merely subnormal result. A
+// Q-Chem cube whose density decayed past FLT_MIN in the last few grid points
+// was rejected with "Invalid cube data" after reading 364719 of 364800 values.
+TEST(GaussianCubeTest, subnormalValuesAreRead)
+{
+  GaussianCube cube;
+  Molecule molecule;
+
+  const std::string input = makeCube({ "1.000000000E-01", "9.293354777E-39",
+                                       "6.601756585E-39", "1.505124610E-39" });
+
+  ASSERT_TRUE(cube.readString(input, molecule));
+  ASSERT_EQ(cube.error(), std::string());
+
+  ASSERT_EQ(molecule.cubeCount(), static_cast<size_t>(1));
+  const auto* values = molecule.cube(0)->data();
+  ASSERT_NE(values, nullptr);
+  ASSERT_EQ(values->size(), static_cast<size_t>(4));
+
+  EXPECT_FLOAT_EQ((*values)[0], 1.0e-01f);
+  // Subnormal, so compare against the narrowed value rather than exactly.
+  EXPECT_NEAR((*values)[1], 9.293354777e-39f, 1.0e-40f);
+  EXPECT_NEAR((*values)[2], 6.601756585e-39f, 1.0e-40f);
+  EXPECT_NEAR((*values)[3], 1.505124610e-39f, 1.0e-40f);
+}
+
+// Regression test: an exponent too small even for double is still read as zero,
+// and one too large is clamped rather than becoming an infinity.
+TEST(GaussianCubeTest, outOfRangeExponentsAreClamped)
+{
+  GaussianCube cube;
+  Molecule molecule;
+
+  const std::string input =
+    makeCube({ "1.0E-500", "-1.0E-500", "1.0E+500", "-1.0E+500" });
+
+  ASSERT_TRUE(cube.readString(input, molecule));
+  ASSERT_EQ(cube.error(), std::string());
+
+  const auto* values = molecule.cube(0)->data();
+  ASSERT_NE(values, nullptr);
+  ASSERT_EQ(values->size(), static_cast<size_t>(4));
+
+  EXPECT_FLOAT_EQ((*values)[0], 0.0f);
+  EXPECT_FLOAT_EQ((*values)[1], 0.0f);
+  EXPECT_FALSE(std::isinf((*values)[2]));
+  EXPECT_FALSE(std::isinf((*values)[3]));
+  EXPECT_FLOAT_EQ((*values)[2], std::numeric_limits<float>::max());
+  EXPECT_FLOAT_EQ((*values)[3], std::numeric_limits<float>::lowest());
+}
+
+// Tolerating range errors must not start accepting malformed data.
+TEST(GaussianCubeTest, malformedValuesStillRejected)
+{
+  for (const std::string& bad :
+       { std::string("1.5abc"), std::string("***********"), std::string("nan"),
+         std::string("inf") }) {
+    GaussianCube cube;
+    Molecule molecule;
+    const std::string input = makeCube({ "1.0E-01", bad, "1.0E-01" });
+    EXPECT_FALSE(cube.readString(input, molecule)) << "accepted: " << bad;
+    EXPECT_NE(cube.error(), std::string()) << "no error for: " << bad;
+  }
 }
 
 // Regression test: binary junk input should fail gracefully.


### PR DESCRIPTION
Add a specialized template for lexicalCast for float to actually read as double and cast to float to avoid underflow in the future (e.g., 1.0e-34, etc.)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
