### PR TITLE
Allow a click-and-drag navigation to focus on a particular atom

### DIFF
--- a/avogadro/qtplugins/measuretool/measuretool.cpp
+++ b/avogadro/qtplugins/measuretool/measuretool.cpp
@@ -28,6 +28,7 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QIcon>
 #include <QtGui/QMouseEvent>
+#include <QtGui/QStyleHints>
 
 #include <QDebug>
 
@@ -46,7 +47,8 @@ namespace Avogadro::QtPlugins {
 
 MeasureTool::MeasureTool(QObject* parent_)
   : QtGui::ToolPlugin(parent_), m_activateAction(new QAction(this)),
-    m_molecule(nullptr), m_rwMolecule(nullptr), m_renderer(nullptr)
+    m_molecule(nullptr), m_rwMolecule(nullptr), m_renderer(nullptr),
+    m_dragged(false)
 {
   QString shortcut = tr("Ctrl+8", "control-key 8");
   m_activateAction->setText(tr("Measure"));
@@ -78,16 +80,31 @@ QWidget* MeasureTool::toolWidget() const
 
 QUndoCommand* MeasureTool::mousePressEvent(QMouseEvent* e)
 {
+  m_dragged = false;
+
   if (e->button() != Qt::LeftButton || !m_renderer)
     return nullptr;
 
-  Identifier hit = m_renderer->hit(e->pos().x(), e->pos().y());
+  m_pressPosition = e->pos();
 
-  // If an atom is clicked, accept the event, but don't add it to the atom list
-  // until the button is released (this way the user can cancel the click by
-  // moving off the atom, and the click won't get passed to the default tool).
-  if (hit.type == Rendering::AtomType)
-    e->accept();
+  // Deliberately leave the event unaccepted, even when an atom was hit, so
+  // that it reaches the navigate tool: dragging from an atom rotates the view
+  // around that atom. The atom is only added to the list on release, and only
+  // if the press turns out to be a click rather than a drag.
+  return nullptr;
+}
+
+QUndoCommand* MeasureTool::mouseMoveEvent(QMouseEvent* e)
+{
+  // Remember whether the mouse moved far enough for this to be a navigation
+  // drag instead of a click. Never accept the event -- the navigate tool needs
+  // it to move the camera.
+  if (!m_dragged && (e->buttons() & Qt::LeftButton)) {
+    QPoint delta = e->pos() - m_pressPosition;
+    if (delta.manhattanLength() >=
+        QGuiApplication::styleHints()->startDragDistance())
+      m_dragged = true;
+  }
 
   return nullptr;
 }
@@ -98,15 +115,22 @@ QUndoCommand* MeasureTool::mouseReleaseEvent(QMouseEvent* e)
   if (e->button() != Qt::LeftButton || !m_renderer)
     return nullptr;
 
+  // The drag rotated the view, it wasn't a selection.
+  if (m_dragged) {
+    m_dragged = false;
+    return nullptr;
+  }
+
   Identifier hit = m_renderer->hit(e->pos().x(), e->pos().y());
 
   // Now add the atom on release.
   if (hit.type == Rendering::AtomType) {
     if (toggleAtom(hit))
       emit drawablesChanged();
-    e->accept();
   }
 
+  // The event is left unaccepted so that the navigate tool sees the release
+  // and clears the drag it started when the press was passed through.
   return nullptr;
 }
 

--- a/avogadro/qtplugins/measuretool/measuretool.h
+++ b/avogadro/qtplugins/measuretool/measuretool.h
@@ -12,6 +12,7 @@
 #include <avogadro/rendering/geometrynode.h>
 #include <avogadro/rendering/primitive.h>
 
+#include <QtCore/QPoint>
 #include <QtCore/QVector>
 
 namespace Avogadro {
@@ -42,6 +43,7 @@ public:
   void setGLRenderer(Rendering::GLRenderer* renderer) override;
 
   QUndoCommand* mousePressEvent(QMouseEvent* e) override;
+  QUndoCommand* mouseMoveEvent(QMouseEvent* e) override;
   QUndoCommand* mouseReleaseEvent(QMouseEvent* e) override;
   QUndoCommand* mouseDoubleClickEvent(QMouseEvent* e) override;
 
@@ -58,6 +60,8 @@ private:
   QtGui::RWMolecule* m_rwMolecule;
   Rendering::GLRenderer* m_renderer;
   QVector<Rendering::Identifier> m_atoms;
+  QPoint m_pressPosition;
+  bool m_dragged;
 };
 
 inline void MeasureTool::setMolecule(QtGui::Molecule* mol)

--- a/avogadro/qtplugins/navigator/navigator.cpp
+++ b/avogadro/qtplugins/navigator/navigator.cpp
@@ -7,10 +7,12 @@
 
 #include <avogadro/core/vector.h>
 
+#include <avogadro/qtgui/molecule.h>
 #include <avogadro/qtopengl/glwidget.h>
 
 #include <avogadro/rendering/camera.h>
 #include <avogadro/rendering/glrenderer.h>
+#include <avogadro/rendering/primitive.h>
 #include <avogadro/rendering/scene.h>
 
 #include <QAction>
@@ -39,6 +41,7 @@ Navigator::Navigator(QObject* parent_)
   : QtGui::ToolPlugin(parent_), m_activateAction(new QAction(this)),
     m_molecule(nullptr), m_glWidget(nullptr), m_toolWidget(nullptr),
     m_renderer(nullptr), m_pressedButtons(Qt::NoButton),
+    m_referencePoint(Vector3f::Zero()), m_hasReferencePoint(false),
     m_currentAction(Nothing)
 {
   QString shortcut = tr("Ctrl+1", "control-key 1");
@@ -46,6 +49,7 @@ Navigator::Navigator(QObject* parent_)
   m_activateAction->setToolTip(
     tr("Navigation Tool\t(%1)\n\n"
        "Left Mouse:\tClick and drag to rotate the view.\n"
+       "\tStarting the drag on an atom rotates around that atom.\n"
        "Middle Mouse:\tClick and drag to zoom in or out.\n"
        "Right Mouse:\tClick and drag to move the view.\n\n"
        "Alt(Option)+Drag:\tRotate/zoom/pan from within any tool.\n"
@@ -145,6 +149,7 @@ QUndoCommand* Navigator::mousePressEvent(QMouseEvent* e)
 {
   updatePressedButtons(e, false);
   m_lastMousePosition = e->pos();
+  updateReferencePoint(e->pos());
   e->accept();
 
   // Figure out what type of navigation has been requested.
@@ -171,6 +176,7 @@ QUndoCommand* Navigator::mouseReleaseEvent(QMouseEvent* e)
 {
   updatePressedButtons(e, true);
   m_lastMousePosition = QPoint();
+  m_hasReferencePoint = false;
   m_currentAction = Nothing;
   e->accept();
   return nullptr;
@@ -210,7 +216,7 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
         // undo *ROTATION_SPEED which will happen in rotate()
         double speedCorrection = (1.0 / ROTATION_SPEED) * TRACKBALL_SPAN *
                                  3.14159265358979 / trackballRadius;
-        rotate(m_renderer->camera().focus(), delta.y() * speedCorrection,
+        rotate(referencePoint(), delta.y() * speedCorrection,
                delta.x() * speedCorrection, 0);
       } else {
         // Calculate angle between current and previous ticks
@@ -223,8 +229,7 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
         if (std::abs(crossProduct) > 0.1 || std::abs(dotProduct) > 0.1) {
           // counter-clockwise is positive here
           double angleDelta = std::atan2(crossProduct, dotProduct);
-          rotate(m_renderer->camera().focus(), 0, 0,
-                 -angleDelta * (1.0 / ROTATION_SPEED));
+          rotate(referencePoint(), 0, 0, -angleDelta * (1.0 / ROTATION_SPEED));
         }
       }
       e->accept();
@@ -232,23 +237,23 @@ QUndoCommand* Navigator::mouseMoveEvent(QMouseEvent* e)
     }
     case Rotation: {
       QPoint delta = e->pos() - m_lastMousePosition;
-      rotate(m_renderer->camera().focus(), delta.y(), delta.x(), 0);
+      rotate(referencePoint(), delta.y(), delta.x(), 0);
       e->accept();
       break;
     }
     case Translation: {
       Vector2f fromScreen(m_lastMousePosition.x(), m_lastMousePosition.y());
       Vector2f toScreen(e->localPos().x(), e->localPos().y());
-      translate(m_renderer->camera().focus(), fromScreen, toScreen);
+      translate(referencePoint(), fromScreen, toScreen);
       e->accept();
       break;
     }
     case ZoomTilt: {
       QPoint delta = e->pos() - m_lastMousePosition;
       // Tilt
-      rotate(m_renderer->camera().focus(), 0, 0, delta.x());
+      rotate(referencePoint(), 0, 0, delta.x());
       // Zoom
-      // zoom(m_renderer->camera().focus(), delta.y());
+      // zoom(referencePoint(), delta.y());
       e->accept();
       break;
     }
@@ -381,6 +386,31 @@ inline void Navigator::updatePressedButtons(QMouseEvent* e, bool release)
     m_pressedButtons &= e->buttons();
   else
     m_pressedButtons |= e->buttons();
+}
+
+void Navigator::updateReferencePoint(const QPoint& position)
+{
+  // Rotate, tilt and translate around the atom under the cursor when there is
+  // one, so that clicking an atom and dragging pivots the view about it, as in
+  // Avogadro 1. Everything else keeps navigating around the camera focus.
+  m_hasReferencePoint = false;
+
+  if (m_renderer == nullptr || m_molecule == nullptr)
+    return;
+
+  Rendering::Identifier hit = m_renderer->hit(position.x(), position.y());
+  if (hit.type != Rendering::AtomType ||
+      hit.molecule != static_cast<const void*>(m_molecule) ||
+      hit.index >= m_molecule->atomCount())
+    return;
+
+  m_referencePoint = m_molecule->atomPosition3d(hit.index).cast<float>();
+  m_hasReferencePoint = true;
+}
+
+inline Vector3f Navigator::referencePoint() const
+{
+  return m_hasReferencePoint ? m_referencePoint : m_renderer->camera().focus();
 }
 
 inline void Navigator::rotate(const Vector3f& ref, float x, float y, float z)

--- a/avogadro/qtplugins/navigator/navigator.h
+++ b/avogadro/qtplugins/navigator/navigator.h
@@ -65,6 +65,19 @@ private:
    */
   void updatePressedButtons(QMouseEvent*, bool release);
 
+  /**
+   * Set the point that the current navigation gesture acts around. If an atom
+   * is under @a position, that atom is used, otherwise the camera focus (the
+   * center of the molecule) is used, as before.
+   */
+  void updateReferencePoint(const QPoint& position);
+
+  /**
+   * The point that the current navigation gesture acts around.
+   * @sa updateReferencePoint
+   */
+  Vector3f referencePoint() const;
+
   void rotate(const Vector3f& ref, float x, float y, float z);
   void zoom(const Vector3f& ref, float d);
   void translate(const Vector3f& ref, float x, float y);
@@ -78,6 +91,8 @@ private:
   Qt::MouseButtons m_pressedButtons;
   QPoint m_lastMousePosition;
   int m_zoomDirection;
+  Vector3f m_referencePoint;
+  bool m_hasReferencePoint;
 
   enum ToolAction
   {


### PR DESCRIPTION
Fix #2004 bringing back behavior from Avo v1

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
