### PR TITLE
Add support in RWMolecule for swapAtoms

### DIFF
--- a/avogadro/core/basisset.h
+++ b/avogadro/core/basisset.h
@@ -123,6 +123,17 @@ public:
   virtual bool isValid() = 0;
 
   /**
+   * Exchange the atom indices @a a and @a b wherever this basis set records
+   * which atom a basis function is centred on.
+   *
+   * Called when a molecule renumbers its atoms. Only the recorded indices
+   * change: the basis functions keep their order, so molecular orbital
+   * coefficients stay valid. The default does nothing, for basis sets that
+   * do not refer to atoms by index.
+   */
+  virtual void swapAtomIndices(Index, Index) {}
+
+  /**
    * @return the orbital symmetry labels (if they exist) for the MOs
    */
   std::vector<std::string> symmetryLabels(ElectronType type = Paired) const
@@ -251,7 +262,7 @@ inline unsigned int BasisSet::lumo(ElectronType type) const
       }
     }
   }
-  // fall back to electron count 
+  // fall back to electron count
   // (supports odd number of electrons))
   if (type == Beta) {
     return m_electrons[0] / 2 + 1;

--- a/avogadro/core/gaussianset.cpp
+++ b/avogadro/core/gaussianset.cpp
@@ -296,6 +296,18 @@ bool GaussianSet::isValid()
   return true;
 }
 
+void GaussianSet::swapAtomIndices(Index a, Index b)
+{
+  const auto first = static_cast<unsigned int>(a);
+  const auto second = static_cast<unsigned int>(b);
+  for (auto& index : m_atomIndices) {
+    if (index == first)
+      index = second;
+    else if (index == second)
+      index = first;
+  }
+}
+
 void GaussianSet::initCalculation()
 {
   if (m_init)

--- a/avogadro/core/gaussianset.h
+++ b/avogadro/core/gaussianset.h
@@ -181,6 +181,12 @@ public:
   bool isValid() override;
 
   /**
+   * Exchange atom indices @a a and @a b in the per-shell atom map. The shells
+   * themselves keep their order, so MO coefficients are unaffected.
+   */
+  void swapAtomIndices(Index a, Index b) override;
+
+  /**
    * Set the SCF type for the object.
    */
   void setScfType(ScfType type) { m_scfType = type; }

--- a/avogadro/core/molecule.cpp
+++ b/avogadro/core/molecule.cpp
@@ -689,6 +689,18 @@ namespace {
 // normal modes, partial charges -- is dropped there instead; see the comment
 // in removeAtom(). Deciding which of the two a new member is, is the part
 // that needs thought.
+//
+// A member does not have to be atom-indexed to hold an atom index, and those
+// are the ones this list is apt to miss. m_residues is residue-indexed but
+// the Atom proxies in its name maps store atom indices; m_constraints names
+// up to four atoms per constraint; and m_basisSet records the atom each basis
+// function is centred on. All three need reindexing all the same, and
+// swapAtom() handles them explicitly at its end.
+//
+// One is still unhandled, and needs a decision rather than a mechanical
+// remap: m_residues in removeAtom(). Dropping a hydrogen from a residue is
+// just an erase, but dropping a backbone atom arguably invalidates the
+// residue altogether, and that is a chemistry question.
 
 // Plain Array<T>, one entry per atom.
 template <typename T>
@@ -828,6 +840,46 @@ void Molecule::swapAtom(Index a, Index b)
   m_graph.swapVertexIndices(a, b);
   m_layers.swapLayer(a, b);
   m_atomProperties.swapEntries(a, b, atomCount());
+
+  // Residues are not an atom-indexed member and so are reached by none of the
+  // helpers above: the array is residue-indexed, and it is the Atom proxies
+  // inside each residue's name map that carry an atom index. Left alone, a
+  // residue's atom names go on pointing at indices that now hold different
+  // atoms -- the residue silently adopts its neighbours.
+  for (auto& residue : m_residues) {
+    for (auto& entry : residue.atomNameMap()) {
+      const Index index = entry.second.index();
+      if (index == a)
+        entry.second = AtomType(entry.second.molecule(), b);
+      else if (index == b)
+        entry.second = AtomType(entry.second.molecule(), a);
+    }
+  }
+
+  // Constraints are not atom-indexed either, but each names up to four atoms
+  // by index. Unused references are MaxIndex, which never matches a real
+  // atom, so they are left alone. Constraint::set() re-infers a cached type
+  // that was not set explicitly, and that inference only asks which indices
+  // are MaxIndex -- something a swap cannot change.
+  auto reindex = [a, b](Index index) {
+    if (index == a)
+      return b;
+    if (index == b)
+      return a;
+    return index;
+  };
+  for (auto& constraint : m_constraints) {
+    constraint.set(reindex(constraint.aIndex()), reindex(constraint.bIndex()),
+                   reindex(constraint.cIndex()), reindex(constraint.dIndex()),
+                   constraint.value());
+  }
+
+  // A basis set records which atom each basis function is centred on. Only
+  // those recorded indices move: the basis functions keep their order, so
+  // molecular orbital coefficients, which are indexed by basis function,
+  // remain valid.
+  if (m_basisSet != nullptr)
+    m_basisSet->swapAtomIndices(a, b);
 }
 
 bool Molecule::removeAtom(Index index)

--- a/avogadro/core/slaterset.cpp
+++ b/avogadro/core/slaterset.cpp
@@ -12,6 +12,18 @@
 
 namespace Avogadro::Core {
 
+void SlaterSet::swapAtomIndices(Index a, Index b)
+{
+  const auto first = static_cast<int>(a);
+  const auto second = static_cast<int>(b);
+  for (auto& index : m_slaterIndices) {
+    if (index == first)
+      index = second;
+    else if (index == second)
+      index = first;
+  }
+}
+
 bool SlaterSet::addSlaterIndices(const std::vector<int>& i)
 {
   m_slaterIndices = i;

--- a/avogadro/core/slaterset.h
+++ b/avogadro/core/slaterset.h
@@ -125,6 +125,12 @@ public:
   bool isValid() override { return true; }
 
   /**
+   * Exchange atom indices @a a and @a b in the per-basis-function atom map.
+   * The basis functions keep their order, so MO coefficients are unaffected.
+   */
+  void swapAtomIndices(Index a, Index b) override;
+
+  /**
    * Initialize the calculation, this must normally be done before anything.
    */
   void initCalculation();

--- a/avogadro/qtgui/rwmolecule.cpp
+++ b/avogadro/qtgui/rwmolecule.cpp
@@ -104,6 +104,57 @@ void RWMolecule::clearAtoms()
   m_undoStack.endMacro();
 }
 
+bool RWMolecule::reorderAtoms(const Core::Array<Index>& newOrder)
+{
+  const Index count = atomCount();
+  if (newOrder.size() != count)
+    return false;
+
+  // Check that this really is a permutation before touching the molecule. A
+  // repeated or out-of-range entry would copy one atom's data over another's
+  // and leave no way back.
+  std::vector<bool> seen(count, false);
+  for (Index i = 0; i < count; ++i) {
+    const Index from = newOrder[i];
+    if (from >= count || seen[from])
+      return false;
+    seen[from] = true;
+  }
+
+  // Decompose the permutation into transpositions. current[i] is the
+  // original index of the atom now sitting at i, and where[] is its inverse,
+  // so the atom wanted at each position is found without searching for it.
+  std::vector<Index> current(count);
+  std::vector<Index> where(count);
+  for (Index i = 0; i < count; ++i) {
+    current[i] = i;
+    where[i] = i;
+  }
+
+  std::vector<std::pair<Index, Index>> swaps;
+  for (Index i = 0; i < count; ++i) {
+    const Index wanted = newOrder[i];
+    const Index j = where[wanted];
+    if (j == i)
+      continue; // already in place
+    const Index displaced = current[i];
+    swaps.emplace_back(i, j);
+    std::swap(current[i], current[j]);
+    where[wanted] = i;
+    where[displaced] = j;
+  }
+
+  if (swaps.empty())
+    return true; // the molecule is already in this order
+
+  auto* comm = new ReorderAtomsCommand(*this, swaps);
+  comm->setText(tr("Reorder Atoms"));
+  m_undoStack.push(comm);
+
+  emitChanged(Molecule::Atoms | Molecule::Bonds | Molecule::Modified);
+  return true;
+}
+
 void RWMolecule::adjustHydrogens(Index atomId)
 {
   RWAtom atom = this->atom(atomId);

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -167,10 +167,12 @@ public:
   /**
    * Renumber the atoms in this molecule.
    *
-   * Everything indexed by atom follows its atom: positions, labels, charges,
-   * colors, selection, layers, bonds, residues, coordinate sets and unique
-   * ids. No atom or bond is added or removed, so this is a relabelling of
-   * the same structure.
+   * Everything holding an atom index follows its atom: positions, labels,
+   * charges, colors, selection, layers, bonds, residue membership,
+   * constraints, normal mode displacements, the atom each basis function is
+   * centred on, coordinate sets and unique ids. No atom or bond is added or
+   * removed, so this is a relabelling of the same structure, and results
+   * computed for it -- a wavefunction, a set of vibrations -- stay valid.
    *
    * @param newOrder A permutation of [0, atomCount()): newOrder[i] is the
    * index the atom currently at that position will be moved *from*, so that

--- a/avogadro/qtgui/rwmolecule.h
+++ b/avogadro/qtgui/rwmolecule.h
@@ -165,6 +165,25 @@ public:
   void clearAtoms();
 
   /**
+   * Renumber the atoms in this molecule.
+   *
+   * Everything indexed by atom follows its atom: positions, labels, charges,
+   * colors, selection, layers, bonds, residues, coordinate sets and unique
+   * ids. No atom or bond is added or removed, so this is a relabelling of
+   * the same structure.
+   *
+   * @param newOrder A permutation of [0, atomCount()): newOrder[i] is the
+   * index the atom currently at that position will be moved *from*, so that
+   * after the call atom @a i is the atom that was at newOrder[i].
+   * @return True on success. False, changing nothing, if @a newOrder is not
+   * a permutation of exactly the molecule's atoms.
+   *
+   * @note Atom indices are how selections, scripts and other tables refer to
+   * atoms, so this invalidates any index held elsewhere.
+   */
+  bool reorderAtoms(const Core::Array<Index>& newOrder);
+
+  /**
    * Adjust hydrogens for an atom.
    * @param atomId The index of the atom.
    * @note Checks to make sure the atom is valid before adjusting the hydrogens.

--- a/avogadro/qtgui/rwmolecule_undo.h
+++ b/avogadro/qtgui/rwmolecule_undo.h
@@ -150,6 +150,36 @@ public:
 } // namespace
 
 namespace {
+// Renumbering is stored as the sequence of transpositions that realises the
+// permutation rather than as the permutation itself. A transposition is its
+// own inverse, so undoing is the same sequence walked backwards, and there is
+// no second permutation to keep consistent with the first.
+class ReorderAtomsCommand : public RWMolecule::UndoCommand
+{
+  std::vector<std::pair<Index, Index>> m_swaps;
+
+public:
+  ReorderAtomsCommand(RWMolecule& m,
+                      const std::vector<std::pair<Index, Index>>& swaps)
+    : UndoCommand(m), m_swaps(swaps)
+  {
+  }
+
+  void redo() override
+  {
+    for (const auto& swap : m_swaps)
+      m_molecule.swapAtom(swap.first, swap.second);
+  }
+
+  void undo() override
+  {
+    for (auto it = m_swaps.rbegin(); it != m_swaps.rend(); ++it)
+      m_molecule.swapAtom(it->first, it->second);
+  }
+};
+} // namespace
+
+namespace {
 class SetAtomicNumbersCommand : public RWMolecule::UndoCommand
 {
   Core::Array<unsigned char> m_oldAtomicNumbers;

--- a/tests/core/moleculetest.cpp
+++ b/tests/core/moleculetest.cpp
@@ -9,6 +9,8 @@
 
 #include <avogadro/core/array.h>
 #include <avogadro/core/color3f.h>
+#include <avogadro/core/constraint.h>
+#include <avogadro/core/gaussianset.h>
 #include <avogadro/core/mesh.h>
 #include <avogadro/core/molecule.h>
 #include <avogadro/core/propertymap.h>
@@ -1476,4 +1478,175 @@ TEST_F(MoleculeTest, ConformerProperties)
   // clearCoordinate3d should clear conformer properties
   m_testMolecule.clearCoordinate3d();
   EXPECT_TRUE(m_testMolecule.conformerProperties().empty());
+}
+
+// Residues are residue-indexed, not atom-indexed, but the Atom proxies in
+// their name maps carry atom indices. swapAtom() has to reindex those too, or
+// a residue keeps the names and silently adopts whichever atoms land on the
+// old indices.
+TEST_F(MoleculeTest, SwapAtomReindexesResidues)
+{
+  Avogadro::Core::Molecule molecule;
+  molecule.addAtom(7).setPosition3d(Avogadro::Vector3(0.0, 0.0, 0.0)); // N
+  molecule.addAtom(6).setPosition3d(Avogadro::Vector3(1.5, 0.0, 0.0)); // CA
+  molecule.addAtom(8).setPosition3d(Avogadro::Vector3(2.5, 1.0, 0.0)); // O
+
+  std::string resName = "ALA";
+  Avogadro::Index resNumber = 1;
+  char chain = 'A';
+  Avogadro::Core::Residue& residue =
+    molecule.addResidue(resName, resNumber, chain);
+  residue.addResidueAtom("N", molecule.atom(0));
+  residue.addResidueAtom("CA", molecule.atom(1));
+  residue.addResidueAtom("O", molecule.atom(2));
+
+  molecule.swapAtom(0, 2);
+
+  // Each name must still resolve to the atom it was given, which is now at a
+  // different index and is identified here by its element.
+  const Avogadro::Core::Residue& swapped = molecule.residue(0);
+  EXPECT_EQ(static_cast<Avogadro::Index>(2), swapped.atomByName("N").index());
+  EXPECT_EQ(7, swapped.atomByName("N").atomicNumber());
+  EXPECT_EQ(static_cast<Avogadro::Index>(1), swapped.atomByName("CA").index());
+  EXPECT_EQ(6, swapped.atomByName("CA").atomicNumber());
+  EXPECT_EQ(static_cast<Avogadro::Index>(0), swapped.atomByName("O").index());
+  EXPECT_EQ(8, swapped.atomByName("O").atomicNumber());
+
+  // Swapping back restores the original numbering.
+  molecule.swapAtom(0, 2);
+  EXPECT_EQ(static_cast<Avogadro::Index>(0),
+            molecule.residue(0).atomByName("N").index());
+  EXPECT_EQ(static_cast<Avogadro::Index>(2),
+            molecule.residue(0).atomByName("O").index());
+}
+
+// An atom outside the residue must not be dragged into it by a swap.
+TEST_F(MoleculeTest, SwapAtomLeavesUnrelatedAtomsOutOfResidues)
+{
+  Avogadro::Core::Molecule molecule;
+  for (int i = 0; i < 4; ++i)
+    molecule.addAtom(static_cast<unsigned char>(6 + i));
+
+  std::string resName = "LIG";
+  Avogadro::Index resNumber = 1;
+  char chain = 'A';
+  Avogadro::Core::Residue& residue =
+    molecule.addResidue(resName, resNumber, chain);
+  residue.addResidueAtom("C1", molecule.atom(0));
+
+  // Atom 3 belongs to no residue; swapping it with the residue's only atom
+  // must move the membership, not duplicate or drop it.
+  molecule.swapAtom(0, 3);
+
+  const Avogadro::Core::Residue& swapped = molecule.residue(0);
+  EXPECT_EQ(static_cast<size_t>(1), swapped.residueAtoms().size());
+  EXPECT_EQ(static_cast<Avogadro::Index>(3), swapped.atomByName("C1").index());
+  EXPECT_EQ(6, swapped.atomByName("C1").atomicNumber());
+}
+
+// Constraints name atoms by index without being atom-indexed themselves, so
+// swapAtom() has to reindex them or a constraint silently starts restraining
+// different atoms.
+TEST_F(MoleculeTest, SwapAtomReindexesConstraints)
+{
+  Avogadro::Core::Molecule molecule;
+  for (int i = 0; i < 5; ++i)
+    molecule.addAtom(static_cast<unsigned char>(6 + i));
+
+  // A distance constraint on atoms 0-1, and a torsion on 0-1-2-3.
+  molecule.addConstraint(1.5, 0, 1);
+  molecule.addConstraint(60.0, 0, 1, 2, 3);
+
+  molecule.swapAtom(0, 4);
+
+  const auto& distance = molecule.constraints()[0];
+  EXPECT_EQ(static_cast<Avogadro::Index>(4), distance.aIndex());
+  EXPECT_EQ(static_cast<Avogadro::Index>(1), distance.bIndex());
+  EXPECT_EQ(1.5, distance.value());
+  // An unused reference stays unused rather than being reindexed onto an atom.
+  EXPECT_EQ(Avogadro::MaxIndex, distance.cIndex());
+  EXPECT_EQ(Avogadro::MaxIndex, distance.dIndex());
+  EXPECT_EQ(Avogadro::Core::Constraint::DistanceConstraint, distance.type());
+
+  const auto& torsion = molecule.constraints()[1];
+  EXPECT_EQ(static_cast<Avogadro::Index>(4), torsion.aIndex());
+  EXPECT_EQ(static_cast<Avogadro::Index>(1), torsion.bIndex());
+  EXPECT_EQ(static_cast<Avogadro::Index>(2), torsion.cIndex());
+  EXPECT_EQ(static_cast<Avogadro::Index>(3), torsion.dIndex());
+  EXPECT_EQ(60.0, torsion.value());
+  EXPECT_EQ(Avogadro::Core::Constraint::TorsionConstraint, torsion.type());
+
+  // A swap between two atoms a constraint names must exchange them, not drop
+  // one of them.
+  molecule.swapAtom(1, 2);
+  const auto& swapped = molecule.constraints()[1];
+  EXPECT_EQ(static_cast<Avogadro::Index>(2), swapped.bIndex());
+  EXPECT_EQ(static_cast<Avogadro::Index>(1), swapped.cIndex());
+}
+
+// A basis set records which atom each basis function sits on. Renumbering
+// atoms under a wavefunction has to carry those references across, or the
+// orbitals are silently attributed to the wrong nuclei.
+TEST_F(MoleculeTest, SwapAtomReindexesGaussianBasis)
+{
+  Avogadro::Core::Molecule molecule;
+  for (int i = 0; i < 3; ++i)
+    molecule.addAtom(static_cast<unsigned char>(6 + i));
+
+  auto* basis = new Avogadro::Core::GaussianSet;
+  basis->setMolecule(&molecule);
+  // One shell on atom 0, two on atom 2, one on atom 1.
+  basis->addBasis(0, Avogadro::Core::GaussianSet::S);
+  basis->addBasis(2, Avogadro::Core::GaussianSet::S);
+  basis->addBasis(2, Avogadro::Core::GaussianSet::P);
+  basis->addBasis(1, Avogadro::Core::GaussianSet::S);
+  molecule.setBasisSet(basis);
+
+  molecule.swapAtom(0, 2);
+
+  // Shell order is untouched -- only the atom each shell names moves, which
+  // is what keeps MO coefficients valid.
+  const std::vector<unsigned int> expected = { 2, 0, 0, 1 };
+  EXPECT_EQ(expected, basis->atomIndices());
+}
+
+// Normal mode displacements are stored per mode per atom, so they have to
+// follow their atom through a renumbering.
+TEST_F(MoleculeTest, SwapAtomCarriesVibrationalDisplacements)
+{
+  Avogadro::Core::Molecule molecule;
+  for (int i = 0; i < 3; ++i)
+    molecule.addAtom(static_cast<unsigned char>(6 + i));
+
+  Avogadro::Core::Array<double> frequencies;
+  frequencies.push_back(1000.0);
+  frequencies.push_back(2000.0);
+  molecule.setVibrationFrequencies(frequencies);
+
+  // Two modes, each giving atom i the displacement (i, 0, 0) or (0, i, 0).
+  Avogadro::Core::Array<Avogadro::Core::Array<Avogadro::Vector3>> lx;
+  for (int mode = 0; mode < 2; ++mode) {
+    Avogadro::Core::Array<Avogadro::Vector3> displacements;
+    for (int i = 0; i < 3; ++i)
+      displacements.push_back(mode == 0 ? Avogadro::Vector3(i, 0.0, 0.0)
+                                        : Avogadro::Vector3(0.0, i, 0.0));
+    lx.push_back(displacements);
+  }
+  molecule.setVibrationLx(lx);
+
+  molecule.swapAtom(0, 2);
+
+  // Atom 0's displacement is now at index 2, and vice versa, in every mode.
+  const Avogadro::Core::Array<Avogadro::Vector3> mode0 =
+    molecule.vibrationLx(0);
+  const Avogadro::Core::Array<Avogadro::Vector3> mode1 =
+    molecule.vibrationLx(1);
+  ASSERT_EQ(static_cast<size_t>(3), mode0.size());
+  EXPECT_EQ(Avogadro::Vector3(2.0, 0.0, 0.0), mode0[0]);
+  EXPECT_EQ(Avogadro::Vector3(0.0, 0.0, 0.0), mode0[2]);
+  EXPECT_EQ(Avogadro::Vector3(0.0, 2.0, 0.0), mode1[0]);
+  EXPECT_EQ(Avogadro::Vector3(0.0, 0.0, 0.0), mode1[2]);
+  // The frequencies are mode-indexed and must not move.
+  ASSERT_EQ(static_cast<size_t>(2), molecule.vibrationFrequencies().size());
+  EXPECT_EQ(1000.0, molecule.vibrationFrequencies()[0]);
 }

--- a/tests/qtgui/rwmoleculetest.cpp
+++ b/tests/qtgui/rwmoleculetest.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <avogadro/core/residue.h>
 #include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtgui/rwmolecule.h>
 
@@ -1057,4 +1058,42 @@ TEST(RWMoleculeTest, reorderAtomsEmptyMolecule)
   Array<Index> order(0);
   EXPECT_TRUE(mol.reorderAtoms(order));
   EXPECT_EQ(static_cast<Index>(0), mol.atomCount());
+}
+
+TEST(RWMoleculeTest, reorderAtomsCarriesResidues)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 4);
+
+  std::string resName = "ALA";
+  Index resNumber = 1;
+  char chain = 'A';
+  Avogadro::Core::Residue& residue = m.addResidue(resName, resNumber, chain);
+  residue.addResidueAtom("N", m.atom(0));
+  residue.addResidueAtom("CA", m.atom(1));
+  residue.addResidueAtom("C", m.atom(2));
+
+  // A 3-cycle over the residue's atoms, leaving the fourth atom outside it.
+  Array<Index> order(4);
+  order[0] = 2;
+  order[1] = 0;
+  order[2] = 1;
+  order[3] = 3;
+  ASSERT_TRUE(mol.reorderAtoms(order));
+
+  // Each name still names the atom it was given: buildDistinctAtoms() sets
+  // atomic number i + 1, so the original atom is identifiable after the move.
+  const Avogadro::Core::Residue& moved = m.residue(0);
+  EXPECT_EQ(1, moved.atomByName("N").atomicNumber());
+  EXPECT_EQ(2, moved.atomByName("CA").atomicNumber());
+  EXPECT_EQ(3, moved.atomByName("C").atomicNumber());
+  EXPECT_EQ(static_cast<size_t>(3), moved.residueAtoms().size());
+
+  // And undo puts the membership back where it started.
+  mol.undoStack().undo();
+  const Avogadro::Core::Residue& restored = m.residue(0);
+  EXPECT_EQ(static_cast<Index>(0), restored.atomByName("N").index());
+  EXPECT_EQ(static_cast<Index>(1), restored.atomByName("CA").index());
+  EXPECT_EQ(static_cast<Index>(2), restored.atomByName("C").index());
 }

--- a/tests/qtgui/rwmoleculetest.cpp
+++ b/tests/qtgui/rwmoleculetest.cpp
@@ -842,3 +842,219 @@ TEST(RWMoleculeTest, MoleculeToRWMolecule)
   EXPECT_EQ(rwmol.atom(2).atomicNumber(), mol.atom(2).atomicNumber());
   EXPECT_EQ(rwmol.bond(0).order(), mol.bond(0).order());
 }
+
+namespace {
+
+// A small molecule whose atoms are each distinguishable by every atom-indexed
+// property the reorder has to carry along.
+void buildDistinctAtoms(RWMolecule& mol, Index count)
+{
+  for (Index i = 0; i < count; ++i) {
+    mol.addAtom(static_cast<unsigned char>(i + 1));
+    mol.setAtomPosition3d(i, Vector3(Real(i), Real(10 * i), Real(100 * i)));
+    mol.setAtomLabel(i, "atom" + std::to_string(i));
+    mol.setFormalCharge(i, static_cast<signed char>(i));
+  }
+}
+
+// Assert that atom @p at holds the properties originally given to atom
+// @p from by buildDistinctAtoms().
+void expectAtomIs(const RWMolecule& mol, Index at, Index from)
+{
+  EXPECT_EQ(static_cast<unsigned char>(from + 1), mol.atomicNumber(at))
+    << "atom " << at;
+  EXPECT_EQ(Vector3(Real(from), Real(10 * from), Real(100 * from)),
+            mol.atomPosition3d(at))
+    << "atom " << at;
+  EXPECT_EQ("atom" + std::to_string(from), mol.atomLabel(at)) << "atom " << at;
+  EXPECT_EQ(static_cast<signed char>(from), mol.formalCharge(at))
+    << "atom " << at;
+}
+
+} // namespace
+
+TEST(RWMoleculeTest, reorderAtomsIdentity)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 4);
+  const int before = mol.undoStack().count();
+
+  Array<Index> order(4);
+  for (Index i = 0; i < 4; ++i)
+    order[i] = i;
+
+  EXPECT_TRUE(mol.reorderAtoms(order));
+  for (Index i = 0; i < 4; ++i)
+    expectAtomIs(mol, i, i);
+
+  // Nothing moved, so nothing should be sitting on the undo stack waiting to
+  // be undone.
+  EXPECT_EQ(before, mol.undoStack().count());
+}
+
+TEST(RWMoleculeTest, reorderAtomsTransposition)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 4);
+
+  Array<Index> order(4);
+  order[0] = 0;
+  order[1] = 3;
+  order[2] = 2;
+  order[3] = 1;
+
+  ASSERT_TRUE(mol.reorderAtoms(order));
+  expectAtomIs(mol, 0, 0);
+  expectAtomIs(mol, 1, 3);
+  expectAtomIs(mol, 2, 2);
+  expectAtomIs(mol, 3, 1);
+}
+
+TEST(RWMoleculeTest, reorderAtomsMultiCycle)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 6);
+
+  // Two disjoint 3-cycles, so a single pass of transpositions is not enough
+  // unless the bookkeeping is right.
+  Array<Index> order(6);
+  order[0] = 2;
+  order[1] = 0;
+  order[2] = 1;
+  order[3] = 5;
+  order[4] = 3;
+  order[5] = 4;
+
+  ASSERT_TRUE(mol.reorderAtoms(order));
+  for (Index i = 0; i < 6; ++i)
+    expectAtomIs(mol, i, order[i]);
+}
+
+TEST(RWMoleculeTest, reorderAtomsCarriesBondsAndSelection)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 4);
+  mol.addBond(0, 1, 1);
+  mol.addBond(1, 2, 2);
+  mol.addBond(2, 3, 3);
+  mol.setAtomSelected(1, true);
+
+  // Reverse the atoms.
+  Array<Index> order(4);
+  for (Index i = 0; i < 4; ++i)
+    order[i] = 3 - i;
+  ASSERT_TRUE(mol.reorderAtoms(order));
+
+  // The same three bonds, with the same orders, between the same atoms --
+  // which are now numbered the other way round.
+  ASSERT_EQ(static_cast<Index>(3), mol.bondCount());
+  EXPECT_TRUE(mol.bond(3, 2).isValid());
+  EXPECT_EQ(1, mol.bond(3, 2).order());
+  EXPECT_TRUE(mol.bond(2, 1).isValid());
+  EXPECT_EQ(2, mol.bond(2, 1).order());
+  EXPECT_TRUE(mol.bond(1, 0).isValid());
+  EXPECT_EQ(3, mol.bond(1, 0).order());
+
+  // The selected atom is still the one that was selected.
+  EXPECT_TRUE(mol.atomSelected(2));
+  EXPECT_FALSE(mol.atomSelected(0));
+  EXPECT_FALSE(mol.atomSelected(1));
+  EXPECT_FALSE(mol.atomSelected(3));
+}
+
+TEST(RWMoleculeTest, reorderAtomsKeepsUniqueIds)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 4);
+
+  Array<Index> uids(4);
+  for (Index i = 0; i < 4; ++i)
+    uids[i] = mol.atomUniqueId(i);
+
+  Array<Index> order(4);
+  order[0] = 2;
+  order[1] = 3;
+  order[2] = 0;
+  order[3] = 1;
+  ASSERT_TRUE(mol.reorderAtoms(order));
+
+  // A unique id is a handle held across edits, so it must still resolve to
+  // the same atom rather than to whatever now occupies that index.
+  for (Index i = 0; i < 4; ++i) {
+    RWMolecule::AtomType atom = mol.atomByUniqueId(uids[order[i]]);
+    ASSERT_TRUE(atom.isValid()) << "unique id for original atom " << order[i];
+    EXPECT_EQ(i, atom.index()) << "original atom " << order[i];
+  }
+}
+
+TEST(RWMoleculeTest, reorderAtomsUndoRedo)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 5);
+  mol.addBond(0, 4, 2);
+
+  Array<Index> order(5);
+  order[0] = 4;
+  order[1] = 2;
+  order[2] = 0;
+  order[3] = 3;
+  order[4] = 1;
+  ASSERT_TRUE(mol.reorderAtoms(order));
+
+  mol.undoStack().undo();
+  for (Index i = 0; i < 5; ++i)
+    expectAtomIs(mol, i, i);
+  EXPECT_TRUE(mol.bond(0, 4).isValid());
+  EXPECT_EQ(2, mol.bond(0, 4).order());
+
+  mol.undoStack().redo();
+  for (Index i = 0; i < 5; ++i)
+    expectAtomIs(mol, i, order[i]);
+  EXPECT_TRUE(mol.bond(0, 2).isValid());
+  EXPECT_EQ(2, mol.bond(0, 2).order());
+}
+
+TEST(RWMoleculeTest, reorderAtomsRejectsNonPermutations)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  buildDistinctAtoms(mol, 3);
+  const int before = mol.undoStack().count();
+
+  Array<Index> tooShort(2);
+  tooShort[0] = 0;
+  tooShort[1] = 1;
+  EXPECT_FALSE(mol.reorderAtoms(tooShort));
+
+  Array<Index> outOfRange(3);
+  outOfRange[0] = 0;
+  outOfRange[1] = 1;
+  outOfRange[2] = 7;
+  EXPECT_FALSE(mol.reorderAtoms(outOfRange));
+
+  Array<Index> duplicated(3);
+  duplicated[0] = 2;
+  duplicated[1] = 2;
+  duplicated[2] = 0;
+  EXPECT_FALSE(mol.reorderAtoms(duplicated));
+
+  // A rejected order must leave the molecule and the undo stack untouched.
+  for (Index i = 0; i < 3; ++i)
+    expectAtomIs(mol, i, i);
+  EXPECT_EQ(before, mol.undoStack().count());
+}
+
+TEST(RWMoleculeTest, reorderAtomsEmptyMolecule)
+{
+  Molecule m;
+  RWMolecule mol(m);
+  Array<Index> order(0);
+  EXPECT_TRUE(mol.reorderAtoms(order));
+  EXPECT_EQ(static_cast<Index>(0), mol.atomCount());
+}


### PR DESCRIPTION
This will enable undo / redo for renumbering atoms

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reordering molecule atoms while preserving associated properties, bonds, selections, residues, coordinate sets, and unique identifiers.
  * Added validation to reject invalid atom orderings without modifying the molecule.
  * Added undo and redo support for atom reordering.

* **Bug Fixes**
  * Ensured empty molecules and unchanged atom orders are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->