### PR TITLE
Rework the internal <=> Cartesian conversions

### DIFF
--- a/avogadro/core/internalcoordinates.cpp
+++ b/avogadro/core/internalcoordinates.cpp
@@ -4,301 +4,442 @@
 ******************************************************************************/
 
 #include "internalcoordinates.h"
+
+#include "angletools.h"
+#include "graph.h"
 #include "matrix.h"
 
+#include <Eigen/Geometry>
+
 #include <cmath>
+#include <set>
+#include <vector>
 
 namespace Avogadro::Core {
 
-Array<Vector3> internalToCartesian(
-  const Molecule& molecule, const Array<InternalCoordinate>& internalCoords)
+namespace {
+
+// Two points closer than this are treated as coincident: the direction
+// between them carries no information.
+const Real coincidentTolerance = 1e-8;
+
+// |sin| of the angle below which three points are treated as collinear. The
+// normal to their plane is numerically meaningless below this, so a dihedral
+// measured against them cannot be reconstructed.
+const Real collinearTolerance = 1e-4;
+
+// |sin| above which a reference is good enough to stop looking for a better
+// one, about 5.7 degrees away from collinear.
+const Real goodReferenceTolerance = 0.1;
+
+// A reference is usable only if it names a real atom that has already been
+// given a position.
+bool isPlaced(Index index, const std::vector<bool>& placed)
 {
-  Array<Vector3> coords(molecule.atomCount());
-  Vector3 ab(0.0, 0.0, 0.0);
-  Vector3 bc(0.0, 0.0, 0.0);
+  return index != MaxIndex && index < placed.size() && placed[index];
+}
 
-  for (Index i = 0; i < molecule.atomCount(); ++i) {
-    Real sinTheta, cosTheta, sinPhi, cosPhi;
-    Real length = internalCoords[i].length;
-    Real angle = internalCoords[i].angle;
-    Real dihedral = internalCoords[i].dihedral;
-    // Index i represents the current atom
-    Index a = internalCoords[i].a; // i will be some distance to a
-    Index b = internalCoords[i].b; // i-a-b is an angle
-    Index c = internalCoords[i].c; // i-a-b-c is a dihedral
+// Any unit vector perpendicular to @p v. The axis is chosen away from v to
+// avoid cancellation in the cross product.
+Vector3 anyPerpendicular(const Vector3& v)
+{
+  const Vector3 axis =
+    (std::abs(v.x()) < 0.9) ? Vector3(1.0, 0.0, 0.0) : Vector3(0.0, 1.0, 0.0);
+  const Vector3 perpendicular = axis.cross(v);
+  const Real norm = perpendicular.norm();
+  if (norm < coincidentTolerance)
+    return Vector3(0.0, 0.0, 1.0);
+  return perpendicular / norm;
+}
 
-    switch (i) {
-      case 0:
-        coords[i] = Vector3(0.0, 0.0, 0.0);
-        break;
-      case 1:
-        coords[i] = Vector3(length, 0.0, 0.0);
-        break;
-      case 2: {
-        sinTheta = std::sin(angle * DEG_TO_RAD);
-        cosTheta = std::cos(angle * DEG_TO_RAD);
-        ab = (coords[b] - coords[a]).normalized();
+// |sin| of the angle at @p vertex between the directions to @p p and @p q.
+// Zero when the three points are collinear or two of them coincide.
+Real sineAt(const Vector3& p, const Vector3& vertex, const Vector3& q)
+{
+  const Vector3 u = p - vertex;
+  const Vector3 v = q - vertex;
+  const Real uNorm = u.norm();
+  const Real vNorm = v.norm();
+  if (uNorm < coincidentTolerance || vNorm < coincidentTolerance)
+    return 0.0;
+  return (u / uNorm).cross(v / vNorm).norm();
+}
 
-        // We want to place atom i at distance 'length' from atom a
-        // at angle 'angle' from the a-b direction
+// One row of a z-matrix: the atom it places, and the already-placed atoms it
+// is measured against.
+struct Reference
+{
+  Index atom = MaxIndex;
+  Index a = MaxIndex;
+  Index b = MaxIndex;
+  Index c = MaxIndex;
+};
 
-        // Perpendicular to ab in the xy-plane
-        Vector3 perpendicular(-ab.y(), ab.x(), 0.0);
-        if (perpendicular.norm() > 1e-6) {
-          perpendicular.normalize();
-        } else {
-          // ab is along z-axis, use x-axis as perpendicular
-          perpendicular = Vector3(1.0, 0.0, 0.0);
-        }
+/**
+ * Choose the atoms that row @p atom is measured against.
+ *
+ * References are drawn only from atoms that have already been placed, which
+ * is what makes the result a valid z-matrix: every reference is guaranteed
+ * to appear in an earlier row.
+ *
+ * Bonded references are preferred, so that a row's length, angle and
+ * dihedral are the chemically meaningful ones. Where no bonded candidate
+ * exists -- the opening rows of the matrix, and the first atom of each
+ * additional fragment -- the most recently placed atoms are used instead.
+ * Those still describe the geometry exactly; they are simply not bond
+ * lengths and bond angles.
+ */
+Reference chooseReferences(const Molecule& molecule, const Graph& graph,
+                           Index atom, const std::vector<Index>& placedOrder,
+                           const std::vector<bool>& placed)
+{
+  Reference reference;
+  reference.atom = atom;
+  if (placedOrder.empty())
+    return reference; // the first row has nothing to measure against
 
-        // Place atom i: start from a, extend in direction
-        // that makes angle with ab
-        coords[i] =
-          coords[a] + length * (cosTheta * ab + sinTheta * perpendicular);
-        break;
+  const Vector3 pos = molecule.atomPosition3d(atom);
+
+  // 'a' is a bonded, already-placed neighbour where one exists. The
+  // adjacency list is in bond order rather than index order, so take the
+  // lowest index explicitly to keep the result deterministic.
+  for (size_t neighbor : graph.neighbors(atom)) {
+    if (isPlaced(neighbor, placed) &&
+        (reference.a == MaxIndex || neighbor < reference.a))
+      reference.a = neighbor;
+  }
+  if (reference.a == MaxIndex)
+    reference.a = placedOrder.back(); // a new fragment: anchor to the last atom
+  if (placedOrder.size() < 2)
+    return reference; // the second row can only carry a distance
+
+  const Vector3 posA = molecule.atomPosition3d(reference.a);
+
+  // 'b' completes the angle at 'a'. Prefer an atom bonded to 'a', and among
+  // those one that does not leave atom-a-b collinear.
+  Real bestScore = -1.0;
+  for (size_t neighbor : graph.neighbors(reference.a)) {
+    if (neighbor == atom || !isPlaced(neighbor, placed))
+      continue;
+    const Real score = sineAt(pos, posA, molecule.atomPosition3d(neighbor));
+    if (score > bestScore) {
+      bestScore = score;
+      reference.b = neighbor;
+    }
+  }
+  if (reference.b == MaxIndex) {
+    // No bonded candidate, so walk back through the placement order.
+    for (auto it = placedOrder.rbegin(); it != placedOrder.rend(); ++it) {
+      if (*it == atom || *it == reference.a)
+        continue;
+      if ((molecule.atomPosition3d(*it) - posA).norm() < coincidentTolerance)
+        continue; // coincident with 'a': no angle can be measured
+      const Real score = sineAt(pos, posA, molecule.atomPosition3d(*it));
+      if (score > bestScore) {
+        bestScore = score;
+        reference.b = *it;
       }
-      default:
-        // NeRF formula
-        // see J. Comp. Chem. Vol. 26, No. 10, p. 1063-1068 (2005)
-        // https://doi.org/10.1002/jcc.20237
-        sinTheta = std::sin(angle * DEG_TO_RAD);
-        cosTheta = std::cos(angle * DEG_TO_RAD);
-        sinPhi = std::sin(dihedral * DEG_TO_RAD);
-        cosPhi = std::cos(dihedral * DEG_TO_RAD);
-
-        // Place atom i relative to atoms a, b, c
-        // - i bonds to a at distance 'length'
-        // - angle at a between i-a-b is 'angle'
-        // - dihedral i-a-b-c is 'dihedral'
-
-        // Vector from a to b (the bond direction for angle reference)
-        ab = (coords[b] - coords[a]).normalized();
-
-        // Vector from b to c (needed for dihedral plane)
-        bc = (coords[c] - coords[b]).normalized();
-
-        // Normal to the plane defined by a-b-c
-        Vector3 n = ab.cross(bc);
-        Real n_norm = n.norm();
-
-        if (n_norm > 1e-10) {
-          n.normalize();
-        } else {
-          // Atoms a, b, c are collinear - choose arbitrary perpendicular
-          // Find a vector perpendicular to ab
-          if (std::abs(ab.x()) < 0.9) {
-            n = Vector3(1.0, 0.0, 0.0).cross(ab).normalized();
-          } else {
-            n = Vector3(0.0, 1.0, 0.0).cross(ab).normalized();
-          }
-        }
-
-        // Vector perpendicular to both ab and n
-        // (in the plane perpendicular to ab)
-        Vector3 n_perp = n.cross(ab);
-
-        // Local coordinate system at atom a:
-        // - ab direction: along the a-b bond (reference for angle)
-        // - n_perp direction: perpendicular to ab, in plane for 0° dihedral
-        // - n direction: perpendicular to ab, for rotating out of plane
-
-        // Position in local frame using NeRF formula (page 1066, eq. 2)
-        // We place atom i relative to atom a
-        // The angle is measured from the ab direction
-        // The dihedral rotates around the ab axis
-        Vector3 localPos(length * cosTheta, length * sinTheta * cosPhi,
-                         length * sinTheta * sinPhi);
-
-        // Build rotation matrix with columns [ab, n_perp, n]
-        Matrix3 m;
-        m << ab, n_perp, n;
-
-        // Transform to global coordinates and translate to atom a
-        coords[i] = m * localPos + coords[a];
+      if (bestScore > goodReferenceTolerance)
         break;
     }
+  }
+  if (reference.b == MaxIndex || placedOrder.size() < 3)
+    return reference; // the third row can only carry a distance and an angle
+
+  const Vector3 posB = molecule.atomPosition3d(reference.b);
+
+  // 'c' completes the dihedral about the a-b axis. It is only reconstructible
+  // when a, b and c are not collinear, so candidates below the tolerance are
+  // rejected outright rather than merely scored down.
+  bestScore = collinearTolerance;
+  for (size_t neighbor : graph.neighbors(reference.b)) {
+    if (neighbor == atom || neighbor == reference.a ||
+        !isPlaced(neighbor, placed))
+      continue;
+    const Real score = sineAt(posA, posB, molecule.atomPosition3d(neighbor));
+    if (score > bestScore) {
+      bestScore = score;
+      reference.c = neighbor;
+    }
+  }
+  if (reference.c == MaxIndex) {
+    for (auto it = placedOrder.rbegin(); it != placedOrder.rend(); ++it) {
+      if (*it == atom || *it == reference.a || *it == reference.b)
+        continue;
+      const Real score = sineAt(posA, posB, molecule.atomPosition3d(*it));
+      if (score > bestScore) {
+        bestScore = score;
+        reference.c = *it;
+      }
+      if (bestScore > goodReferenceTolerance)
+        break;
+    }
+  }
+
+  // 'c' may still be unset, meaning every candidate is collinear with a and
+  // b. Then atom-a-b is collinear too, the dihedral has no bearing on where
+  // the atom sits, and a distance and an angle describe the row exactly.
+  return reference;
+}
+
+/**
+ * Order the atoms into a valid z-matrix and choose each row's references.
+ *
+ * Atoms are taken in bond order from the lowest-indexed atom outwards,
+ * always preferring the lowest-indexed atom reachable from those already
+ * placed. A molecule whose atom order is already a valid z-matrix order
+ * therefore keeps that order, and the caller's row-to-atom map is the
+ * identity. When the bonded frontier runs out, the lowest unplaced atom
+ * starts the next fragment.
+ */
+std::vector<Reference> buildZMatrix(const Molecule& molecule)
+{
+  const Index atomCount = molecule.atomCount();
+  std::vector<Reference> rows;
+  if (atomCount == 0)
+    return rows;
+  rows.reserve(atomCount);
+
+  const Graph& graph = molecule.graph();
+  std::vector<bool> placed(atomCount, false);
+  std::vector<Index> placedOrder;
+  placedOrder.reserve(atomCount);
+
+  // Unplaced atoms bonded to something already placed, kept in index order.
+  std::set<Index> frontier;
+  Index nextUnplaced = 0;
+
+  while (rows.size() < atomCount) {
+    Index atom = MaxIndex;
+    if (!frontier.empty()) {
+      atom = *frontier.begin();
+      frontier.erase(frontier.begin());
+    } else {
+      // Start the matrix, or a new fragment, at the lowest unplaced atom.
+      while (nextUnplaced < atomCount && placed[nextUnplaced])
+        ++nextUnplaced;
+      if (nextUnplaced >= atomCount)
+        break;
+      atom = nextUnplaced;
+    }
+
+    rows.push_back(
+      chooseReferences(molecule, graph, atom, placedOrder, placed));
+    placed[atom] = true;
+    placedOrder.push_back(atom);
+
+    for (size_t neighbor : graph.neighbors(atom)) {
+      if (neighbor < atomCount && !placed[neighbor])
+        frontier.insert(neighbor);
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * The in-plane direction perpendicular to @p ab that a distance-and-angle
+ * row is placed along. The row is free to rotate about the a-b axis, so
+ * either the molecule's existing plane or the xy-plane is used.
+ */
+Vector3 referencePerpendicular(const Molecule& molecule, Index atom, Index a,
+                               Index b, const Vector3& ab, ZMatrixOrigin origin)
+{
+  if (origin == ZMatrixOrigin::Preserve) {
+    Vector3 oldAb = molecule.atomPosition3d(b) - molecule.atomPosition3d(a);
+    const Vector3 oldV =
+      molecule.atomPosition3d(atom) - molecule.atomPosition3d(a);
+    if (oldAb.norm() > coincidentTolerance) {
+      oldAb.normalize();
+      Vector3 oldPerpendicular = oldV - oldV.dot(oldAb) * oldAb;
+      if (oldPerpendicular.norm() > coincidentTolerance) {
+        oldPerpendicular.normalize();
+        // Carry the molecule's own plane onto the rebuilt a-b direction.
+        const Eigen::Quaternion<Real> rotation =
+          Eigen::Quaternion<Real>::FromTwoVectors(oldAb, ab);
+        return (rotation * oldPerpendicular).normalized();
+      }
+    }
+    // The molecule has no plane to preserve here, so fall through.
+  }
+
+  // Canonical: keep the third atom in the xy-plane where a-b allows it.
+  Vector3 perpendicular(-ab.y(), ab.x(), 0.0);
+  if (perpendicular.norm() > coincidentTolerance)
+    return perpendicular.normalized();
+  return anyPerpendicular(ab);
+}
+
+Array<Vector3> buildCartesian(const Molecule& molecule,
+                              const Array<InternalCoordinate>& internalCoords,
+                              const Array<Index>& rowToAtom,
+                              ZMatrixOrigin origin)
+{
+  const Index atomCount = molecule.atomCount();
+  Array<Vector3> coords(atomCount, Vector3(0.0, 0.0, 0.0));
+
+  // An atom that no row places keeps the position it already has rather than
+  // being dragged to the origin, so a short or malformed matrix disturbs
+  // only the atoms it actually names.
+  if (origin == ZMatrixOrigin::Preserve) {
+    for (Index i = 0; i < atomCount; ++i)
+      coords[i] = molecule.atomPosition3d(i);
+  }
+
+  if (internalCoords.size() != rowToAtom.size())
+    return coords;
+
+  std::vector<bool> placed(atomCount, false);
+
+  for (size_t row = 0; row < internalCoords.size(); ++row) {
+    const Index atom = rowToAtom[row];
+    if (atom >= atomCount)
+      continue; // the map does not name a real atom
+
+    const InternalCoordinate& internal = internalCoords[row];
+    const Index a = internal.a;
+    const Index b = internal.b;
+    const Index c = internal.c;
+
+    // Each branch uses as much of the row as is actually usable. A row whose
+    // references have not been placed is not an error: it is how the opening
+    // rows of every z-matrix are defined.
+    if (!isPlaced(a, placed)) {
+      // Nothing to measure from: this row anchors the matrix.
+      coords[atom] = (origin == ZMatrixOrigin::Preserve)
+                       ? molecule.atomPosition3d(atom)
+                       : Vector3(0.0, 0.0, 0.0);
+    } else if (!isPlaced(b, placed)) {
+      // A distance only, so any direction satisfies the row.
+      Vector3 direction(1.0, 0.0, 0.0);
+      if (origin == ZMatrixOrigin::Preserve) {
+        const Vector3 existing =
+          molecule.atomPosition3d(atom) - molecule.atomPosition3d(a);
+        if (existing.norm() > coincidentTolerance)
+          direction = existing.normalized();
+      }
+      coords[atom] = coords[a] + internal.length * direction;
+    } else {
+      Vector3 ab = coords[b] - coords[a];
+      const Real abNorm = ab.norm();
+      if (abNorm < coincidentTolerance) {
+        // 'a' and 'b' coincide, so there is no axis to measure the angle
+        // from. Keep the distance and place the atom along +x.
+        coords[atom] = coords[a] + internal.length * Vector3(1.0, 0.0, 0.0);
+        placed[atom] = true;
+        continue;
+      }
+      ab /= abNorm;
+
+      const Real theta = internal.angle * DEG_TO_RAD;
+      const Real sinTheta = std::sin(theta);
+      const Real cosTheta = std::cos(theta);
+
+      if (!isPlaced(c, placed)) {
+        // A distance and an angle: free to rotate about the a-b axis.
+        const Vector3 perpendicular =
+          referencePerpendicular(molecule, atom, a, b, ab, origin);
+        coords[atom] = coords[a] + internal.length *
+                                     (cosTheta * ab + sinTheta * perpendicular);
+      } else {
+        // Natural extension reference frame, see
+        // J. Comp. Chem. Vol. 26, No. 10, p. 1063-1068 (2005)
+        // https://doi.org/10.1002/jcc.20237
+        Vector3 bc = coords[c] - coords[b];
+        const Real bcNorm = bc.norm();
+        if (bcNorm > coincidentTolerance)
+          bc /= bcNorm;
+
+        Vector3 normal = ab.cross(bc);
+        const Real normalNorm = normal.norm();
+        if (normalNorm > collinearTolerance)
+          normal /= normalNorm;
+        else
+          normal = anyPerpendicular(ab); // a, b and c are collinear
+
+        const Vector3 inPlane = normal.cross(ab);
+        // A z-matrix dihedral is the IUPAC signed torsion atom-a-b-c, whose
+        // sense about the a-b axis is opposite to that of this frame, so the
+        // rotation is applied negated. Getting this wrong does not disturb
+        // any distance or angle -- it silently builds the mirror image.
+        const Real phi = -internal.dihedral * DEG_TO_RAD;
+
+        // Local frame at 'a': +ab is the angle reference, inPlane carries a
+        // zero dihedral, and normal rotates the atom out of the a-b-c plane.
+        const Vector3 local(internal.length * cosTheta,
+                            internal.length * sinTheta * std::cos(phi),
+                            internal.length * sinTheta * std::sin(phi));
+
+        Matrix3 frame;
+        frame << ab, inPlane, normal;
+        coords[atom] = frame * local + coords[a];
+      }
+    }
+
+    placed[atom] = true;
   }
 
   return coords;
 }
 
-// Helper structure to store the connectivity tree
-struct ConnectivityTree
+} // namespace
+
+Array<Vector3> internalToCartesian(
+  const Molecule& molecule, const Array<InternalCoordinate>& internalCoords)
 {
-  Array<Index> parent;      // parent[i] = atom that i bonds to (atom a)
-  Array<Index> grandparent; // grandparent[i] = parent's parent (atom b)
-  Array<Index>
-    greatgrandparent; // greatgrandparent[i] = grandparent's parent (atom c)
-};
+  // In this form the row index is the atom index.
+  Array<Index> rowToAtom(internalCoords.size());
+  for (size_t i = 0; i < rowToAtom.size(); ++i)
+    rowToAtom[i] = i;
 
-// Build a spanning tree of the molecule using BFS
-// Handles disconnected fragments by building a separate tree for each component
-ConnectivityTree buildConnectivityTree(const Molecule& molecule)
-{
-  Index atomCount = molecule.atomCount();
-  ConnectivityTree tree;
-  tree.parent.resize(atomCount);
-  tree.grandparent.resize(atomCount);
-  tree.greatgrandparent.resize(atomCount);
-
-  // Initialize all to -1 (invalid index)
-  for (Index i = 0; i < atomCount; ++i) {
-    tree.parent[i] = static_cast<Index>(-1);
-    tree.grandparent[i] = static_cast<Index>(-1);
-    tree.greatgrandparent[i] = static_cast<Index>(-1);
-  }
-
-  // Get connected components from the molecule's graph
-  const Graph& graph = molecule.graph();
-  std::vector<std::set<size_t>> components = graph.connectedComponents();
-
-  // Process each connected component separately
-  for (const auto& component : components) {
-    if (component.empty())
-      continue;
-
-    // Pick the first atom in this component as root
-    Index root = *component.begin();
-
-    // BFS from this root
-    std::vector<bool> visited(atomCount, false);
-    std::vector<Index> queue;
-    queue.push_back(root);
-    visited[root] = true;
-
-    while (!queue.empty()) {
-      Index current = queue.front();
-      queue.erase(queue.begin());
-
-      // Get neighbors from the graph
-      std::vector<size_t> neighborIndices = graph.neighbors(current);
-
-      for (Index neighbor : neighborIndices) {
-        if (!visited[neighbor]) {
-          visited[neighbor] = true;
-          tree.parent[neighbor] = current;
-
-          // Set grandparent if parent has a parent
-          if (tree.parent[current] != static_cast<Index>(-1)) {
-            tree.grandparent[neighbor] = tree.parent[current];
-
-            // Set great-grandparent if grandparent has a parent
-            Index grandparentIdx = tree.parent[current];
-            if (tree.parent[grandparentIdx] != static_cast<Index>(-1)) {
-              tree.greatgrandparent[neighbor] = tree.parent[grandparentIdx];
-            }
-          }
-
-          queue.push_back(neighbor);
-        }
-      }
-    }
-  }
-
-  return tree;
+  return buildCartesian(molecule, internalCoords, rowToAtom,
+                        ZMatrixOrigin::Canonical);
 }
 
-Array<InternalCoordinate> cartesianToInternal(const Molecule& molecule)
+Array<Vector3> internalToCartesian(
+  const Molecule& molecule, const Array<InternalCoordinate>& internalCoords,
+  const Array<Index>& rowToAtom, ZMatrixOrigin origin)
 {
-  Array<InternalCoordinate> internalCoords(molecule.atomCount());
+  return buildCartesian(molecule, internalCoords, rowToAtom, origin);
+}
 
-  if (molecule.atomCount() < 1)
-    return internalCoords;
+Array<InternalCoordinate> cartesianToInternal(const Molecule& molecule,
+                                              Array<Index>& rowToAtom)
+{
+  const std::vector<Reference> rows = buildZMatrix(molecule);
 
-  // Build connectivity tree using the molecule's graph
-  ConnectivityTree tree = buildConnectivityTree(molecule);
+  Array<InternalCoordinate> internalCoords(rows.size());
+  rowToAtom.resize(rows.size());
 
-  // Convert each atom to internal coordinates based on tree
-  for (Index i = 0; i < molecule.atomCount(); ++i) {
+  for (size_t row = 0; row < rows.size(); ++row) {
+    const Reference& reference = rows[row];
+    rowToAtom[row] = reference.atom;
+
     InternalCoordinate coord;
-    coord.a = tree.parent[i];
-    coord.b = tree.grandparent[i];
-    coord.c = tree.greatgrandparent[i];
+    coord.a = reference.a;
+    coord.b = reference.b;
+    coord.c = reference.c;
 
-    if (tree.parent[i] == static_cast<Index>(-1)) {
-      // Root of a fragment - place at origin
-      coord.length = 0.0;
-      coord.angle = 0.0;
-      coord.dihedral = 0.0;
-    } else {
-      // Calculate distance from i to parent (atom a)
-      Vector3 vec_i_to_a = molecule.atom(tree.parent[i]).position3d() -
-                           molecule.atom(i).position3d();
-      coord.length = vec_i_to_a.norm();
+    if (reference.a != MaxIndex) {
+      const Vector3 pos = molecule.atomPosition3d(reference.atom);
+      const Vector3 posA = molecule.atomPosition3d(reference.a);
+      coord.length = (pos - posA).norm();
 
-      if (tree.grandparent[i] == static_cast<Index>(-1)) {
-        // Second atom in fragment - has distance only
-        coord.angle = 0.0;
-        coord.dihedral = 0.0;
-      } else {
-        // Calculate angle i-a-b (at atom a, between i-a and a-b bonds)
-        Index a = tree.parent[i];
-        Index b = tree.grandparent[i];
+      if (reference.b != MaxIndex) {
+        const Vector3 posB = molecule.atomPosition3d(reference.b);
+        if (coord.length > coincidentTolerance &&
+            (posB - posA).norm() > coincidentTolerance)
+          coord.angle = calculateAngle(pos, posA, posB);
 
-        Vector3 vec_a_to_i = -vec_i_to_a; // from a to i
-        Vector3 vec_a_to_b =
-          molecule.atom(b).position3d() - molecule.atom(a).position3d();
-
-        Real dot = vec_a_to_i.dot(vec_a_to_b);
-        Real len_product = vec_a_to_i.norm() * vec_a_to_b.norm();
-
-        if (len_product > 1e-8) {
-          Real cosAngle = dot / len_product;
-          // Clamp to avoid numerical issues with acos
-          cosAngle = std::clamp(cosAngle, -1.0, 1.0);
-          coord.angle = std::acos(cosAngle) * RAD_TO_DEG;
-        } else {
-          coord.angle = 0.0;
-        }
-
-        if (tree.greatgrandparent[i] == static_cast<Index>(-1)) {
-          // Third atom in fragment - has distance and angle only
-          coord.dihedral = 0.0;
-        } else {
-          // Calculate dihedral i-a-b-c
-          Index c = tree.greatgrandparent[i];
-
-          Vector3 p_i = molecule.atom(i).position3d();
-          Vector3 p_a = molecule.atom(a).position3d();
-          Vector3 p_b = molecule.atom(b).position3d();
-          Vector3 p_c = molecule.atom(c).position3d();
-
-          // Vectors along bonds
-          Vector3 b1 = p_a - p_i; // i -> a
-          Vector3 b2 = p_b - p_a; // a -> b
-          Vector3 b3 = p_c - p_b; // b -> c
-
-          // Normals to planes
-          Vector3 n1 = b1.cross(b2); // plane containing i-a-b
-          Vector3 n2 = b2.cross(b3); // plane containing a-b-c
-
-          Real n1_norm = n1.norm();
-          Real n2_norm = n2.norm();
-
-          if (n1_norm > 1e-8 && n2_norm > 1e-8) {
-            n1 = n1 / n1_norm;
-            n2 = n2 / n2_norm;
-
-            Real cos_dihedral = n1.dot(n2);
-            // Clamp to avoid numerical issues
-            cos_dihedral = std::clamp(cos_dihedral, -1.0, 1.0);
-
-            // Determine sign using triple product
-            Real sign = (n1.cross(n2)).dot(b2);
-
-            coord.dihedral = std::acos(cos_dihedral) * RAD_TO_DEG;
-            if (sign < 0) {
-              coord.dihedral = -coord.dihedral;
-            }
-          } else {
-            // Atoms are collinear
-            coord.dihedral = 0.0;
-          }
+        if (reference.c != MaxIndex) {
+          const Vector3 posC = molecule.atomPosition3d(reference.c);
+          if ((posC - posB).norm() > coincidentTolerance)
+            coord.dihedral = calculateDihedral(pos, posA, posB, posC);
         }
       }
     }
 
-    internalCoords[i] = coord;
+    internalCoords[row] = coord;
   }
 
   return internalCoords;

--- a/avogadro/core/internalcoordinates.h
+++ b/avogadro/core/internalcoordinates.h
@@ -15,7 +15,17 @@
 namespace Avogadro {
 namespace Core {
 
-/** A simple struct to define internal / z-matrix coordinates. */
+/**
+ * A single row of a z-matrix: the distance to atom @a a, the angle at @a a
+ * to atom @a b, and the dihedral about the @a a - @a b axis to atom @a c.
+ *
+ * @a a, @a b and @a c are molecule atom indices, or MaxIndex where the row
+ * has no such reference. The first three rows of a z-matrix necessarily have
+ * fewer than three references, since there are not yet three atoms to
+ * measure against.
+ *
+ * Angles and dihedrals are in degrees.
+ */
 struct InternalCoordinate
 {
   Index a = MaxIndex;
@@ -26,11 +36,80 @@ struct InternalCoordinate
   Real dihedral = 0.0;
 };
 
+/**
+ * How the opening rows of a z-matrix are anchored in Cartesian space.
+ *
+ * A z-matrix fixes a molecule's internal geometry but not where it sits or
+ * how it is oriented: the first atom, the direction to the second, and the
+ * plane of the third are all free.
+ */
+enum class ZMatrixOrigin
+{
+  /** First atom at the origin, second along +x, third in the xy-plane. */
+  Canonical,
+  /**
+   * Take the free parameters from the molecule's current coordinates, so
+   * that rebuilding a molecule that already has a geometry neither moves nor
+   * reorients it.
+   */
+  Preserve
+};
+
+/**
+ * Rebuild Cartesian coordinates from a z-matrix whose rows are in atom
+ * order, so that row @a i places atom @a i.
+ *
+ * Each row's references must name atoms in earlier rows; a row referencing
+ * an atom that has not yet been placed keeps as much of its definition as is
+ * usable (a distance and an angle, or a distance alone) rather than reading
+ * an unset position.
+ *
+ * @param molecule The molecule being rebuilt, used for its atom count.
+ * @param internalCoords One row per atom, in atom order.
+ * @return Positions indexed by atom index.
+ */
 AVOGADROCORE_EXPORT Array<Vector3> internalToCartesian(
   const Molecule& molecule, const Array<InternalCoordinate>& internalCoords);
 
+/**
+ * Rebuild Cartesian coordinates from a z-matrix whose row order differs from
+ * the molecule's atom order.
+ *
+ * @param molecule The molecule being rebuilt.
+ * @param internalCoords One row per atom, in z-matrix order.
+ * @param rowToAtom The atom index each row places, as returned by
+ * cartesianToInternal().
+ * @param origin Whether to anchor the result canonically or on the
+ * molecule's existing coordinates.
+ * @return Positions indexed by atom index.
+ */
+AVOGADROCORE_EXPORT Array<Vector3> internalToCartesian(
+  const Molecule& molecule, const Array<InternalCoordinate>& internalCoords,
+  const Array<Index>& rowToAtom,
+  ZMatrixOrigin origin = ZMatrixOrigin::Preserve);
+
+/**
+ * Derive a z-matrix from a molecule's Cartesian coordinates.
+ *
+ * Rows are returned in z-matrix order, which is not necessarily the
+ * molecule's atom order: every row's references are guaranteed to name atoms
+ * that appear in earlier rows, which is what makes the result a valid
+ * z-matrix. @p rowToAtom maps each row back to the atom it places, and is
+ * the identity when the molecule's atom order is already a valid z-matrix
+ * order.
+ *
+ * References are drawn from bonded atoms wherever possible, so that a row's
+ * length, angle and dihedral are chemically meaningful. Disconnected
+ * fragments are anchored to the atoms placed before them, so the geometry of
+ * a multi-fragment system is described exactly rather than fragment by
+ * fragment.
+ *
+ * @param molecule The molecule to describe.
+ * @param rowToAtom Filled with the atom index each row places.
+ * @return One row per atom, in z-matrix order.
+ */
 AVOGADROCORE_EXPORT Array<InternalCoordinate> cartesianToInternal(
-  const Molecule& molecule);
+  const Molecule& molecule, Array<Index>& rowToAtom);
 
 } // namespace Core
 } // namespace Avogadro

--- a/tests/core/internalcoordinatestest.cpp
+++ b/tests/core/internalcoordinatestest.cpp
@@ -654,3 +654,63 @@ TEST(InternalCoordinatesTest, coincidentAtoms)
     EXPECT_TRUE(std::isfinite(rebuilt[i].z())) << "atom " << i;
   }
 }
+
+// The three-atom case above never reaches the dihedral branch, so repeat it
+// with four atoms and the coincident pair in each position along the chain.
+//
+// This also pins the invariant that keeps the dihedral branch safe: 'c' is
+// only ever chosen by scoring candidates with sineAt(posA, posB, ...), which
+// is zero when A and B coincide, and both loops start from
+// collinearTolerance. So a row whose A and B coincide never acquires a 'c',
+// and the a-b axis a dihedral turns about is never degenerate at the point
+// calculateDihedral() is called.
+TEST(InternalCoordinatesTest, coincidentAtomsFourAtomChain)
+{
+  for (int coincidentWith = 0; coincidentWith < 3; ++coincidentWith) {
+    Molecule mol;
+    // A chain of four, where atom coincidentWith + 1 sits on top of its
+    // predecessor.
+    Vector3 positions[4] = { Vector3(0.0, 0.0, 0.0), Vector3(1.5, 0.0, 0.0),
+                             Vector3(2.0, 1.4, 0.0), Vector3(3.2, 1.8, 0.7) };
+    positions[coincidentWith + 1] = positions[coincidentWith];
+    for (const auto& position : positions)
+      mol.addAtom(6).setPosition3d(position);
+    for (int k = 0; k < 3; ++k)
+      mol.addBond(mol.atom(k), mol.atom(k + 1), 1);
+
+    Array<Index> rowToAtom;
+    Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+    ASSERT_EQ(ic.size(), static_cast<size_t>(4)) << "pair " << coincidentWith;
+
+    for (size_t row = 0; row < ic.size(); ++row) {
+      EXPECT_TRUE(std::isfinite(ic[row].length))
+        << "pair " << coincidentWith << " row " << row;
+      EXPECT_TRUE(std::isfinite(ic[row].angle))
+        << "pair " << coincidentWith << " row " << row;
+      EXPECT_TRUE(std::isfinite(ic[row].dihedral))
+        << "pair " << coincidentWith << " row " << row;
+
+      if (ic[row].a == MaxIndex || ic[row].b == MaxIndex)
+        continue;
+      const bool abCoincide =
+        (mol.atom(ic[row].b).position3d() - mol.atom(ic[row].a).position3d())
+          .norm() < 1e-8;
+      if (abCoincide)
+        EXPECT_EQ(ic[row].c, MaxIndex)
+          << "pair " << coincidentWith << " row " << row
+          << " has a dihedral about a degenerate a-b axis";
+    }
+
+    const Array<Vector3> rebuilt =
+      internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Canonical);
+    ASSERT_EQ(rebuilt.size(), static_cast<size_t>(4));
+    for (Index i = 0; i < 4; ++i) {
+      EXPECT_TRUE(std::isfinite(rebuilt[i].x()))
+        << "pair " << coincidentWith << " atom " << i;
+      EXPECT_TRUE(std::isfinite(rebuilt[i].y()))
+        << "pair " << coincidentWith << " atom " << i;
+      EXPECT_TRUE(std::isfinite(rebuilt[i].z()))
+        << "pair " << coincidentWith << " atom " << i;
+    }
+  }
+}

--- a/tests/core/internalcoordinatestest.cpp
+++ b/tests/core/internalcoordinatestest.cpp
@@ -5,13 +5,18 @@
 
 #include <gtest/gtest.h>
 
+#include <avogadro/core/angletools.h>
 #include <avogadro/core/array.h>
 #include <avogadro/core/internalcoordinates.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/vector.h>
 
 #include <cmath>
+#include <map>
 
+using Avogadro::calculateDihedral;
+using Avogadro::Index;
+using Avogadro::MaxIndex;
 using Avogadro::Real;
 using Avogadro::Vector3;
 using Avogadro::Core::Array;
@@ -19,6 +24,7 @@ using Avogadro::Core::cartesianToInternal;
 using Avogadro::Core::InternalCoordinate;
 using Avogadro::Core::internalToCartesian;
 using Avogadro::Core::Molecule;
+using Avogadro::Core::ZMatrixOrigin;
 
 namespace {
 
@@ -29,13 +35,89 @@ double distance(const Vector3& a, const Vector3& b)
   return (a - b).norm();
 }
 
+// Round-trip a molecule through its z-matrix and back. The result is
+// anchored canonically rather than on the molecule's own coordinates, so the
+// z-matrix alone has to carry the whole geometry -- preserving the origin
+// would let a partly-empty z-matrix pass by copying positions across.
+Array<Vector3> roundTrip(const Molecule& mol)
+{
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  return internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Canonical);
+}
+
+// Every pairwise distance surviving is the orientation-independent statement
+// that the geometry came back unchanged.
+void expectSameGeometry(const Molecule& mol, const Array<Vector3>& rebuilt,
+                        double tolerance = 1e-6)
+{
+  ASSERT_EQ(rebuilt.size(), mol.atomCount());
+  for (Index i = 0; i < mol.atomCount(); ++i) {
+    for (Index j = i + 1; j < mol.atomCount(); ++j) {
+      const double before =
+        distance(mol.atom(i).position3d(), mol.atom(j).position3d());
+      const double after = distance(rebuilt[i], rebuilt[j]);
+      EXPECT_NEAR(after, before, tolerance)
+        << "distance between atoms " << i << " and " << j;
+    }
+  }
+}
+
+// Idealised chair cyclohexane: a six-ring puckered above and below the mean
+// plane. The exact geometry does not matter here, only that it is a ring.
+Molecule chairCyclohexane()
+{
+  Molecule mol;
+  for (int k = 0; k < 6; ++k) {
+    const double theta = k * M_PI / 3.0;
+    const double z = (k % 2 == 0) ? 0.25 : -0.25;
+    mol.addAtom(6).setPosition3d(
+      Vector3(1.46 * std::cos(theta), 1.46 * std::sin(theta), z));
+  }
+  for (int k = 0; k < 6; ++k)
+    mol.addBond(mol.atom(k), mol.atom((k + 1) % 6), 1);
+  return mol;
+}
+
+// Tetrahedral methane, carbon first.
+Molecule methane()
+{
+  const double d = 1.09 / std::sqrt(3.0);
+  Molecule mol;
+  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(1).setPosition3d(Vector3(d, d, d));
+  mol.addAtom(1).setPosition3d(Vector3(d, -d, -d));
+  mol.addAtom(1).setPosition3d(Vector3(-d, d, -d));
+  mol.addAtom(1).setPosition3d(Vector3(-d, -d, d));
+  for (int k = 1; k <= 4; ++k)
+    mol.addBond(mol.atom(0), mol.atom(k), 1);
+  return mol;
+}
+
+// Gauche n-butane, so that the backbone dihedral is neither 0 nor 180 and
+// its sign is meaningful.
+Molecule gaucheButane()
+{
+  Molecule mol;
+  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(1.54, 0.0, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(2.05, 1.45, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(3.59, 1.45, 0.62));
+  mol.addBond(mol.atom(0), mol.atom(1), 1);
+  mol.addBond(mol.atom(1), mol.atom(2), 1);
+  mol.addBond(mol.atom(2), mol.atom(3), 1);
+  return mol;
+}
+
 } // namespace
 
 TEST(InternalCoordinatesTest, emptyMolecule)
 {
   Molecule mol;
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
   EXPECT_EQ(ic.size(), static_cast<size_t>(0));
+  EXPECT_EQ(rowToAtom.size(), static_cast<size_t>(0));
 }
 
 TEST(InternalCoordinatesTest, singleAtom)
@@ -43,8 +125,11 @@ TEST(InternalCoordinatesTest, singleAtom)
   Molecule mol;
   mol.addAtom(6).setPosition3d(Vector3(1.0, 2.0, 3.0));
 
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
-  EXPECT_EQ(ic.size(), static_cast<size_t>(1));
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(1));
+  EXPECT_EQ(rowToAtom[0], Index(0));
+  EXPECT_EQ(ic[0].a, MaxIndex);
   EXPECT_NEAR(ic[0].length, 0.0, 1e-6);
 }
 
@@ -55,17 +140,148 @@ TEST(InternalCoordinatesTest, twoAtoms)
   mol.addAtom(6).setPosition3d(Vector3(1.5, 0.0, 0.0));
   mol.addBond(mol.atom(0), mol.atom(1), 1);
 
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
-  EXPECT_EQ(ic.size(), static_cast<size_t>(2));
-  // Second atom should have length ~1.5
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(2));
+  EXPECT_EQ(ic[1].a, Index(0));
+  EXPECT_EQ(ic[1].b, MaxIndex);
   EXPECT_NEAR(ic[1].length, 1.5, 1e-4);
+}
+
+// A branch point must not lose its bond angle. Before references were drawn
+// from already-placed atoms, both hydrogens hung off the tree root with no
+// grandparent, and water came back with an H-O-H angle of exactly zero.
+TEST(InternalCoordinatesTest, branchedAtomKeepsBondAngle)
+{
+  Molecule mol;
+  mol.addAtom(8).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(1).setPosition3d(Vector3(0.9572, 0.0, 0.0));
+  mol.addAtom(1).setPosition3d(Vector3(-0.2400, 0.9266, 0.0));
+  mol.addBond(mol.atom(0), mol.atom(1), 1);
+  mol.addBond(mol.atom(0), mol.atom(2), 1);
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(3));
+
+  // The second hydrogen is measured against the oxygen and the first
+  // hydrogen, which is the only way its angle can be expressed.
+  EXPECT_EQ(ic[2].a, Index(0));
+  EXPECT_EQ(ic[2].b, Index(1));
+  EXPECT_NEAR(ic[2].angle, 104.52, 0.05);
+
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+// Hydrogens on a common centre used to receive identical references, so the
+// z-matrix could not tell them apart and they superimposed on rebuild.
+TEST(InternalCoordinatesTest, siblingsAreDistinguishable)
+{
+  Molecule mol = methane();
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(5));
+
+  // Both need a dihedral at all: without one there is nothing to separate a
+  // hydrogen from its siblings around the C-H axis.
+  EXPECT_NE(ic[3].c, MaxIndex);
+  EXPECT_NE(ic[4].c, MaxIndex);
+
+  // The two rows must not be the same row. They may share a dihedral value
+  // while measuring it against different atoms, which is why the references
+  // are part of the comparison.
+  const bool identical = ic[3].a == ic[4].a && ic[3].b == ic[4].b &&
+                         ic[3].c == ic[4].c &&
+                         std::abs(ic[3].dihedral - ic[4].dihedral) < 1e-6;
+  EXPECT_FALSE(identical) << "rows 3 and 4 describe the same position";
+
+  // Which shows up as the hydrogens landing on top of each other.
+  const Array<Vector3> rebuilt = roundTrip(mol);
+  ASSERT_EQ(rebuilt.size(), static_cast<size_t>(5));
+  for (Index i = 1; i <= 4; ++i)
+    for (Index j = i + 1; j <= 4; ++j)
+      EXPECT_GT(distance(rebuilt[i], rebuilt[j]), 1.0)
+        << "hydrogens " << i << " and " << j << " superimposed";
+
+  expectSameGeometry(mol, rebuilt);
+}
+
+// Every reference must name an atom from an earlier row, or the rebuild
+// reads a position that has not been computed yet. A molecule whose central
+// atom is not first exercises this.
+TEST(InternalCoordinatesTest, referencesPrecedeTheirRow)
+{
+  Molecule mol;
+  mol.addAtom(1).setPosition3d(Vector3(1.0, 0.0, 0.0));
+  mol.addAtom(1).setPosition3d(Vector3(-0.5, 0.9, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(1).setPosition3d(Vector3(-0.5, -0.45, 0.78));
+  mol.addBond(mol.atom(2), mol.atom(0), 1);
+  mol.addBond(mol.atom(2), mol.atom(1), 1);
+  mol.addBond(mol.atom(2), mol.atom(3), 1);
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(4));
+
+  std::map<Index, size_t> rowOfAtom;
+  for (size_t row = 0; row < rowToAtom.size(); ++row)
+    rowOfAtom[rowToAtom[row]] = row;
+  EXPECT_EQ(rowOfAtom.size(), static_cast<size_t>(4)) << "atoms placed twice";
+
+  for (size_t row = 0; row < ic.size(); ++row) {
+    for (Index reference : { ic[row].a, ic[row].b, ic[row].c }) {
+      if (reference == MaxIndex)
+        continue;
+      ASSERT_EQ(rowOfAtom.count(reference), static_cast<size_t>(1))
+        << "row " << row << " references atom " << reference
+        << ", which is not in the matrix";
+      EXPECT_LT(rowOfAtom[reference], row)
+        << "row " << row << " references atom " << reference
+        << " from a later row";
+    }
+  }
+
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+// A molecule already in a valid z-matrix order keeps that order, so the
+// editor has no reason to renumber it.
+TEST(InternalCoordinatesTest, validOrderIsLeftAlone)
+{
+  Molecule mol = methane();
+
+  Array<Index> rowToAtom;
+  cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(rowToAtom.size(), static_cast<size_t>(5));
+  for (size_t row = 0; row < rowToAtom.size(); ++row)
+    EXPECT_EQ(rowToAtom[row], Index(row)) << "row " << row;
+}
+
+// Separate fragments used to be rooted at the origin one on top of another.
+TEST(InternalCoordinatesTest, disconnectedFragmentsStayApart)
+{
+  Molecule mol;
+  for (int fragment = 0; fragment < 2; ++fragment) {
+    const double shift = 5.0 * fragment;
+    const Index o = mol.atomCount();
+    mol.addAtom(8).setPosition3d(Vector3(shift, 0.0, 0.0));
+    mol.addAtom(1).setPosition3d(Vector3(shift + 0.9572, 0.0, 0.0));
+    mol.addAtom(1).setPosition3d(Vector3(shift - 0.2400, 0.9266, 0.0));
+    mol.addBond(mol.atom(o), mol.atom(o + 1), 1);
+    mol.addBond(mol.atom(o), mol.atom(o + 2), 1);
+  }
+
+  const Array<Vector3> rebuilt = roundTrip(mol);
+  ASSERT_EQ(rebuilt.size(), static_cast<size_t>(6));
+  EXPECT_NEAR(distance(rebuilt[0], rebuilt[3]), 5.0, 1e-6)
+    << "the two fragments collapsed onto each other";
+  expectSameGeometry(mol, rebuilt);
 }
 
 TEST(InternalCoordinatesTest, chainRoundTrip)
 {
-  // Chain molecule (propane-like): C-C-C
-  // Round-trip works for chain topologies where BFS tree gives
-  // proper parent/grandparent references
   Molecule mol;
   mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
   mol.addAtom(6).setPosition3d(Vector3(1.54, 0.0, 0.0));
@@ -73,67 +289,124 @@ TEST(InternalCoordinatesTest, chainRoundTrip)
   mol.addBond(mol.atom(0), mol.atom(1), 1);
   mol.addBond(mol.atom(1), mol.atom(2), 1);
 
-  // Get original interatomic distances
-  double d01_orig =
-    distance(mol.atom(0).position3d(), mol.atom(1).position3d());
-  double d12_orig =
-    distance(mol.atom(1).position3d(), mol.atom(2).position3d());
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(3));
+  EXPECT_NEAR(ic[1].length, 1.54, 1e-4);
+  EXPECT_NEAR(ic[2].length,
+              distance(mol.atom(1).position3d(), mol.atom(2).position3d()),
+              1e-4);
 
-  // Convert to internal coordinates
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
-  EXPECT_EQ(ic.size(), static_cast<size_t>(3));
-
-  // Verify bond lengths in internal coords
-  EXPECT_NEAR(ic[1].length, d01_orig, 1e-4);
-  EXPECT_NEAR(ic[2].length, d12_orig, 1e-4);
-
-  // Convert back to Cartesian
-  Array<Vector3> newCoords = internalToCartesian(mol, ic);
-  EXPECT_EQ(newCoords.size(), static_cast<size_t>(3));
-
-  // Compare interatomic distances
-  double d01_new = distance(newCoords[0], newCoords[1]);
-  double d12_new = distance(newCoords[1], newCoords[2]);
-
-  EXPECT_NEAR(d01_new, d01_orig, 1e-4);
-  EXPECT_NEAR(d12_new, d12_orig, 1e-4);
+  expectSameGeometry(mol, roundTrip(mol));
 }
 
 TEST(InternalCoordinatesTest, butaneRoundTrip)
 {
-  // Butane chain: C-C-C-C (tests dihedral code path)
+  Molecule mol = gaucheButane();
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+// The dihedral has to come back with its sign intact, or a rebuild mirrors
+// the molecule. This also pins cartesianToInternal() to the same convention
+// as Core::calculateDihedral(), which the property tables use.
+TEST(InternalCoordinatesTest, dihedralSignSurvivesRoundTrip)
+{
+  Molecule mol = gaucheButane();
+
+  const Real expected =
+    calculateDihedral(mol.atom(3).position3d(), mol.atom(2).position3d(),
+                      mol.atom(1).position3d(), mol.atom(0).position3d());
+  ASSERT_GT(std::abs(expected), 5.0) << "test needs a non-planar backbone";
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(4));
+
+  // Row 3 places atom 3 against 2, 1 and 0, which is that same dihedral.
+  EXPECT_EQ(ic[3].a, Index(2));
+  EXPECT_EQ(ic[3].b, Index(1));
+  EXPECT_EQ(ic[3].c, Index(0));
+  EXPECT_NEAR(ic[3].dihedral, expected, 1e-4);
+
+  const Array<Vector3> rebuilt = roundTrip(mol);
+  const Real after =
+    calculateDihedral(rebuilt[3], rebuilt[2], rebuilt[1], rebuilt[0]);
+  EXPECT_NEAR(after, expected, 1e-4) << "the rebuilt molecule is mirrored";
+}
+
+// The dihedral sign is not a matter of taste: reading it the wrong way round
+// leaves every distance and angle correct and builds the enantiomer. This is
+// the shape InsertPeptide relies on, whose residue z-matrices come from
+// fragments/amino/*.zmat -- the first eight rows of ALA.zmat are reproduced
+// here, with the file's 1-based references converted to 0-based.
+TEST(InternalCoordinatesTest, chiralityFromZMatrix)
+{
   Molecule mol;
-  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
-  mol.addAtom(6).setPosition3d(Vector3(1.54, 0.0, 0.0));
-  mol.addAtom(6).setPosition3d(Vector3(2.31, 1.26, 0.0));
-  mol.addAtom(6).setPosition3d(Vector3(3.85, 1.26, 0.0));
-  mol.addBond(mol.atom(0), mol.atom(1), 1);
-  mol.addBond(mol.atom(1), mol.atom(2), 1);
-  mol.addBond(mol.atom(2), mol.atom(3), 1);
+  for (int i = 0; i < 8; ++i)
+    mol.addAtom(6); // N, CA, C, O, CB, OXT, H, HA
 
-  // Store original pairwise distances
-  std::vector<double> origDist;
-  for (int i = 0; i < 4; ++i)
-    for (int j = i + 1; j < 4; ++j)
-      origDist.push_back(
-        distance(mol.atom(i).position3d(), mol.atom(j).position3d()));
+  Array<InternalCoordinate> ic(8);
+  auto row = [&ic](int i, Index a, Real length, Index b, Real angle, Index c,
+                   Real dihedral) {
+    ic[i].a = a;
+    ic[i].length = length;
+    ic[i].b = b;
+    ic[i].angle = angle;
+    ic[i].c = c;
+    ic[i].dihedral = dihedral;
+  };
+  row(0, MaxIndex, 0.0, MaxIndex, 0.0, MaxIndex, 0.0);
+  row(1, 0, 1.4677, MaxIndex, 0.0, MaxIndex, 0.0);
+  row(2, 1, 1.5054, 0, 109.5241, MaxIndex, 0.0);
+  row(3, 2, 1.2070, 1, 120.0308, 0, 330.1001);
+  row(4, 1, 1.5294, 0, 109.4645, 2, 240.0009);
+  row(5, 2, 1.3419, 1, 120.0083, 0, 149.9558);
+  row(6, 0, 1.0084, 1, 106.7514, 2, 59.95234);
+  row(7, 1, 1.0899, 0, 109.4654, 2, 120.0828);
 
-  // Round-trip
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
-  EXPECT_EQ(ic.size(), static_cast<size_t>(4));
+  const Array<Vector3> pos = internalToCartesian(mol, ic);
+  ASSERT_EQ(pos.size(), static_cast<size_t>(8));
 
-  Array<Vector3> newCoords = internalToCartesian(mol, ic);
-  EXPECT_EQ(newCoords.size(), static_cast<size_t>(4));
+  // CIP priorities at the alpha carbon are N > C(=O) > CB > HA. With the
+  // three highest taken in order, a positive determinant is S and a negative
+  // one is R. Alanine as tabulated is L, which is (S).
+  const Vector3 toN = pos[0] - pos[1];
+  const Vector3 toC = pos[2] - pos[1];
+  const Vector3 toCB = pos[4] - pos[1];
+  EXPECT_GT(toN.dot(toC.cross(toCB)), 0.0)
+    << "the residue was built as its D enantiomer";
 
-  // Compare all pairwise distances
-  int idx = 0;
-  for (int i = 0; i < 4; ++i)
-    for (int j = i + 1; j < 4; ++j) {
-      double newDist = distance(newCoords[i], newCoords[j]);
-      EXPECT_NEAR(newDist, origDist[idx], 1e-3)
-        << "Distance mismatch between atoms " << i << " and " << j;
-      ++idx;
-    }
+  // The alpha carbon should still be tetrahedral, so that a failure above is
+  // read as a mirrored centre rather than a mangled one.
+  const Vector3 toHA = pos[7] - pos[1];
+  EXPECT_LT(toHA.dot(toN.normalized() + toC.normalized() + toCB.normalized()),
+            0.0);
+}
+
+TEST(InternalCoordinatesTest, ringRoundTrip)
+{
+  Molecule mol = chairCyclohexane();
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+// Rebuilding a molecule that has not been edited must not move it, which is
+// what lets the editor rebuild without the view jumping.
+TEST(InternalCoordinatesTest, preserveOriginKeepsPlacement)
+{
+  Molecule mol = gaucheButane();
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  const Array<Vector3> rebuilt =
+    internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Preserve);
+
+  ASSERT_EQ(rebuilt.size(), mol.atomCount());
+  for (Index i = 0; i < mol.atomCount(); ++i) {
+    const Vector3 before = mol.atom(i).position3d();
+    EXPECT_NEAR(rebuilt[i].x(), before.x(), 1e-6) << "atom " << i;
+    EXPECT_NEAR(rebuilt[i].y(), before.y(), 1e-6) << "atom " << i;
+    EXPECT_NEAR(rebuilt[i].z(), before.z(), 1e-6) << "atom " << i;
+  }
 }
 
 TEST(InternalCoordinatesTest, waterFromInternal)
@@ -178,12 +451,14 @@ TEST(InternalCoordinatesTest, waterFromInternal)
   for (size_t i = 0; i < 3; ++i)
     mol.atom(i).setPosition3d(coords[i]);
 
-  Array<InternalCoordinate> ic2 = cartesianToInternal(mol);
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic2 = cartesianToInternal(mol, rowToAtom);
   ASSERT_EQ(ic2.size(), static_cast<size_t>(3));
 
-  // Bond lengths should survive the round-trip
+  // Bond lengths and the angle should survive the round-trip
   EXPECT_NEAR(ic2[1].length, 0.96, 1e-4);
   EXPECT_NEAR(ic2[2].length, 0.96, 1e-4);
+  EXPECT_NEAR(ic2[2].angle, 104.5, 1e-3);
 }
 
 TEST(InternalCoordinatesTest, methaneFromInternal)
@@ -254,7 +529,8 @@ TEST(InternalCoordinatesTest, methaneFromInternal)
   for (size_t i = 0; i < 5; ++i)
     mol.atom(i).setPosition3d(coords[i]);
 
-  Array<InternalCoordinate> ic2 = cartesianToInternal(mol);
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic2 = cartesianToInternal(mol, rowToAtom);
   ASSERT_EQ(ic2.size(), static_cast<size_t>(5));
 
   // All C-H bond lengths should survive the round-trip
@@ -263,9 +539,11 @@ TEST(InternalCoordinatesTest, methaneFromInternal)
       << "Round-trip C-H" << i << " bond length";
 }
 
+// A collinear molecule has no plane for a dihedral to be measured in. The
+// angle is then 0 or 180, so the dihedral cannot affect where the atom sits
+// and the geometry still rebuilds exactly.
 TEST(InternalCoordinatesTest, linearTriatomic)
 {
-  // CO2-like: O-C-O along x-axis
   Molecule mol;
   mol.addAtom(8).setPosition3d(Vector3(-1.16, 0.0, 0.0));
   mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
@@ -273,10 +551,106 @@ TEST(InternalCoordinatesTest, linearTriatomic)
   mol.addBond(mol.atom(0), mol.atom(1), 2);
   mol.addBond(mol.atom(1), mol.atom(2), 2);
 
-  Array<InternalCoordinate> ic = cartesianToInternal(mol);
-  EXPECT_EQ(ic.size(), static_cast<size_t>(3));
-
-  // Verify bond lengths
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(3));
   EXPECT_NEAR(ic[1].length, 1.16, 1e-3);
   EXPECT_NEAR(ic[2].length, 1.16, 1e-3);
+  EXPECT_NEAR(ic[2].angle, 180.0, 1e-3);
+
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+TEST(InternalCoordinatesTest, linearFourAtoms)
+{
+  // Diacetylene-like: four collinear atoms, so no candidate for 'c' is ever
+  // out of line and the fourth row falls back to a distance and an angle.
+  Molecule mol;
+  for (int k = 0; k < 4; ++k)
+    mol.addAtom(6).setPosition3d(Vector3(1.2 * k, 0.0, 0.0));
+  for (int k = 0; k < 3; ++k)
+    mol.addBond(mol.atom(k), mol.atom(k + 1), 1);
+
+  expectSameGeometry(mol, roundTrip(mol));
+}
+
+// Malformed input must not read past the end of an array.
+TEST(InternalCoordinatesTest, mismatchedRowCount)
+{
+  Molecule mol = gaucheButane();
+
+  Array<InternalCoordinate> ic(2);
+  Array<Index> rowToAtom(3);
+  rowToAtom[0] = 0;
+  rowToAtom[1] = 1;
+  rowToAtom[2] = 2;
+
+  const Array<Vector3> coords =
+    internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Canonical);
+  EXPECT_EQ(coords.size(), mol.atomCount());
+}
+
+TEST(InternalCoordinatesTest, outOfRangeReferences)
+{
+  Molecule mol = gaucheButane();
+
+  Array<Index> rowToAtom(4);
+  Array<InternalCoordinate> ic(4);
+  for (size_t row = 0; row < 4; ++row)
+    rowToAtom[row] = row;
+
+  // References naming atoms that do not exist, or that this row's own
+  // position would be needed to place.
+  ic[1].a = 999;
+  ic[1].length = 1.5;
+  ic[2].a = 0;
+  ic[2].b = 3; // not placed yet
+  ic[2].length = 1.5;
+  ic[2].angle = 110.0;
+  ic[3].a = 0;
+  ic[3].b = 1;
+  ic[3].c = MaxIndex;
+  ic[3].length = 1.5;
+  ic[3].angle = 110.0;
+
+  const Array<Vector3> coords =
+    internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Canonical);
+  ASSERT_EQ(coords.size(), static_cast<size_t>(4));
+  for (Index i = 0; i < 4; ++i) {
+    EXPECT_TRUE(std::isfinite(coords[i].x())) << "atom " << i;
+    EXPECT_TRUE(std::isfinite(coords[i].y())) << "atom " << i;
+    EXPECT_TRUE(std::isfinite(coords[i].z())) << "atom " << i;
+  }
+  // The rows that were usable still honour their distance.
+  EXPECT_NEAR(distance(coords[0], coords[2]), 1.5, 1e-6);
+  EXPECT_NEAR(distance(coords[0], coords[3]), 1.5, 1e-6);
+}
+
+// Atoms sitting on top of each other must not produce NaN positions.
+TEST(InternalCoordinatesTest, coincidentAtoms)
+{
+  Molecule mol;
+  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(0.0, 0.0, 0.0));
+  mol.addAtom(6).setPosition3d(Vector3(1.5, 0.0, 0.0));
+  mol.addBond(mol.atom(0), mol.atom(1), 1);
+  mol.addBond(mol.atom(1), mol.atom(2), 1);
+
+  Array<Index> rowToAtom;
+  Array<InternalCoordinate> ic = cartesianToInternal(mol, rowToAtom);
+  ASSERT_EQ(ic.size(), static_cast<size_t>(3));
+  for (size_t row = 0; row < ic.size(); ++row) {
+    EXPECT_TRUE(std::isfinite(ic[row].length)) << "row " << row;
+    EXPECT_TRUE(std::isfinite(ic[row].angle)) << "row " << row;
+    EXPECT_TRUE(std::isfinite(ic[row].dihedral)) << "row " << row;
+  }
+
+  const Array<Vector3> rebuilt =
+    internalToCartesian(mol, ic, rowToAtom, ZMatrixOrigin::Canonical);
+  ASSERT_EQ(rebuilt.size(), static_cast<size_t>(3));
+  for (Index i = 0; i < 3; ++i) {
+    EXPECT_TRUE(std::isfinite(rebuilt[i].x())) << "atom " << i;
+    EXPECT_TRUE(std::isfinite(rebuilt[i].y())) << "atom " << i;
+    EXPECT_TRUE(std::isfinite(rebuilt[i].z())) << "atom " << i;
+  }
 }


### PR DESCRIPTION
This is the start of a z-matrix editor window

Draw atoms from those placed, not necessarily BFS order Fixed a bug with sign of dihedral angle placement

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved conversion between molecular Cartesian coordinates and internal (Z-matrix) coordinates.
  * Added support for preserving atom ordering and the original coordinate-system orientation.
  * Added handling for branched and disconnected molecules, linear structures, chirality, and dihedral signs.

* **Bug Fixes**
  * Improved geometry reconstruction for complex molecular structures, including coincident atoms and ambiguous references.

* **Tests**
  * Expanded round-trip and validation coverage for internal-coordinate conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->